### PR TITLE
Fix: Resolve recursive loading in ResourcePool API

### DIFF
--- a/app/Http/Controllers/ResourcePoolController.php
+++ b/app/Http/Controllers/ResourcePoolController.php
@@ -74,10 +74,10 @@ class ResourcePoolController extends Controller
     {
         $members = User::where('is_in_resource_pool', true)
                         ->where('id', '!=', Auth::id())
-                        ->with('atasan:id,name')   // muat nama atasan saja
+                        ->with('atasan:id,name') // Still only load id and name to be safe
                         ->get(['id','name','role','pool_availability_notes','atasan_id']);
 
-        // Transformasi ke array sederhana untuk mencegah siklus rekursif
+        // Transform to an array, but maintain the nested structure the frontend expects
         $formatted = $members->map(function ($user) {
             return [
                 'id'   => $user->id,
@@ -85,7 +85,10 @@ class ResourcePoolController extends Controller
                 'role' => $user->role,
                 'pool_availability_notes' => $user->pool_availability_notes,
                 'atasan_id'   => $user->atasan_id,
-                'atasan_name' => $user->atasan?->name,
+                'atasan' => $user->atasan ? [         // Recreate the nested atasan object
+                    'id' => $user->atasan->id,
+                    'name' => $user->atasan->name,
+                ] : null,
             ];
         });
 


### PR DESCRIPTION
This commit provides a definitive fix for a persistent memory exhaustion error that occurred during user impersonation.

The root cause was identified in the `ResourcePoolController@getAvailableMembers` API endpoint. Eager-loading the full `atasan` (supervisor) relationship caused an infinite recursive loop during JSON serialization. The initial fix for this broke the API contract, causing a frontend display issue.

This commit resolves both issues by implementing a safe data-fetching pattern:
1.  The `atasan` relationship is loaded with only the necessary `id` and `name` columns.
2.  The resulting Eloquent collection is manually transformed into a plain array, recreating the nested `atasan` object structure that the frontend expects. This breaks the backend recursion loop while satisfying the frontend's data requirements.

This commit supersedes previous attempts and provides a stable and comprehensive solution to the problem.