### PR TITLE
fix: Resolve critical regressions from dashboard overhaul

### DIFF
--- a/app/Http/Controllers/ExecutiveSummaryController.php
+++ b/app/Http/Controllers/ExecutiveSummaryController.php
@@ -134,8 +134,10 @@ class ExecutiveSummaryController extends Controller
     
     private function getAllSubordinatesIteratively(User $user, $includeSelf = false): Collection
     {
-        if ($user->role === User::ROLE_SUPERADMIN) {
-            return User::where('id', '!=', $user->id)->get();
+        // SUPERADMIN FIX: A Superadmin does not have organizational subordinates in the same way.
+        // Loading all users is a performance killer and incorrect. Return an empty collection.
+        if ($user->isSuperAdmin()) {
+            return collect();
         }
 
         if (!$user->unit) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -353,6 +353,11 @@ class UserController extends Controller
             }
 
             // 4. Update the user
+            // Safeguard: Prevent a Superadmin's role from being accidentally changed by this form.
+            // The Superadmin role should be managed separately and intentionally.
+            if ($user->isSuperAdmin()) {
+                unset($updateData['role']);
+            }
             $user->update($updateData);
             $user->refresh(); // Refresh to get the latest data including the new role
 


### PR DESCRIPTION
This hotfix addresses two critical regressions introduced in the previous feature deployment: a non-functional impersonation feature and an infinite loading screen on the main dashboard for Superadmins.

1.  **Fix Impersonation Failure:**
    -   **Root Cause:** The `UserController@update` method's logic for assigning roles based on a user's `jabatan` was incorrectly stripping the 'Superadmin' role from admin users when their profiles were edited. This made them unable to pass the `superadmin` middleware check required for impersonation.
    -   **Solution:** Added a safeguard to the `UserController@update` method. It now checks if the user being edited is a Superadmin, and if so, it explicitly prevents any changes to their role, ensuring their administrative privileges are preserved.

2.  **Fix Infinite Loading on Dashboard:**
    -   **Root Cause:** When a Superadmin logged in, they were routed to the `ExecutiveSummaryController`. A helper method, `getAllSubordinatesIteratively`, was incorrectly attempting to fetch every user from the database as a "subordinate" for the Superadmin. On a large database, this caused a timeout or memory exhaustion, resulting in the page never loading.
    -   **Solution:** Modified the `getAllSubordinatesIteratively` method to recognize the Superadmin case. It now correctly returns an empty collection, as a Superadmin has no organizational subordinates. This prevents the massive database query and allows the executive dashboard to load instantly and correctly display (empty) subordinate-based statistics.