### PR TITLE
refactor(units): Align UnitController with current architecture

### DIFF
--- a/resources/views/admin/units/partials/form-fields.blade.php
+++ b/resources/views/admin/units/partials/form-fields.blade.php
@@ -8,19 +8,6 @@
     </div>
 
     <div>
-        <label for="level" class="block font-semibold text-sm text-gray-700 mb-1">
-            <i class="fas fa-stairs mr-2 text-gray-500"></i> Level <span class="text-red-500">*</span>
-        </label>
-        <select name="level" id="level" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" required>
-            <option value="">-- Pilih Level --</option>
-            @foreach(\App\Models\Unit::LEVELS as $levelData)
-                <option value="{{ $levelData['name'] }}" @selected(old('level', $unit->level ?? '') == $levelData['name'])>{{ $levelData['name'] }}</option>
-            @endforeach
-        </select>
-        @error('level') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
-    </div>
-
-    <div>
         <label for="parent_unit_id" class="block font-semibold text-sm text-gray-700 mb-1">
             <i class="fas fa-building-circle-arrow-up mr-2 text-gray-500"></i> Unit Atasan (Opsional)
         </label>
@@ -34,14 +21,4 @@
         @error('parent_unit_id') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
     </div>
 
-    @if(!isset($unit)) {{-- Only show on create form --}}
-    <div class="md:col-span-2">
-        <label for="main_jabatan_name" class="block font-semibold text-sm text-gray-700 mb-1">
-            <i class="fas fa-id-badge mr-2 text-gray-500"></i> Nama Jabatan Pimpinan Unit <span class="text-red-500">*</span>
-        </label>
-        <input type="text" name="main_jabatan_name" id="main_jabatan_name" value="{{ old('main_jabatan_name') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" required placeholder="e.g., Kepala Divisi, Koordinator, etc.">
-        <p class="text-xs text-gray-500 mt-1">Jabatan ini akan menjadi posisi pimpinan untuk unit yang baru dibuat.</p>
-        @error('main_jabatan_name') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
-    </div>
-    @endif
 </div>


### PR DESCRIPTION
This commit refactors the UnitController and its views to bring them in sync with the current application design, which no longer uses a 'level' property on units.

- The `store` and `update` methods in `UnitController` have been simplified to only handle `name` and `parent_unit_id`. All logic related to `level` has been removed.
- The `form-fields.blade.php` partial for unit creation/editing has been updated to remove the input fields for 'Level' and 'Nama Jabatan Utama'.

This resolves fatal errors that would occur when trying to create or edit a unit and makes the module consistent with the rest of the application's hierarchical structure.