### PR TITLE
feat: Add home icon to Beranda navigation link

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -23,7 +23,10 @@ if (count($words) >= 2) {
 
                 <div class="hidden space-x-4 sm:-my-px sm:ms-10 sm:flex">
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard', 'executive.summary')" class="text-white hover:text-yellow-300 transition duration-150 ease-in-out">
-                        Beranda
+                        <div class="flex items-center">
+                            <i class="fas fa-home mr-2"></i>
+                            <span>Beranda</span>
+                        </div>
                     </x-nav-link>
 
                     {{-- Dropdown Menu Kerja --}}


### PR DESCRIPTION
- Adds a Font Awesome 'home' icon to the 'Beranda' link in the main navigation bar.
- Uses flexbox classes to ensure the icon and text are vertically aligned, consistent with other menu items.

Note: I was unable to run the test suite due to issues locating the PHP executable in the environment. The change is a low-risk, cosmetic modification to a Blade template.