### PR TITLE
Fix: Resolve recursive loading and update impersonation logic

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -34,6 +34,15 @@ class Unit extends Model
         'parent_unit_id',
     ];
 
+    /**
+     * The relationships that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'kepalaUnit',
+    ];
+
     public function parentUnit(): BelongsTo
     {
         return $this->belongsTo(Unit::class, 'parent_unit_id');


### PR DESCRIPTION
This commit resolves a recurring memory exhaustion error and refines the user impersonation feature.

The primary issue was a recursive relationship loop that occurred during model serialization, most likely after a user impersonation. This has been fixed by:
1.  Removing the explicit `childrenRecursive` relationship from the `Unit` model.
2.  Hiding the `kepalaUnit` relationship on the `Unit` model from serialization. This prevents an indirect `User -> Unit -> User` loop from being triggered.

Additionally, the impersonation flow has been improved:
1.  The `leaveImpersonate` method now correctly removes the impersonation key from the session *before* logging the original user back in.
2.  The email verification check has been removed from the `impersonate` method, allowing admins to impersonate unverified users as per a follow-up request.