### PR TITLE
Fix: Resolve impersonation issues and remove verification check

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -505,13 +505,6 @@ class UserController extends Controller
             return redirect()->route('users.index')->with('error', 'Tidak dapat meniru sesama Superadmin.');
         }
 
-        // TOTAL FIX: Prevent impersonating an unverified user to avoid a redirect loop
-        // with the 'verified' middleware.
-        if (!$user->hasVerifiedEmail()) {
-            // The user list route is 'users.index', not 'admin.users.index'.
-            return redirect()->route('users.index')->with('error', 'Gagal meniru: Pengguna "' . $user->name . '" belum memverifikasi email mereka.');
-        }
-
         // Store the original user's ID
         $originalUserId = Auth::id();
 


### PR DESCRIPTION
This commit addresses two issues related to the user impersonation feature.

First, it resolves a critical memory exhaustion error caused by an infinite recursive relationship in the `Unit` model. The `childrenRecursive()` method, which was the root cause of the error, has been removed from `app/Models/Unit.php`.

Second, it updates the session handling in the `leaveImpersonate()` method in `app/Http/Controllers/UserController.php` to be more robust by ensuring the session is cleaned before logging the original user back in.

Finally, based on a follow-up request, the email verification check has been removed from the `impersonate()` method. This allows administrators to impersonate users even if their email addresses have not been verified.