### PR TITLE
feat: Enhance seeders for realistic performance data

### DIFF
--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -28,6 +28,7 @@ class TaskFactory extends Factory
             'deadline' => $this->faker->dateTimeBetween('+1 week', '+3 months'),
             'project_id' => Project::factory(),
             'estimated_hours' => $this->faker->numberBetween(4, 40),
+            'priority' => $this->faker->randomElement(['Low', 'Normal', 'High', 'Critical']),
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             ProjectSeeder::class,
             TaskSeeder::class,
+            TimeLogSeeder::class, // Tambahkan TimeLogSeeder di sini
             SpecialAssignmentSeeder::class,
             AdHocTaskSeeder::class,
         ]);

--- a/database/seeders/TimeLogSeeder.php
+++ b/database/seeders/TimeLogSeeder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Task;
+use App\Models\TimeLog;
+use Carbon\Carbon;
+
+class TimeLogSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Hapus data lama untuk menghindari duplikasi saat re-seed
+        TimeLog::truncate();
+
+        $tasks = Task::with('assignees')->get();
+
+        if ($tasks->isEmpty()) {
+            $this->command->info('Tidak ada tugas untuk ditambahkan time log. Jalankan TaskSeeder dulu.');
+            return;
+        }
+
+        $this->command->getOutput()->progressStart($tasks->count());
+
+        foreach ($tasks as $task) {
+            if ($task->assignees->isEmpty()) {
+                continue; // Lewati tugas tanpa penanggung jawab
+            }
+
+            // Jangan buat log untuk tugas yang belum dimulai
+            if ($task->status === 'pending' || $task->progress === 0) {
+                continue;
+            }
+
+            // Simulasi actual hours yang realistis, sekitar 80% - 120% dari estimasi
+            $estimated = $task->estimated_hours;
+            $variance = (rand(-20, 20) / 100); // Variansi antara -20% dan +20%
+            $actualHours = $estimated * (1 + $variance);
+            $actualHours = max(1, round($actualHours, 1)); // Pastikan minimal 1 jam
+
+            // Buat satu time log untuk setiap assignee pada tugas ini
+            foreach ($task->assignees as $assignee) {
+                // Waktu mulai acak dalam seminggu terakhir
+                $startTime = Carbon::now()->subDays(rand(1, 7))->subHours(rand(1, 8));
+                $endTime = $startTime->copy()->addHours($actualHours);
+
+                TimeLog::create([
+                    'task_id' => $task->id,
+                    'user_id' => $assignee->id,
+                    'start_time' => $startTime,
+                    'end_time' => $endTime,
+                ]);
+            }
+            $this->command->getOutput()->progressAdvance();
+        }
+
+        $this->command->getOutput()->progressFinish();
+        $this->command->info(TimeLog::count() . ' time logs berhasil dibuat.');
+    }
+}


### PR DESCRIPTION
This commit improves the database seeders to generate more realistic and varied data for testing the performance calculation system.

Key changes:
- **Updated TaskFactory:** The `TaskFactory` now assigns a random priority ('Low', 'Normal', 'High', 'Critical') to each new task. This allows the weighted average calculation to be tested effectively.
- **Added TimeLogSeeder:** A new `TimeLogSeeder` has been created. It populates the `time_logs` table by creating realistic time entries for existing tasks. The actual hours are generated with a +/- 20% variance from the estimated hours to simulate different levels of your efficiency.
- **Updated DatabaseSeeder:** The main seeder now calls the new `TimeLogSeeder`, ensuring that time log data is generated automatically during database seeding.

These changes enable a much more thorough and realistic test of the performance calculation logic, as it now uses the priority weighting and efficiency factor components.