### PR TITLE
Fitur: Menambahkan kemampuan manajemen pengguna yang didelegasikan

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -166,9 +166,19 @@ class UnitController extends Controller
             'name' => 'required|string|max:255',
             'type' => ['required', Rule::in(['struktural', 'fungsional'])],
             'role' => ['required', Rule::in($validRoles)],
+            'can_manage_users' => ['nullable', 'boolean'],
         ]);
 
-        $unit->jabatans()->create($validated);
+        // The 'boolean' validation rule handles the checkbox value correctly.
+        // If the checkbox is not checked, it won't be in the request, and validation will treat it as false.
+        $dataToCreate = [
+            'name' => $validated['name'],
+            'type' => $validated['type'],
+            'role' => $validated['role'],
+            'can_manage_users' => $request->has('can_manage_users'),
+        ];
+
+        $unit->jabatans()->create($dataToCreate);
 
         return back()->with('success', 'Jabatan berhasil ditambahkan.');
     }

--- a/app/Models/Jabatan.php
+++ b/app/Models/Jabatan.php
@@ -15,8 +15,13 @@ class Jabatan extends Model
         'name',
         'type',
         'role',
+        'can_manage_users',
         'unit_id',
         'user_id',
+    ];
+
+    protected $casts = [
+        'can_manage_users' => 'boolean',
     ];
 
     public function unit(): BelongsTo

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -159,4 +159,29 @@ class Unit extends Model
         return $this->belongsToMany(self::class, 'unit_paths', 'ancestor_id', 'descendant_id')
                     ->where('depth', '>', 0);
     }
+
+    /**
+     * Get the Eselon II ancestor for this unit.
+     *
+     * @return Unit|null
+     */
+    public function getEselonIIAncestor(): ?Unit
+    {
+        // The depth of the unit itself relative to its own ancestors (i.e., its level in the hierarchy)
+        $selfDepth = $this->ancestors()->count();
+
+        // If this unit is an Eselon II unit (depth 2), return itself.
+        // Depth is 0-indexed: 0=Menteri, 1=Eselon I, 2=Eselon II
+        if ($selfDepth === 2) {
+            return $this;
+        }
+
+        // Otherwise, find the ancestor that is at depth 2.
+        // The 'depth' in the unit_paths table is relative from the ancestor to the descendant.
+        // So we need to find an ancestor where the path from it to `this` unit has a certain depth.
+        // A more direct way is to just find an ancestor whose own depth is 2.
+        return $this->ancestors()->get()->first(function ($ancestor) {
+            return $ancestor->ancestors()->count() === 2;
+        });
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ use App\Models\Traits\RecordsActivity;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Unit; // Pastikan ini diimpor
 use App\Models\Project;
+use App\Models\Jabatan;
 use App\Scopes\HierarchicalScope;
 
 class User extends Authenticatable
@@ -265,6 +266,12 @@ class User extends Authenticatable
 
     public function canManageUsers(): bool
     {
+        // Delegated admin check
+        if ($this->jabatan?->can_manage_users) {
+            return true;
+        }
+
+        // Default role-based check
         return in_array($this->role, [self::ROLE_MENTERI, self::ROLE_SUPERADMIN, self::ROLE_ESELON_I, self::ROLE_ESELON_II, self::ROLE_KOORDINATOR]);
     }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -47,7 +47,18 @@ class UserPolicy
      */
     public function update(User $user, User $model): bool
     {
-        // Pengguna bisa mengedit bawahannya.
+        // Delegated admin with Eselon II scope
+        if ($user->jabatan?->can_manage_users) {
+            $userEselonII = $user->unit?->getEselonIIAncestor();
+            $modelEselonII = $model->unit?->getEselonIIAncestor();
+
+            // Allow if both are in the same Eselon II unit branch
+            if ($userEselonII && $modelEselonII && $userEselonII->id === $modelEselonII->id) {
+                return true;
+            }
+        }
+
+        // Default logic: a user can edit their own subordinates.
         return $model->isSubordinateOf($user);
     }
 

--- a/database/migrations/2025_08_17_011500_add_can_manage_users_to_jabatans_table.php
+++ b/database/migrations/2025_08_17_011500_add_can_manage_users_to_jabatans_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('jabatans', function (Blueprint $table) {
+            $table->boolean('can_manage_users')->default(false)->after('role')->comment('Determines if the holder of this position can manage other users in their unit scope.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('jabatans', function (Blueprint $table) {
+            $table->dropColumn('can_manage_users');
+        });
+    }
+};

--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -74,9 +74,9 @@
                     <form action="{{ route('admin.units.jabatans.store', $unit) }}" method="POST" class="border-t border-gray-200 pt-6">
                         @csrf
                         <h4 class="font-semibold text-lg text-gray-800 mb-4">Tambah Jabatan Baru</h4>
-                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
                             {{-- Nama Jabatan --}}
-                            <div>
+                            <div class="md:col-span-2">
                                 <label for="jabatan_name" class="block text-sm font-medium text-gray-700">Nama Jabatan</label>
                                 <input type="text" name="name" id="jabatan_name" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" placeholder="e.g., Staf Pelaksana" required>
                             </div>
@@ -99,6 +99,12 @@
                                     @endforeach
                                 </select>
                             </div>
+                        </div>
+                        <div class="mt-6">
+                             <label for="can_manage_users" class="flex items-center">
+                                <input type="checkbox" name="can_manage_users" id="can_manage_users" value="1" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500">
+                                <span class="ml-2 text-sm text-gray-600">Dapat Mengelola Pengguna di Unit Eselon II nya</span>
+                            </label>
                         </div>
                         <div class="flex justify-end mt-6">
                             <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md">


### PR DESCRIPTION
Memperkenalkan kemampuan baru bagi peran non-Superadmin (seperti Kasubbag Tata Usaha) untuk mengelola pengguna dalam lingkup yang ditentukan.

- Menambahkan kolom boolean `can_manage_users` ke tabel `jabatans`.
- Memperbarui formulir pembuatan Jabatan untuk menyertakan checkbox yang memberikan hak akses ini.
- Memperbarui `UserPolicy` untuk memberikan izin `create` dan `update` kepada pengguna yang jabatannya memiliki flag `can_manage_users`.
- Izin ini terbatas pada pengelolaan pengguna lain yang berada dalam lingkup unit Eselon II yang sama.
- Menambahkan metode helper `getEselonIIAncestor` ke model `Unit` untuk memfasilitasi pemeriksaan cakupan Eselon II.