### PR TITLE
This commit provides a definitive fix for the "Cannot redeclare funct…

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -379,10 +379,19 @@ class UserController extends Controller
         return redirect()->route('users.index')->with('success', 'User berhasil dihapus dan jabatan telah dikosongkan.');
     }
 
-    public function getUsersByUnit(Unit $unit)
+    public function getUsersByUnitFromId(int $unitId)
+    {
+        $users = User::where('unit_id', $unitId)
+                     ->orderBy('name')
+                     ->get(['id', 'name', 'email']);
+
+        return response()->json(['users' => $users]);
+    }
+
+    public function getUsersByUnitFromModel(Unit $unit)
     {
         $users = $unit->users()
-            ->with('jabatan') // Eager load jabatan for efficiency
+            ->with('jabatan')
             ->orderBy('name')
             ->get()
             ->map(function ($user) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,7 @@ Route::get('/', function () {
 });
 
 
-Route::get('/get-users-by-unit/{unit}', [UserController::class, 'getUsersByUnit'])->name('users.by-unit');
+Route::get('/get-users-by-unit/{unitId}', [UserController::class, 'getUsersByUnitFromId'])->name('users.by-unit');
 
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;


### PR DESCRIPTION
…ion" fatal error in `UserController.php`.

Following the user's explicit suggestion, this change implements two uniquely named methods:
- `getUsersByUnitFromId(int $unitId)`
- `getUsersByUnitFromModel(Unit $unit)`

The route file `routes/web.php` has been updated to point to the correct, non-conflicting method. This replaces the previous strategy and should guarantee that no function name collisions occur.