### PR TITLE
fix(Seeder): Trigger performance calculation after seeding

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,9 +19,15 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             ProjectSeeder::class,
             TaskSeeder::class,
-            TimeLogSeeder::class, // Tambahkan TimeLogSeeder di sini
+            TimeLogSeeder::class,
             SpecialAssignmentSeeder::class,
             AdHocTaskSeeder::class,
         ]);
+
+        // Panggil PerformanceCalculatorService untuk memastikan data kinerja terisi
+        $this->command->info('Calculating performance scores for all users...');
+        $calculator = new \App\Services\PerformanceCalculatorService();
+        $calculator->calculateForAllUsers();
+        $this->command->info('Performance scores calculated.');
     }
 }


### PR DESCRIPTION
This commit fixes the root cause of the insight cards not appearing. The `InsightService` relies on pre-calculated performance ratings (`work_result_rating`) which were not being generated during the database seeding process. This resulted in the insight filters always failing because the performance data was stale or null.

The fix involves adding a final step to the `DatabaseSeeder` to explicitly call the `PerformanceCalculatorService` after all other seeders have run. This ensures that performance data is always fresh and accurate before the application is used, allowing the `InsightService` to correctly identify and flag relevant issues like overloaded or underperforming users.

This commit also reverts the unnecessary changes to `InsightService.php` since the issue was in the seeding process, not the service itself.