### PR TITLE
Fix: Memperbaiki urutan rute pengguna dan mengkonsolidasikan rute profil

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -82,17 +82,19 @@ Route::middleware(['auth'])->group(function () {
 
     Route::get('users/hierarchy', [UserController::class, 'hierarchy'])->name('users.hierarchy');
     Route::get('users/modern', [UserController::class, 'modern'])->name('users.modern');
-    Route::get('users/{user}/profile', [UserController::class, 'profile'])->name('users.profile');
-    // Custom routes for user management to replace Route::resource
+
+    // Custom routes for user management
     Route::get('/users', [UserController::class, 'index'])->name('users.index');
     Route::get('/users/create', [UserController::class, 'create'])->name('users.create');
+    Route::get('/users/archived', [UserController::class, 'archived'])->name('users.archived');
     Route::post('/users', [UserController::class, 'store'])->name('users.store');
-    Route::get('/users/{user}', [UserController::class, 'show'])->name('users.show');
+    // Wildcard routes must be last
+    Route::get('/users/{user}', [UserController::class, 'profile'])->name('users.show');
     Route::get('/users/{user}/edit', [UserController::class, 'edit'])->name('users.edit');
     Route::put('/users/{user}', [UserController::class, 'update'])->name('users.update');
     Route::post('/users/{user}/deactivate', [UserController::class, 'deactivate'])->name('users.deactivate');
-    Route::get('/users/archived', [UserController::class, 'archived'])->name('users.archived');
     Route::post('/users/{user}/reactivate', [UserController::class, 'reactivate'])->name('users.reactivate');
+
     Route::get('/api/users/search', [App\Http\Controllers\UserController::class, 'search'])->name('api.users.search');
 
     Route::get('/workload-analysis', [WorkloadAnalysisController::class, 'index'])->name('workload.analysis');


### PR DESCRIPTION
Memperbaiki bug di mana rute `/users/archived` secara keliru ditangani oleh rute wildcard `/users/{user}` karena urutan definisi yang salah. Ini menyebabkan error 'method show does not exist'.

- Mengubah urutan rute di `routes/web.php` untuk memastikan rute spesifik seperti `/users/archived` dan `/users/create` didefinisikan sebelum rute wildcard.
- Menghapus rute `/users/{user}/profile` yang redundan dan mengarahkan rute `GET /users/{user}` (bernama `users.show`) ke metode `profile` yang sudah ada di `UserController`.