### PR TITLE
Fix foreign key constraint violation in UserSeeder

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Unit;
 use App\Models\User;
 use App\Models\Jabatan;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Hash;
 
@@ -18,6 +19,13 @@ class UserSeeder extends Seeder
         Jabatan::truncate();
         Unit::truncate();
         Schema::enableForeignKeyConstraints();
+
+        // --- PREPARE SUPERADMIN FOR ACTIVITY LOGGING ---
+        $superAdmin = User::create([
+            'name' => 'Super Admin', 'email' => 'superadmin@example.com', 'password' => Hash::make('password'), 'role' => User::ROLE_SUPERADMIN, 'status' => User::STATUS_ACTIVE
+        ]);
+        Auth::login($superAdmin);
+
 
         // --- UNIT AND JABATAN CREATION ---
 
@@ -56,8 +64,6 @@ class UserSeeder extends Seeder
         }
 
         // --- USER CREATION ---
-
-        User::create(['name' => 'Super Admin', 'email' => 'superadmin@example.com', 'password' => Hash::make('password'), 'role' => User::ROLE_SUPERADMIN, 'status' => User::STATUS_ACTIVE]);
 
         $createUserForJabatan = function(string $jabatanName, string $userName, string $email, string $role, ?User $atasan) {
             $jabatan = Jabatan::where('name', $jabatanName)->whereNull('user_id')->first();


### PR DESCRIPTION
The database seeder was failing because it attempted to create `Unit` models before any `User` models. The creation of a `Unit` triggers an activity log, which requires a `user_id`.

This change fixes the issue by reordering the `UserSeeder` operations:
1. The Super Admin user is now created first.
2. `Auth::login()` is used to authenticate as the Super Admin for the duration of the seeder.

This ensures that when `Unit`s and other models are created, the `RecordsActivity` trait can successfully retrieve an authenticated user ID, resolving the foreign key constraint violation.