### PR TITLE
feat: Add in-app API usage documentation

### DIFF
--- a/app/Http/Controllers/Admin/ApiKeyController.php
+++ b/app/Http/Controllers/Admin/ApiKeyController.php
@@ -21,6 +21,14 @@ class ApiKeyController extends Controller
     }
 
     /**
+     * Display the API usage documentation page.
+     */
+    public function showDocs()
+    {
+        return view('admin.api_keys.docs');
+    }
+
+    /**
      * Store a newly created API client in storage.
      */
     public function store(Request $request)

--- a/resources/views/admin/api_keys/docs.blade.php
+++ b/resources/views/admin/api_keys/docs.blade.php
@@ -1,0 +1,114 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Panduan Penggunaan API') }}
+            </h2>
+            <a href="{{ route('admin.api_keys.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                <i class="fas fa-arrow-left mr-2"></i>
+                Kembali ke Manajemen Kunci API
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 sm:p-8 text-gray-900 space-y-8">
+
+                    {{-- Introduction --}}
+                    <div>
+                        <h3 class="text-2xl font-semibold border-b pb-2 mb-4">Pengantar</h3>
+                        <p class="text-gray-700 leading-relaxed">
+                            Dokumen ini adalah panduan praktis bagi tim teknis untuk mengintegrasikan sistem mereka dengan API Tasmen. API ini memungkinkan sistem eksternal untuk mengakses data secara terprogram dan aman.
+                        </p>
+                    </div>
+
+                    {{-- Authentication --}}
+                    <div>
+                        <h3 class="text-2xl font-semibold border-b pb-2 mb-4">1. Autentikasi</h3>
+                        <p class="text-gray-700 leading-relaxed mb-4">
+                            Semua permintaan (request) ke API harus menyertakan sebuah **API Key** yang valid. Kunci ini harus dikirimkan dalam *header* HTTP `Authorization` dengan skema `Bearer`.
+                        </p>
+                        <p class="text-gray-700 leading-relaxed">
+                            Format Header:
+                        </p>
+                        <div class="mt-2 p-3 bg-gray-100 border rounded-md text-sm">
+                            <code class="font-mono">Authorization: Bearer &lt;API_KEY_ANDA_DISINI&gt;</code>
+                        </div>
+                        <p class="mt-4 text-gray-700">
+                            <strong>Penting:</strong> Jaga kerahasiaan API Key Anda. Jangan pernah menampilkannya di kode sisi klien (frontend) atau menyimpannya di lokasi yang tidak aman.
+                        </p>
+                    </div>
+
+                    {{-- Example Request --}}
+                    <div>
+                        <h3 class="text-2xl font-semibold border-b pb-2 mb-4">2. Contoh Permintaan (Request)</h3>
+                        <p class="text-gray-700 leading-relaxed mb-4">
+                            Cara termudah untuk menguji koneksi Anda adalah dengan membuat permintaan `GET` ke endpoint status. Endpoint ini akan memverifikasi apakah API Key Anda valid dan aktif.
+                        </p>
+                        <p class="text-gray-700 leading-relaxed font-semibold">
+                            Endpoint Status:
+                        </p>
+                        <div class="mt-2 p-3 bg-gray-100 border rounded-md text-sm">
+                            <code class="font-mono">{{ url('/api/v1/status') }}</code>
+                        </div>
+
+                        <p class="mt-4 text-gray-700 leading-relaxed font-semibold">
+                            Contoh menggunakan cURL:
+                        </p>
+                        <div class="mt-2 p-4 bg-gray-800 text-white rounded-md text-sm">
+                            <pre><code class="language-bash">curl -X GET "{{ url('/api/v1/status') }}" \
+-H "Authorization: Bearer 1|aBcDeFgHiJkLmNoPqRs..." \
+-H "Accept: application/json"</code></pre>
+                        </div>
+                        <p class="mt-4 text-gray-600 text-sm">
+                            Ganti `1|aBcDeFgHiJkLmNoPqRs...` dengan API Key yang telah Anda terima.
+                        </p>
+                    </div>
+
+                    {{-- Response Format --}}
+                    <div>
+                        <h3 class="text-2xl font-semibold border-b pb-2 mb-4">3. Format Respons</h3>
+                        <p class="text-gray-700 leading-relaxed mb-4">
+                            Semua respons dari API akan dibungkus dalam format JSON yang konsisten (disebut "envelope") untuk mempermudah pemrosesan.
+                        </p>
+
+                        <p class="text-gray-700 leading-relaxed font-semibold">
+                            Contoh Respons Sukses:
+                        </p>
+                        <div class="mt-2 p-4 bg-gray-800 text-white rounded-md text-sm">
+                            <pre><code class="language-json">{
+    "success": true,
+    "message": "API service is running and accessible.",
+    "data": {
+        "service_status": "online",
+        "authenticated_client": "Nama Client Anda",
+        "timestamp": "2025-08-17T21:30:00.000000Z"
+    }
+}</code></pre>
+                        </div>
+                        <p class="mt-4 text-gray-700 leading-relaxed">
+                            Jika `success` bernilai `true`, artinya permintaan Anda berhasil diproses. Data yang Anda minta akan berada di dalam properti `data`.
+                        </p>
+
+                        <p class="mt-6 text-gray-700 leading-relaxed font-semibold">
+                            Contoh Respons Gagal (Key tidak valid):
+                        </p>
+                        <div class="mt-2 p-4 bg-gray-800 text-white rounded-md text-sm">
+                            <pre><code class="language-json">{
+    "success": false,
+    "message": "Invalid API Key.",
+    "data": null
+}</code></pre>
+                        </div>
+                        <p class="mt-4 text-gray-700 leading-relaxed">
+                            Jika `success` bernilai `false`, periksa `message` untuk mengetahui penyebab kegagalan.
+                        </p>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/api_keys/index.blade.php
+++ b/resources/views/admin/api_keys/index.blade.php
@@ -1,8 +1,14 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('API Key Management') }}
-        </h2>
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('API Key Management') }}
+            </h2>
+            <a href="{{ route('admin.api_keys.docs') }}" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                <i class="fas fa-book-open mr-2"></i>
+                Lihat Panduan Penggunaan
+            </a>
+        </div>
     </x-slot>
 
     <div class="py-12">

--- a/routes/web.php
+++ b/routes/web.php
@@ -199,6 +199,7 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     Route::get('/activities', [\App\Http\Controllers\ActivityController::class, 'index'])->name('activities.index');
 
     // API Key Management
+    Route::get('api_keys/docs', [ApiKeyController::class, 'showDocs'])->name('api_keys.docs');
     Route::resource('api_keys', ApiKeyController::class)->except(['show', 'edit'])->parameters(['api_keys' => 'client']);
     Route::post('api_keys/{client}/tokens', [ApiKeyController::class, 'generateToken'])->name('api_keys.tokens.store');
     Route::delete('api_keys/{client}/tokens/{tokenId}', [ApiKeyController::class, 'revokeToken'])->name('api_keys.tokens.destroy');

--- a/tests/Feature/Admin/ApiKeyManagementTest.php
+++ b/tests/Feature/Admin/ApiKeyManagementTest.php
@@ -28,6 +28,13 @@ class ApiKeyManagementTest extends TestCase
         $response->assertSee('API Key Management');
     }
 
+    public function test_superadmin_can_access_api_docs_page()
+    {
+        $response = $this->actingAs($this->superadmin)->get(route('admin.api_keys.docs'));
+        $response->assertStatus(200);
+        $response->assertSee('Panduan Penggunaan API');
+    }
+
     public function test_regular_user_cannot_access_api_key_management_page()
     {
         $response = $this->actingAs($this->regularUser)->get(route('admin.api-keys.index'));


### PR DESCRIPTION
This commit adds a new page within the admin panel that provides a user-friendly guide on how to use the generated API keys.

Key changes:
- Created a new route and controller method for `/admin/api_keys/docs`.
- Created a new Blade view (`docs.blade.php`) with formatted instructions, code examples (cURL), and explanations of the API's authentication and response structure.
- Added a 'Lihat Panduan Penggunaan' (View Usage Guide) button to the main API key management page for easy access.
- Added a feature test to ensure the new documentation page is accessible to superadmins and returns a 200 status code.