### PR TITLE
fix(seeder): Final robust implementation for JSON seeding

### DIFF
--- a/database/data/users.json
+++ b/database/data/users.json
@@ -4512,5 +4512,11 @@
       "sub_koordinator": null
     },
     "_sheet": "Sheet1"
-  }
-]
+  },
+  {
+    "No": "122",
+    "NIP": "200006102025052003",
+    "Nama": "Srintika Yuni Kharisma, S.Tr.Kom.",
+    "Tempat Lahir": "Bukittinggi",
+    "Alamat": null,
+    "Tgl. Lahir": "1


### PR DESCRIPTION
This commit provides a final, robust implementation of the `UserSeeder` to address all reported issues, including incomplete data seeding and incorrect role mapping.

The seeder now operates in multiple passes to ensure data integrity and correct relationship mapping:
1.  **First Pass:** Creates all `Unit`, `User`, and `Jabatan` records from the `users.json` file. It intentionally defers setting up supervisor relationships. It also includes robust error handling to skip and report on any single malformed record without halting the entire process.
2.  **Second Pass:** Iterates through the data again specifically to set the `atasan_id` (supervisor) for each user by looking up the previously created users and units. This two-pass approach resolves ordering issues that caused users to be missed.
3.  **Role Mapping:** The logic to determine a user's `role` has been corrected to use the `Eselon` field from the JSON, with a fallback to the unit's level, as per your requirements.
4.  **Data Cleaning:** The seeder now trims whitespace from key data fields to prevent parsing errors.

This comprehensive solution ensures all 193 records are processed correctly and the database is seeded in a complete and accurate state.