### PR TITLE
fix(seeder): Create default superadmin user

### DIFF
--- a/database/seeders/OrganizationalDataSeeder.php
+++ b/database/seeders/OrganizationalDataSeeder.php
@@ -153,6 +153,15 @@ class OrganizationalDataSeeder extends Seeder
         // Set Atasan ID
         $this->setAtasan();
 
+        // Create a default Super Admin user
+        User::create([
+            'name' => 'Super Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+            'role' => User::ROLE_SUPERADMIN,
+            'status' => 'active',
+        ]);
+
         if ($dbDriver === 'mysql') {
             DB::statement('SET FOREIGN_KEY_CHECKS=1;');
         } elseif ($dbDriver === 'pgsql') {


### PR DESCRIPTION
- The seeder previously truncated the users table without recreating a superadmin, leaving the application without an admin account.
- Added logic to `OrganizationalDataSeeder` to create a default Super Admin user after seeding from the JSON file.
- This ensures the application is always in a usable state after seeding.