### PR TITLE
Fix: Mencegah Super Admin dialihkan ke halaman 'Lengkapi Profil'

### DIFF
--- a/app/Http/Middleware/CheckProfileIsComplete.php
+++ b/app/Http/Middleware/CheckProfileIsComplete.php
@@ -19,9 +19,10 @@ class CheckProfileIsComplete
         $user = Auth::user();
 
         // If the user is authenticated, their profile is incomplete (no unit_id),
+        // AND THEY ARE NOT A SUPERADMIN,
         // and they are not already on the 'complete profile' page or trying to log out,
         // then redirect them.
-        if ($user && is_null($user->unit_id) && !$request->routeIs('profile.complete.*') && !$request->routeIs('logout')) {
+        if ($user && !$user->isSuperAdmin() && is_null($user->unit_id) && !$request->routeIs('profile.complete.*') && !$request->routeIs('logout')) {
             return redirect()->route('profile.complete.create')->with('warning', 'Harap lengkapi profil Anda untuk melanjutkan.');
         }
 


### PR DESCRIPTION
Memperbaiki bug di middleware `CheckProfileIsComplete` yang secara tidak benar mengarahkan Super Admin ke halaman kelengkapan profil. Super Admin, yang secara desain tidak memiliki `unit_id`, secara keliru dianggap sebagai pengguna dengan profil yang tidak lengkap.

- Menambahkan kondisi `!$user->isSuperAdmin()` ke dalam pernyataan `if` di middleware.
- Ini memastikan bahwa pemeriksaan kelengkapan profil hanya berlaku untuk pengguna non-Superadmin, memungkinkan Super Admin untuk mengakses dashboard dan bagian lain dari aplikasi tanpa gangguan.