### PR TITLE
Fix: Menggunakan whereNull untuk mengambil unit Eselon I, bukan kolom…

### DIFF
--- a/app/Http/Controllers/CompleteProfileController.php
+++ b/app/Http/Controllers/CompleteProfileController.php
@@ -21,7 +21,7 @@ class CompleteProfileController extends Controller
             return redirect()->route('dashboard');
         }
 
-        $eselonIUnits = Unit::where('level', Unit::LEVEL_ESELON_I)->orderBy('name')->get();
+        $eselonIUnits = Unit::whereNull('parent_unit_id')->orderBy('name')->get();
         $selectedUnitPath = []; // For the form partial
 
         return view('profile.complete', compact('eselonIUnits', 'selectedUnitPath'));


### PR DESCRIPTION
… 'level'

Memperbaiki bug SQLSTATE[42703] yang terjadi karena mencoba melakukan kueri pada kolom 'level' yang tidak ada di tabel `units`. Kolom ini telah dihapus dalam migrasi sebelumnya dan digantikan oleh sistem hierarki berbasis kedalaman.

- Logika di `CompleteProfileController@create` telah diperbaiki untuk menggunakan `whereNull('parent_unit_id')` untuk secara akurat mengambil unit Eselon I (unit root).
- Ini menyelesaikan fatal error dan menyelaraskan controller dengan skema database saat ini.