### PR TITLE
Fitur: Menambahkan fungsionalitas Hapus Permanen untuk pengguna yang …

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -541,6 +541,23 @@ class UserController extends Controller
         return redirect()->route('users.archived')->with('success', 'Pengguna telah berhasil diaktifkan kembali.');
     }
 
+    public function forceDelete(User $user)
+    {
+        $this->authorize('forceDelete', $user);
+
+        DB::transaction(function () use ($user) {
+            // Manually nullify relationships that are RESTRICTed on delete.
+            \App\Models\Project::where('leader_id', $user->id)->update(['leader_id' => null]);
+
+            // Other relationships like jabatan, project_user, task_user, etc., are handled
+            // by onDelete('cascade') or onDelete('set null') at the database level.
+
+            $user->delete();
+        });
+
+        return redirect()->route('users.archived')->with('success', 'Pengguna telah dihapus secara permanen.');
+    }
+
     private function isLeadershipRole(string $role): bool
     {
         return in_array($role, [

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -95,6 +95,15 @@ class UserPolicy
     }
 
     /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, User $model): bool
+    {
+        // Only superadmins can force delete, and only if the user is already suspended.
+        return $user->isSuperAdmin() && $model->status === User::STATUS_SUSPENDED;
+    }
+
+    /**
      * Tentukan apakah seorang manajer bisa menilai perilaku kerja seorang user.
      */
     public function rateBehavior(User $manager, User $subordinate): bool

--- a/resources/views/users/archived.blade.php
+++ b/resources/views/users/archived.blade.php
@@ -51,12 +51,23 @@
                                     </div>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
-                                    <form action="{{ route('users.reactivate', $user) }}" method="POST" class="inline-block" onsubmit="return confirm('{{ __('Aktifkan kembali pengguna ini?') }}');">
-                                        @csrf
-                                        <button type="submit" class="text-green-600 hover:text-green-900 inline-flex items-center p-2 rounded-full hover:bg-green-50 transition-colors duration-200" title="{{ __('Aktifkan Kembali') }}">
-                                            <i class="fas fa-user-check"></i>
-                                        </button>
-                                    </form>
+                                    @can('reactivate', $user)
+                                        <form action="{{ route('users.reactivate', $user) }}" method="POST" class="inline-block" onsubmit="return confirm('{{ __('Aktifkan kembali pengguna ini?') }}');">
+                                            @csrf
+                                            <button type="submit" class="text-green-600 hover:text-green-900 inline-flex items-center p-2 rounded-full hover:bg-green-50 transition-colors duration-200" title="{{ __('Aktifkan Kembali') }}">
+                                                <i class="fas fa-user-check"></i>
+                                            </button>
+                                        </form>
+                                    @endcan
+                                    @can('forceDelete', $user)
+                                        <form action="{{ route('users.force-delete', $user) }}" method="POST" class="inline-block ml-2" onsubmit="return confirm('{{ __('PERINGATAN: Anda akan menghapus pengguna ini secara permanen. Tindakan ini tidak dapat dibatalkan. Lanjutkan?') }}');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-600 hover:text-red-900 inline-flex items-center p-2 rounded-full hover:bg-red-50 transition-colors duration-200" title="{{ __('Hapus Permanen') }}">
+                                                <i class="fas fa-skull-crossbones"></i>
+                                            </button>
+                                        </form>
+                                    @endcan
                                 </td>
                             </tr>
                         @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,7 @@ Route::middleware(['auth'])->group(function () {
     Route::put('/users/{user}', [UserController::class, 'update'])->name('users.update');
     Route::post('/users/{user}/deactivate', [UserController::class, 'deactivate'])->name('users.deactivate');
     Route::post('/users/{user}/reactivate', [UserController::class, 'reactivate'])->name('users.reactivate');
+    Route::delete('/users/{user}/force-delete', [UserController::class, 'forceDelete'])->name('users.force-delete');
 
     Route::get('/api/users/search', [App\Http\Controllers\UserController::class, 'search'])->name('api.users.search');
 


### PR DESCRIPTION
…diarsipkan

Menambahkan kemampuan bagi Superadmin untuk menghapus pengguna secara permanen dari sistem. Tindakan ini hanya tersedia untuk pengguna yang sudah berada dalam status 'diarsipkan' (suspended).

- Menambahkan tombol 'Hapus Permanen' ke halaman arsip pengguna, yang hanya terlihat oleh Superadmin.
- Membuat rute `DELETE /users/{user}/force-delete` baru.
- Menambahkan kebijakan `forceDelete` di `UserPolicy` untuk mengunci fitur ini hanya untuk Superadmin dan pada pengguna yang diarsipkan.
- Mengimplementasikan metode `forceDelete` di `UserController` yang menangani penghapusan dengan aman, termasuk men-null-kan `leader_id` pada proyek terkait sebelum menghapus pengguna untuk menghindari error foreign key.