### PR TITLE
fix: Resolve N+1 query problem in ProjectPolicy to fix loading issue

### DIFF
--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -35,7 +35,8 @@ class ProjectPolicy
 
         // Manajer bisa melihat proyek milik bawahannya
         if ($user->isManager() && $user->unit && $project->owner && $project->owner->unit) {
-            return in_array($project->owner->unit->id, $user->unit->getAllSubordinateUnitIds());
+            // Use the cached method to prevent N+1 performance issues
+            return $user->getSubordinateUnitIdsWithCache()->contains($project->owner->unit->id);
         }
 
         return false;
@@ -66,7 +67,8 @@ class ProjectPolicy
 
         // Manajer dari pemilik bisa update
         if ($user->isManager() && $user->unit && $project->owner && $project->owner->unit) {
-            return in_array($project->owner->unit->id, $user->unit->getAllSubordinateUnitIds());
+            // Use the cached method to prevent N+1 performance issues
+            return $user->getSubordinateUnitIdsWithCache()->contains($project->owner->unit->id);
         }
 
         return false;


### PR DESCRIPTION
This commit resolves the final 'infinite loading' issue reported during impersonation, which was caused by a severe N+1 query performance problem.

**Root Cause:**
The `ProjectPolicy`'s `view` and `update` methods were inefficient. For every project rendered on the dashboard, the policy would call a method to get all subordinate unit IDs for the currently authenticated user. While the underlying database query for the hierarchy was fast (using a Closure Table), calling it repeatedly for every project resulted in a classic N+1 problem, causing the page load to hang or time out.

**Solution:**
An in-request caching mechanism has been implemented on the `User` model to drastically improve performance:

1.  **New Caching Property:** A public property `$subordinateUnitIdsCache` was added to the `User` model to store the hierarchy data.
2.  **New Caching Method:** A new method, `getSubordinateUnitIdsWithCache()`, was created. This method retrieves the subordinate unit IDs only once per user per request and stores the result in the cache property for subsequent calls.
3.  **Policy Optimization:** The `ProjectPolicy` and the `User::isSubordinateOf` method have been updated to use this new cached method instead of the uncached one.

This eliminates the N+1 query issue, ensuring the database is only hit once for the hierarchy check per request, which will allow the dashboard to load quickly and efficiently.