### PR TITLE
Fix: Memperbaiki logika fallback penentuan peran agar tidak salah men…

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -531,7 +531,6 @@ class UserController extends Controller
         $depth = $unit->ancestors()->count();
 
         return match ($depth) {
-            0 => User::ROLE_MENTERI,
             1 => User::ROLE_ESELON_I,
             2 => User::ROLE_ESELON_II,
             3 => User::ROLE_KOORDINATOR,

--- a/app/Services/OrganizationalDataImporterService.php
+++ b/app/Services/OrganizationalDataImporterService.php
@@ -137,7 +137,6 @@ class OrganizationalDataImporterService
         // or structural staff without a clear Eselon mapping.
         $depth = $unit->ancestors()->count();
         return match ($depth) {
-            0 => User::ROLE_MENTERI,
             1 => User::ROLE_ESELON_I,
             2 => User::ROLE_ESELON_II,
             3 => User::ROLE_KOORDINATOR,


### PR DESCRIPTION
…etapkan Menteri

Memperbaiki bug di mana pengguna di unit level 0 (root) secara tidak benar diberi peran 'Menteri' secara default. Ini terjadi di `UserController` (untuk pembuatan/pembaruan manual) dan di `OrganizationalDataImporterService` (untuk impor data).

- Kasus `0 => User::ROLE_MENTERI` telah dihapus dari pernyataan `match` di kedua file.
- Sekarang, setiap unit yang tidak secara eksplisit cocok dengan level Eselon I-IV akan dengan benar jatuh ke kasus `default`, yang menetapkan peran 'Staf'.
- Peran 'Menteri' sekarang harus ditetapkan secara eksplisit pada Jabatan, sesuai dengan arsitektur yang diinginkan.