### PR TITLE
fix: Resolve fatal error in AuthServiceProvider

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,7 +16,6 @@ use App\Policies\UnitPolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
-use App\Models\User;
 
 class AuthServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
This commit fixes a fatal PHP error that was preventing the application from running.

**Root Cause:**
A duplicate `use App\Models\User;` statement was accidentally added to `app/Providers/AuthServiceProvider.php`, causing a "name already in use" fatal error.

**Solution:**
The duplicate `use` statement has been removed.

This commit also preserves the definitive fixes for the user impersonation feature that were included in the previous, non-running commit:
- The `CheckSuperadmin` middleware now correctly handles impersonation sessions.
- A global `Gate::before` hook ensures Superadmins retain their permissions while impersonating.