### PR TITLE
This commit fixes a fatal error in the S-Curve generation logic that …

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -278,8 +278,11 @@ class ProjectController extends Controller
             if ($taskDurationDays > 0) {
                 $hoursPerDay = $task->estimated_hours / $taskDurationDays;
                 for ($date = $taskStart->copy(); $date->lte($taskEnd); $date->addDay()) {
-                    if ($date->lte($endDate)) { // Hanya tambahkan jika masih dalam periode proyek
-                       $plannedDailyHours[$date->format('Y-m-d')] += $hoursPerDay;
+                    $currentDateStr = $date->format('Y-m-d');
+                    // Directly check if the date key exists in our planned hours array.
+                    // This is the most robust way to prevent the "Undefined array key" error.
+                    if (isset($plannedDailyHours[$currentDateStr])) {
+                       $plannedDailyHours[$currentDateStr] += $hoursPerDay;
                     }
                 }
             }


### PR DESCRIPTION
…occurred when a task's date range fell outside the project's official date range.

The `sCurve` method in `ProjectController` was attempting to access an array key for a date that did not exist in the initialized `$plannedDailyHours` array.

The fix replaces the simple date boundary check with a more robust `isset()` check on the array key before attempting to write to it. This directly prevents the "Undefined array key" error and makes the calculation more resilient to tasks with dates outside the main project timeline.