### PR TITLE
fix: Restore original data seeders

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,13 +16,11 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
         $this->call([
             OrganizationalDataSeeder::class,
-            // UnitSeeder::class,
-            // UserSeeder::class,
-            // ProjectSeeder::class,
-            // TaskSeeder::class,
-            // TimeLogSeeder::class,
-            // SpecialAssignmentSeeder::class,
-            // AdHocTaskSeeder::class,
+            ProjectSeeder::class,
+            TaskSeeder::class,
+            TimeLogSeeder::class,
+            SpecialAssignmentSeeder::class,
+            AdHocTaskSeeder::class,
         ]);
 
         // Panggil PerformanceCalculatorService untuk memastikan data kinerja terisi


### PR DESCRIPTION
- Re-enables the `ProjectSeeder`, `TaskSeeder`, and other data seeders in `DatabaseSeeder.php`.
- Ensures `OrganizationalDataSeeder` is run first to establish the base user and unit data before other data is created.
- This corrects the previous erroneous assumption that these seeders should be disabled.