### PR TITLE
fix: Resolve TypeError in OrganizationalDataSeeder

### DIFF
--- a/database/seeders/OrganizationalDataSeeder.php
+++ b/database/seeders/OrganizationalDataSeeder.php
@@ -38,7 +38,7 @@ class OrganizationalDataSeeder extends Seeder
 
         // Get data from JSON file
         $json = File::get(database_path('data/users_profile_data.json'));
-        $data = json_decode($json, true); // Decode as an associative array
+        $data = json_decode($json); // Decode as an array of objects
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             $this->command->error('JSON file is invalid: ' . json_last_error_msg());


### PR DESCRIPTION
Changed the json_decode method in the OrganizationalDataSeeder to produce an array of objects (stdClass) instead of an array of associative arrays. This is necessary because the OrganizationalDataImporterService's processItem method is type-hinted to accept an object.

This change resolves the TypeError that occurred when running `php artisan migrate:fresh --seed`.