### PR TITLE
fix(data): Correct syntax of users.json data file

### DIFF
--- a/database/data/users.json
+++ b/database/data/users.json
@@ -4512,11 +4512,5 @@
       "sub_koordinator": null
     },
     "_sheet": "Sheet1"
-  },
-  {
-    "No": "122",
-    "NIP": "200006102025052003",
-    "Nama": "Srintika Yuni Kharisma, S.Tr.Kom.",
-    "Tempat Lahir": "Bukittinggi",
-    "Alamat": null,
-    "Tgl. Lahir": "1
+  }
+]


### PR DESCRIPTION
This commit fixes a persistent `TypeError` that occurred during database seeding. The error was caused by an invalid JSON structure in the `database/data/users.json` file.

The JSON you provided was incomplete, with the last object being cut off and the closing array bracket missing. This caused `json_decode()` to fail and return `null`, leading to the crash.

This fix removes the final, corrupted data entry and properly closes the JSON array, making the file syntactically valid. This allows the seeder to run to completion with all the valid data provided.