### PR TITLE
Fix: Resolve recursive loading in impersonation feature

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -537,10 +537,11 @@ class UserController extends Controller
 
         // Login back as the original user
         $originalUserId = session('impersonator_id');
-        Auth::login(User::find($originalUserId));
 
-        // Forget the impersonator_id from session
+        // Forget the impersonator_id from session BEFORE logging back in
         session()->forget('impersonator_id');
+
+        Auth::login(User::find($originalUserId));
 
         return redirect()->route('users.index')->with('success', 'Sesi peniruan telah berakhir.');
     }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -49,11 +49,6 @@ class Unit extends Model
         return $this->hasMany(Unit::class, 'parent_unit_id');
     }
 
-    public function childrenRecursive()
-    {
-        return $this->children()->with('childrenRecursive');
-    }
-
     public function jabatans(): HasMany
     {
         return $this->hasMany(Jabatan::class);


### PR DESCRIPTION
This commit resolves a critical memory exhaustion error that occurred during user impersonation. The error was caused by an infinite recursive relationship in the `Unit` model that was triggered when an impersonated user's data was loaded.

The fix includes two key changes:

1.  **Removed Recursive Relationship:** The `childrenRecursive()` method in the `app/Models/Unit.php` model has been removed. This was the root cause of the memory exhaustion, as it attempted to load an entire organizational unit tree into memory.

2.  **Corrected Impersonation Flow:** The `leaveImpersonate()` method in `app/Http/Controllers/UserController.php` has been updated to ensure the `impersonator_id` is removed from the session *before* logging the original user back in. This prevents the impersonation state from leaking into the original user's session and makes the flow more robust.