### PR TITLE
fix(controller): Add missing User model import

### DIFF
--- a/app/Http/Controllers/WeeklyWorkloadController.php
+++ b/app/Http/Controllers/WeeklyWorkloadController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 


### PR DESCRIPTION
This commit fixes a fatal error (`Class "App\Http\Controllers\User" not found`) on the Weekly Workload page.

The error was caused by the `WeeklyWorkloadController` referencing the `User` model's constants without the proper `use` statement. This change adds the required `use App\Models\User;` to the top of the file, resolving the namespace issue.