### PR TITLE
feat: Implement hierarchical unit selection in user forms

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -248,6 +248,13 @@ class UnitController extends Controller
 
     // --- API METHODS ---
 
+    public function getChildren(Unit $unit)
+    {
+        // We only need id and name for the dropdown
+        $children = $unit->childUnits()->orderBy('name')->get(['id', 'name']);
+        return response()->json($children);
+    }
+
     public function getVacantJabatans(Unit $unit)
     {
         // This is for the chained dropdown in user creation form

--- a/resources/views/users/partials/form-fields.blade.php
+++ b/resources/views/users/partials/form-fields.blade.php
@@ -23,19 +23,43 @@
         </div>
 
         <div class="mb-6">
-            <label for="unit_id" class="block font-semibold text-sm text-gray-700 mb-1">1. Pilih Unit Kerja</label>
-            <select name="unit_id" id="unit_id" required class="select2-searchable block mt-1 w-full rounded-lg shadow-sm">
-                <option value="">-- Pilih Unit --</option>
-                @foreach($units as $unitOption)
-                    <option value="{{ $unitOption->id }}" @selected(old('unit_id', $user->unit_id ?? '') == $unitOption->id)>{{ $unitOption->name }}</option>
+            <label for="eselon_i" class="block font-semibold text-sm text-gray-700 mb-1">1. Unit Eselon I</label>
+            <select id="eselon_i" class="unit-select block mt-1 w-full rounded-lg shadow-sm" data-level="1" data-placeholder="-- Pilih Unit Eselon I --">
+                <option value="">-- Pilih Unit Eselon I --</option>
+                @foreach($eselonIUnits as $unit)
+                    <option value="{{ $unit->id }}">{{ $unit->name }}</option>
                 @endforeach
             </select>
         </div>
 
         <div class="mb-6">
-            <label for="jabatan_id" class="block font-semibold text-sm text-gray-700 mb-1">2. Pilih Jabatan Tersedia</label>
+            <label for="eselon_ii" class="block font-semibold text-sm text-gray-700 mb-1">2. Unit Eselon II</label>
+            <select id="eselon_ii" class="unit-select block mt-1 w-full rounded-lg shadow-sm" data-level="2" data-placeholder="-- Pilih Unit Eselon II --" disabled>
+                <option value="">-- Pilih Unit Eselon I Dahulu --</option>
+            </select>
+        </div>
+
+        <div class="mb-6">
+            <label for="koordinator" class="block font-semibold text-sm text-gray-700 mb-1">3. Koordinator</label>
+            <select id="koordinator" class="unit-select block mt-1 w-full rounded-lg shadow-sm" data-level="3" data-placeholder="-- Pilih Koordinator --" disabled>
+                <option value="">-- Pilih Unit Eselon II Dahulu --</option>
+            </select>
+        </div>
+
+        <div class="mb-6">
+            <label for="sub_koordinator" class="block font-semibold text-sm text-gray-700 mb-1">4. Sub Koordinator</label>
+            <select id="sub_koordinator" class="unit-select block mt-1 w-full rounded-lg shadow-sm" data-level="4" data-placeholder="-- Pilih Sub Koordinator --" disabled>
+                <option value="">-- Pilih Koordinator Dahulu --</option>
+            </select>
+        </div>
+
+        <!-- Hidden input to store the final selected unit_id -->
+        <input type="hidden" name="unit_id" id="unit_id" value="{{ old('unit_id', $user->unit_id ?? '') }}">
+
+        <div class="mb-6">
+            <label for="jabatan_id" class="block font-semibold text-sm text-gray-700 mb-1">5. Pilih Jabatan Tersedia</label>
             <select name="jabatan_id" id="jabatan_id" required class="select2-searchable block mt-1 w-full rounded-lg shadow-sm" disabled>
-                <option value="">-- Pilih Unit Dahulu --</option>
+                <option value="">-- Pilih Unit Kerja Terakhir --</option>
             </select>
         </div>
     </div>
@@ -75,58 +99,159 @@
 
 @push('scripts')
 <script>
-    $(document).ready(function() {
-        const unitSelect = $('#unit_id');
-        const jabatanSelect = $('#jabatan_id');
+$(document).ready(function() {
+    const jabatanSelect = $('#jabatan_id');
+    const unitIdInput = $('#unit_id');
+    const unitSelects = $('.unit-select');
 
-        @isset($user)
-            const oldJabatanId = '{{ old('jabatan_id', optional($user->jabatan)->id ?? '') }}';
-        @else
-            const oldJabatanId = '{{ old('jabatan_id', '') }}';
-        @endisset
+    // Path for pre-selection on edit form
+    const selectedUnitPath = @json($selectedUnitPath ?? []);
 
-        function fetchAndPopulateJabatans(unitId, selectedId = null) {
-            jabatanSelect.prop('disabled', true).html('<option value="">-- Memuat... --</option>');
+    @isset($user)
+        const oldJabatanId = '{{ old('jabatan_id', optional($user->jabatan)->id ?? '') }}';
+    @else
+        const oldJabatanId = '{{ old('jabatan_id', '') }}';
+    @endisset
 
-            if (!unitId) {
-                jabatanSelect.html('<option value="">-- Pilih Unit Dahulu --</option>').trigger('change');
-                return;
+    function fetchAndPopulateJabatans(unitId, selectedId = null) {
+        jabatanSelect.prop('disabled', true).html('<option value="">-- Memuat... --</option>');
+
+        if (!unitId) {
+            jabatanSelect.html('<option value="">-- Pilih Unit Kerja Terakhir --</option>').trigger('change');
+            return;
+        }
+
+        $.ajax({
+            url: `/api/units/${unitId}/vacant-jabatans`,
+            type: 'GET',
+            success: function(data) {
+                jabatanSelect.empty().append('<option value="">-- Pilih Jabatan --</option>');
+
+                if (data.length === 0) {
+                    jabatanSelect.html('<option value="">-- Tidak ada jabatan kosong --</option>');
+                } else {
+                    $.each(data, function(key, jabatan) {
+                        jabatanSelect.append(new Option(jabatan.name, jabatan.id, false, false));
+                    });
+                }
+
+                if (selectedId) {
+                    jabatanSelect.val(selectedId).trigger('change');
+                }
+
+                jabatanSelect.prop('disabled', false);
+            },
+            error: function() {
+                jabatanSelect.html('<option value="">-- Gagal Memuat Jabatan --</option>');
             }
+        });
+    }
 
+    function resetSubsequentSelects(level) {
+        for (let i = level; i <= unitSelects.length; i++) {
+            const select = $(unitSelects[i]);
+            const placeholder = select.data('placeholder') || '-- Pilih --';
+            select.empty().append(new Option(placeholder, '')).prop('disabled', true).val('').trigger('change');
+        }
+        jabatanSelect.empty().append('<option value="">-- Pilih Unit Kerja Terakhir --</option>').prop('disabled', true).val('').trigger('change');
+    }
+
+    unitSelects.on('change', function() {
+        const selectedValue = $(this).val();
+        const currentLevel = parseInt($(this).data('level'), 10);
+
+        unitIdInput.val(selectedValue); // Update hidden input
+        resetSubsequentSelects(currentLevel);
+
+        if (!selectedValue) {
+            // If placeholder is selected, ensure the hidden unit_id is cleared
+            // or set to the value of the previous dropdown.
+            if(currentLevel > 1) {
+                const prevSelect = $(unitSelects[currentLevel - 2]);
+                unitIdInput.val(prevSelect.val());
+            } else {
+                unitIdInput.val('');
+            }
+            fetchAndPopulateJabatans(unitIdInput.val());
+            return;
+        }
+
+        fetchAndPopulateJabatans(selectedValue);
+
+        const nextLevel = currentLevel + 1;
+        const nextSelect = $(`.unit-select[data-level='${nextLevel}']`);
+
+        if (nextSelect.length) {
+            nextSelect.prop('disabled', true).html('<option value="">-- Memuat... --</option>');
             $.ajax({
-                url: `/api/units/${unitId}/vacant-jabatans`,
+                url: `/units/${selectedValue}/children`,
                 type: 'GET',
                 success: function(data) {
-                    jabatanSelect.empty().append('<option value="">-- Pilih Jabatan --</option>');
-
-                    if (data.length === 0) {
-                        jabatanSelect.html('<option value="">-- Tidak ada jabatan kosong --</option>');
-                    } else {
-                        $.each(data, function(key, jabatan) {
-                            jabatanSelect.append(new Option(jabatan.name, jabatan.id, false, false));
+                    const placeholder = nextSelect.data('placeholder');
+                    nextSelect.empty().append(new Option(placeholder, ''));
+                    if (data.length > 0) {
+                        $.each(data, function(key, unit) {
+                            nextSelect.append(new Option(unit.name, unit.id));
                         });
+                        nextSelect.prop('disabled', false);
+                    } else {
+                        nextSelect.html(new Option('-- Tidak ada unit bawahan --', '')).prop('disabled', true);
                     }
-
-                    if (selectedId) {
-                        jabatanSelect.val(selectedId);
-                    }
-
-                    jabatanSelect.prop('disabled', false).trigger('change');
                 },
                 error: function() {
-                    jabatanSelect.html('<option value="">-- Gagal Memuat --</option>').trigger('change');
+                    nextSelect.html(new Option('-- Gagal memuat data --', '')).prop('disabled', true);
                 }
             });
         }
+    });
 
-        unitSelect.on('change', function() {
-            fetchAndPopulateJabatans($(this).val());
+    function initializePath() {
+        if (selectedUnitPath.length === 0) {
+            // On create form, if there's an old unit_id (e.g., validation fails),
+            // we should still try to fetch jabatans for it.
+            if(unitIdInput.val()) {
+                fetchAndPopulateJabatans(unitIdInput.val(), oldJabatanId);
+            }
+            return;
+        };
+
+        let currentPromise = $.Deferred().resolve().promise();
+
+        selectedUnitPath.forEach((unitId, index) => {
+            currentPromise = currentPromise.then(() => {
+                return new Promise(resolve => {
+                    const select = $(unitSelects[index]);
+                    if(index > 0) {
+                        // For selects other than the first one, wait for them to be populated
+                        // This uses a MutationObserver to wait for the options to be added
+                        const observer = new MutationObserver((mutationsList, obs) => {
+                            for(const mutation of mutationsList) {
+                                if (mutation.type === 'childList') {
+                                    select.val(unitId).trigger('change');
+                                    obs.disconnect(); // Clean up the observer
+                                    resolve();
+                                    return;
+                                }
+                            }
+                        });
+                        observer.observe(select[0], { childList: true });
+                    } else {
+                        // First select is already populated, just trigger it
+                        select.val(unitId).trigger('change');
+                        resolve();
+                    }
+                });
+            });
         });
 
-        // Initial load if a unit is already selected
-        if (unitSelect.val()) {
-            fetchAndPopulateJabatans(unitSelect.val(), oldJabatanId);
-        }
-    });
+        currentPromise.then(() => {
+            // After the chain is complete, fetch the jabatans for the final unit
+            const finalUnitId = selectedUnitPath[selectedUnitPath.length - 1];
+            fetchAndPopulateJabatans(finalUnitId, oldJabatanId);
+        });
+    }
+
+    initializePath();
+});
 </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('users/hierarchy', [UserController::class, 'hierarchy'])->name('users.hierarchy');
     Route::get('users/modern', [UserController::class, 'modern'])->name('users.modern');
     Route::resource('users', UserController::class);
+    Route::get('/units/{unit}/children', [UnitController::class, 'getChildren'])->name('units.children');
     Route::get('/api/users/search', [App\Http\Controllers\UserController::class, 'search'])->name('api.users.search');
 
     Route::get('/workload-analysis', [WorkloadAnalysisController::class, 'index'])->name('workload.analysis');


### PR DESCRIPTION
This commit refactors the user creation and editing forms to support hierarchical unit selection, addressing the issue where Eselon I, Eselon II, and other unit levels were not being displayed correctly.

Key changes:
- Modified `UserController` to load only top-level (Eselon I) units initially and to fetch the full unit path for existing users.
- Added a new route and a `getChildren` method to `UnitController` to dynamically fetch child units via an API call.
- Overhauled the user form partial (`form-fields.blade.php`) to replace the single unit dropdown with four cascading dropdowns for each level of the hierarchy (Eselon I, Eselon II, Koordinator, Sub Koordinator).
- Implemented JavaScript to handle the dynamic loading of these dropdowns, manage form state, and pre-populate the fields when editing a user.