### PR TITLE
fix(js): Load jQuery library and remove debug logs

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -108,6 +108,9 @@
     </script>
     @endif
     
+    {{-- jQuery --}}
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+
     {{-- Slot untuk script tambahan per halaman --}}
     @stack('scripts')
 </body>

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -217,26 +217,19 @@ $(document).ready(function() {
                 url: `/api/units/${selectedValue}/children`,
                 type: 'GET',
                 success: function(data) {
-                    console.log('Successfully fetched child units. Response:', data);
                     const placeholder = nextSelect.data('placeholder');
                     nextSelect.empty().append(new Option(placeholder, ''));
                     if (data.length > 0) {
-                        console.log(`Found ${data.length} child units. Populating dropdown.`);
                         $.each(data, function(key, unit) {
                             nextSelect.append(new Option(unit.name, unit.id));
                         });
                         nextSelect.prop('disabled', false);
                     } else {
-                        console.log('Response contained 0 child units.');
                         nextSelect.html(new Option('-- Tidak ada unit bawahan --', '')).prop('disabled', true);
                     }
                 },
-                error: function(jqXHR, textStatus, errorThrown) {
-                    console.error('AJAX call failed to fetch child units.');
-                    console.error('Status:', textStatus);
-                    console.error('Error:', errorThrown);
-                    console.error('Response:', jqXHR.responseText);
-                    nextSelect.html(new Option('-- Gagal memuat data --', '')).prop('disabled',true);
+                error: function() {
+                    nextSelect.html(new Option('-- Gagal memuat data --', '')).prop('disabled', true);
                 }
             });
         }


### PR DESCRIPTION
I resolved a `ReferenceError: $ is not defined` on your forms by including the jQuery library from a CDN in the main application layout (`app.blade.php`), placing the script tag before the `@stack('scripts')` directive to ensure it is available for page-specific scripts.

I also removed the temporary `console.log` statements that were added to your form's JavaScript for debugging the cascading dropdown issue.