### PR TITLE
fix(seeder): Correct User-Jabatan relationship logic

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -48,7 +48,6 @@ class User extends Authenticatable
         'role',
         'atasan_id',
         'unit_id',
-        'jabatan_id',
         'status',
         'nip',
         'tempat_lahir',

--- a/database/seeders/OrganizationalDataSeeder.php
+++ b/database/seeders/OrganizationalDataSeeder.php
@@ -118,7 +118,6 @@ class OrganizationalDataSeeder extends Seeder
                 'email' => strtolower(str_replace(' ', '.', preg_replace('/[^a-zA-Z0-9\s]/', '', $item->Nama))) . '@example.com',
                 'password' => Hash::make('password'),
                 'unit_id' => $lastUnitId,
-                'jabatan_id' => $jabatan->id,
                 'role' => $role,
                 'status' => 'active',
                 'tempat_lahir' => $item->{'Tempat Lahir'},


### PR DESCRIPTION
- The seeder was incorrectly attempting to set `jabatan_id` on the User model, which does not exist in the `users` table.
- The correct relationship is `jabatans.user_id` referencing a user.
- Removed `jabatan_id` from the User's `$fillable` array.
- Removed the `jabatan_id` assignment from the `User::create()` call in the `OrganizationalDataSeeder`.

This change corrects the faulty logic and should allow the database seeder to run successfully.