### PR TITLE
Refactor performance calculation logic for fairness and stability.

### DIFF
--- a/database/migrations/2025_08_05_010130_add_priority_to_tasks_table.php
+++ b/database/migrations/2025_08_05_010130_add_priority_to_tasks_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->string('priority')->default('Normal')->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('priority');
+        });
+    }
+};


### PR DESCRIPTION
This commit addresses critical flaws in the performance calculation service that could lead to illogical and unfair scores.

Key changes:
- **Replaced IKI Formula:** The core Individual Performance Index (IKI) formula `Progress / Effort` has been replaced with a more stable model: `Base Score * Capped Efficiency Factor`. This prevents scores from exploding due to very low actual hours reported.
- **Introduced Task Weighting:** Tasks now have a `priority` attribute ('Critical', 'High', 'Normal', 'Low'). The IKI calculation now uses a weighted average of progress, ensuring that critical tasks have a higher impact on the score. A migration file to add the `priority` column to the `tasks` table is included.
- **Corrected "No Task" Scenario:** Employees with no tasks are now assigned an IKI of 0.0, resulting in a "Tidak Dapat Dinilai" (Cannot Be Assessed) rating, instead of an unfair default of "Sesuai Ekspektasi".
- **Capped Efficiency Factor:** The efficiency bonus/malus is now capped between 0.9x and 1.25x to keep scores within a logical range.

Note: The new migration must be run manually (`php artisan migrate`) in the production environment to apply the necessary database schema changes.