### PR TITLE
fix: Implement hierarchical unit and position selection on registrati…

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -352,7 +352,7 @@ $(document).ready(function() {
         if (nextSelect.length) {
             nextSelect.prop('disabled', true).html('<option value="">Memuat...</option>');
             $.ajax({
-                url: `/units/${selectedValue}/children`,
+                url: `/api/units/${selectedValue}/children`,
                 type: 'GET',
                 success: function(data) {
                     const placeholder = nextSelect.data('placeholder');

--- a/routes/web.php
+++ b/routes/web.php
@@ -179,4 +179,4 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     Route::get('/activities', [\App\Http\Controllers\ActivityController::class, 'index'])->name('activities.index');
 });
 
-Route::get('/api/units/{unit}/vacant-jabatans', [UnitController::class, 'getVacantJabatans'])->name('api.units.vacant-jabatans')->middleware('auth');
+Route::get('/api/units/{unit}/vacant-jabatans', [UnitController::class, 'getVacantJabatans'])->name('api.units.vacant-jabatans');


### PR DESCRIPTION
…on page

This commit completely overhauls the user registration page (`/register`) to align with the application's unit and position management system. The previous implementation was incomplete and non-functional.

The key changes include:

1.  **Controller Logic:**
    - Fixed a bug in `RegisteredUserController@create` that was preventing Eselon I units from being loaded due to an incorrect query.
    - Completely rewrote the `RegisteredUserController@store` method to securely handle the new registration flow. It now finds a vacant `Jabatan` (position), creates the user, and assigns them to it within a database transaction.

2.  **View and UI:**
    - Replaced the old, incomplete dropdowns in `register.blade.php` with a full, cascading selection for the entire unit hierarchy (Eselon I, II, Koordinator, Sub-Koordinator).
    - Added a "Jabatan" (Position) dropdown that is dynamically populated with vacant positions based on the selected unit.
    - Implemented a robust JavaScript (jQuery) solution to power the dynamic dropdowns.

3.  **Validation:**
    - Updated `RegisterRequest` to include validation for `jabatan_id`, including a custom rule to ensure the selected position is still vacant at the time of form submission.

4.  **API Routes:**
    - Corrected the JavaScript to use the proper public API route for fetching child units.
    - Removed the `auth` middleware from the `vacant-jabatans` API route to make it accessible from the public registration page.

This resolves the issue where unit selection was not working on the registration page and makes the public registration flow consistent with the internal data structure of the application.