### PR TITLE
feat(Seeder): Create specific test case for insight service

### DIFF
--- a/database/seeders/TaskSeeder.php
+++ b/database/seeders/TaskSeeder.php
@@ -38,5 +38,26 @@ class TaskSeeder extends Seeder
                 $task->assignees()->attach($assignees->pluck('id'));
             }
         }
+
+        // --- Logic to overload the test user ---
+        $this->command->info('Overloading test user...');
+        $testUser = User::where('email', 'staf.test@example.com')->first();
+        $project = Project::first(); // Assign to the first project
+
+        if ($testUser && $project) {
+            if (!$project->members->contains($testUser)) {
+                $project->members()->attach($testUser->id);
+            }
+
+            for ($i = 0; $i < 10; $i++) {
+                $task = Task::factory()->create([
+                    'project_id' => $project->id,
+                    'estimated_hours' => 20, // 10 tasks * 20 hours = 200 hours
+                    'title' => 'Tugas Beban Kerja Ekstra ' . ($i + 1),
+                ]);
+                $task->assignees()->attach($testUser->id);
+            }
+            $this->command->info('Test user has been overloaded with 10 extra tasks.');
+        }
     }
 }

--- a/database/seeders/TimeLogSeeder.php
+++ b/database/seeders/TimeLogSeeder.php
@@ -38,15 +38,22 @@ class TimeLogSeeder extends Seeder
                 continue;
             }
 
-            // Simulasi actual hours yang realistis, sekitar 80% - 120% dari estimasi
-            $estimated = $task->estimated_hours;
-            $variance = (rand(-20, 20) / 100); // Variansi antara -20% dan +20%
-            $actualHours = $estimated * (1 + $variance);
-            $actualHours = max(1, round($actualHours, 1)); // Pastikan minimal 1 jam
-
-            // Buat satu time log untuk setiap assignee pada tugas ini
             foreach ($task->assignees as $assignee) {
-                // Waktu mulai acak dalam seminggu terakhir
+                $estimated = $task->estimated_hours;
+                $actualHours = 0;
+
+                // --- Logic to sabotage the test user ---
+                if ($assignee->email === 'staf.test@example.com') {
+                    // Make this user inefficient
+                    $actualHours = $estimated * 1.5; // 150% of estimated time
+                } else {
+                    // Other users remain realistic
+                    $variance = (rand(-20, 20) / 100); // Variansi antara -20% dan +20%
+                    $actualHours = $estimated * (1 + $variance);
+                }
+
+                $actualHours = max(1, round($actualHours, 1));
+
                 $startTime = Carbon::now()->subDays(rand(1, 7))->subHours(rand(1, 8));
                 $endTime = $startTime->copy()->addHours($actualHours);
 


### PR DESCRIPTION
This commit modifies the database seeders to intentionally create a specific test case to validate the enhanced InsightService logic.

Specifically, the changes ensure the creation of an 'overloaded and underperforming' user:
- **UserSeeder:** Now creates a predictable user 'Staf Uji Coba' with the email 'staf.test@example.com'.
- **TaskSeeder:** Assigns a high volume of extra tasks (200 estimated hours) specifically to this test user to ensure their workload exceeds the 'overloaded' threshold.
- **TimeLogSeeder:** Intentionally creates inefficient time logs for the test user, setting their actual work hours to 150% of the estimate. This guarantees their performance rating will be low.

This setup will trigger the 'Overloaded User' insight, confirming that the new, more intelligent warning system is functioning as designed.