### PR TITLE
refactor: Rework Role and Position Logic for Consistency

### DIFF
--- a/app/Models/Jabatan.php
+++ b/app/Models/Jabatan.php
@@ -13,6 +13,7 @@ class Jabatan extends Model
 
     protected $fillable = [
         'name',
+        'type',
         'unit_id',
         'user_id',
     ];

--- a/database/migrations/2025_08_15_043028_add_type_to_jabatans_table.php
+++ b/database/migrations/2025_08_15_043028_add_type_to_jabatans_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('jabatans', function (Blueprint $table) {
+            $table->enum('type', ['struktural', 'fungsional'])->default('fungsional')->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('jabatans', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+    }
+};


### PR DESCRIPTION
This commit implements a significant architectural refactoring to address fundamental inconsistencies in how user roles, positions (jabatan), and organizational units are handled. The previous logic incorrectly assigned managerial roles to functional staff, leading to potential security and data integrity issues.

Key changes:

1.  **Introduced Position (`Jabatan`) Types**:
    - A `type` column (`struktural`, `fungsional`) has been added to the `jabatans` table via a new migration. This allows the system to differentiate between structural/managerial positions and functional staff positions.

2.  **Refactored Role Assignment Logic**:
    - The `UserController` (store and update methods) now determines a user's role based on their assigned position's type.
    - If a position is 'struktural', the role is determined by the unit's depth in the hierarchy (e.g., Eselon I, Koordinator).
    - If a position is 'fungsional', the user is correctly assigned the `User::ROLE_STAF`, regardless of their unit's level. This prevents non-managerial staff from receiving incorrect permissions.

3.  **Enforced Data Consistency**:
    - The `UserController` now derives a user's `unit_id` directly from their assigned `jabatan_id`. The `unit_id` field has been removed from the validation rules for creating/updating users, as it is now set automatically, guaranteeing that a user's unit and position are always synchronized.

4.  **Refined Head of Unit Logic**:
    - As a direct result of the improved role assignment, the logic for setting the `kepala_unit_id` is now implicitly correct. It will only be assigned to users who are given a 'struktural' position that corresponds to a leadership role.