### PR TITLE
fix(db): Make user_id nullable in activities table

### DIFF
--- a/database/migrations/2025_08_14_230700_make_user_id_nullable_in_activities_table.php
+++ b/database/migrations/2025_08_14_230700_make_user_id_nullable_in_activities_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            // Note: Reverting this might fail if NULL values exist in the column.
+            // For this project's context, this is acceptable.
+            $table->unsignedBigInteger('user_id')->nullable(false)->change();
+        });
+    }
+};


### PR DESCRIPTION
Creates a new migration to alter the `activities` table, changing the `user_id` column to be nullable. This is required to allow the `OrganizationalDataSeeder` to run without a currently authenticated user, as the `RecordsActivity` trait will now correctly insert a null `user_id` for system-generated events. This resolves the final 'Not null violation' error during seeding.