### PR TITLE
fix: Resolve issue with unit dropdowns not appearing

### DIFF
--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -15,7 +15,7 @@
                         @csrf
                         
                         {{-- Pastikan users.partials.form-fields sudah di-styling dengan UI terbaru --}}
-                        @include('users.partials.form-fields')
+                        @include('users.partials.form-fields', ['user' => new \App\Models\User()])
 
                         <div class="flex items-center justify-end mt-8 border-t border-gray-200 pt-6"> {{-- Menambahkan margin atas, border, dan padding atas --}}
                             <a href="{{ route('users.index') }}" class="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 font-medium mr-6 transition-colors duration-200">


### PR DESCRIPTION
This commit fixes a bug in the user creation form where the new hierarchical unit dropdowns were not being rendered.

The root cause was that the `users.create` view was not providing a default, empty `User` object to the `form-fields` partial. The partial requires this object to correctly handle `old()` form values, and its absence caused a rendering error that prevented the form from displaying.

The fix involves explicitly passing a `new User()` object to the partial from within the `create.blade.php` template. This ensures the partial has the necessary data and can render correctly. The `edit` form was unaffected as it already provided a `$user` object.