### PR TITLE
feat: Fix Jabatan dropdown in your edit form

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -255,11 +255,19 @@ class UnitController extends Controller
         return response()->json($children);
     }
 
-    public function getVacantJabatans(Unit $unit)
+    public function getVacantJabatans(Request $request, Unit $unit)
     {
-        // This is for the chained dropdown in user creation form
-        $vacantJabatans = $unit->jabatans()->whereNull('user_id')->get(['id', 'name']);
+        $userIdBeingEdited = $request->query('user_id');
 
-        return response()->json($vacantJabatans);
+        $query = $unit->jabatans()->where(function ($q) use ($userIdBeingEdited) {
+            $q->whereNull('user_id');
+            if ($userIdBeingEdited) {
+                $q->orWhere('user_id', $userIdBeingEdited);
+            }
+        });
+
+        $jabatans = $query->orderBy('name')->get(['id', 'name']);
+
+        return response()->json($jabatans);
     }
 }

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -135,33 +135,35 @@ $(document).ready(function() {
             return;
         }
 
+        let url = `/api/units/${unitId}/vacant-jabatans`;
+        @if ($user->exists)
+            url += `?user_id={{ $user->id }}`;
+        @endif
+
         $.ajax({
-            url: `/api/units/${unitId}/vacant-jabatans`,
+            url: url,
             type: 'GET',
             success: function(data) {
                 jabatanSelect.empty().append('<option value="">-- Pilih Jabatan --</option>');
 
-                // If editing, add the current user's jabatan to the list so it can be re-selected
-                @if($user->exists && $user->jabatan)
-                    if (unitId == '{{ $user->unit_id }}') {
-                        jabatanSelect.append(new Option('{{ $user->jabatan->name }} (Current)', '{{ $user->jabatan->id }}', false, true));
-                    }
-                @endif
-
                 if (data.length > 0) {
                     $.each(data, function(key, jabatan) {
-                        jabatanSelect.append(new Option(jabatan.name, jabatan.id));
+                        // Set the 'selected' property if the current jabatan id matches the old one
+                        let isSelected = (jabatan.id == selectedId);
+                        jabatanSelect.append(new Option(jabatan.name, jabatan.id, false, isSelected));
                     });
                 }
 
-                if (jabatanSelect.find('option').length <= 1) {
-                    jabatanSelect.html('<option value="">-- Tidak ada jabatan kosong --</option>');
-                } else {
-                    jabatanSelect.prop('disabled', false);
+                // After populating, if a selectedId was passed, ensure it's selected.
+                // This is a fallback for cases where the initial selection might not have caught.
+                if (selectedId) {
+                    jabatanSelect.val(selectedId);
                 }
 
-                if (selectedId) {
-                    jabatanSelect.val(selectedId).trigger('change');
+                if (jabatanSelect.find('option').length <= 1) {
+                    jabatanSelect.html('<option value="">-- Tidak ada jabatan tersedia --</option>');
+                } else {
+                    jabatanSelect.prop('disabled', false);
                 }
             },
             error: function() {


### PR DESCRIPTION
- I modified the getVacantJabatans API to include your current Jabatan in the list for the edit form.
- I updated the form's JavaScript to use the improved API and removed the old client-side workaround.
- This ensures your current position is always available for selection when your profile is being edited.

Note: I was unable to run the automated test suite due to a missing PHP executable in the environment. I've verified the changes through code review and manual inspection.