### PR TITLE
refactor: Move API and Log management to new System Settings menu

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -43,7 +43,6 @@ if (count($words) >= 2) {
                             </x-slot>
                             <x-slot name="content">
                                 <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
-                                    {{-- PERBAIKAN: Tampilkan link Daftar Kegiatan untuk semua user, otorisasi ditangani oleh controller --}}
                                     <x-dropdown-link :href="route('global.dashboard')" :active="request()->routeIs('global.dashboard')">Daftar Kegiatan</x-dropdown-link>
                                     <div class="border-t border-gray-200"></div>
                                     <x-dropdown-link :href="route('adhoc-tasks.index')" :active="request()->routeIs('adhoc-tasks.*')">Tugas Harian</x-dropdown-link>
@@ -53,7 +52,7 @@ if (count($words) >= 2) {
                         </x-dropdown>
                     </div>
 
-                    {{-- Dropdown Laporan & Analisis (Hanya untuk Top Level Manager) --}}
+                    {{-- Dropdown Laporan & Analisis --}}
                     @if (Auth::user()->isTopLevelManager())
                         <div class="hidden sm:flex sm:items-center">
                             <x-dropdown align="left" width="60">
@@ -76,13 +75,13 @@ if (count($words) >= 2) {
                         </div>
                     @endif
 
-                    {{-- Dropdown Manajemen Tim (Hanya untuk Manajer) --}}
+                    {{-- Dropdown Manajemen Tim --}}
                     @if(Auth::user()->canManageUsers())
                         <div class="hidden sm:flex sm:items-center">
                             <x-dropdown align="left" width="60">
                                 <x-slot name="trigger">
                                     <button class="inline-flex items-center h-full px-3 py-2 border-b-2 text-sm font-medium leading-5 transition duration-150 ease-in-out
-                                        {{ request()->routeIs(['users.*', 'admin.units.*', 'resource-pool.*', 'peminjaman-requests.*'])
+                                        {{ request()->routeIs(['users.*', 'admin.units.*', 'resource-pool.*', 'peminjaman-requests.*']) && !request()->routeIs('admin.api_keys.*', 'admin.activities.index')
                                             ? 'border-yellow-300 text-white bg-green-700/50'
                                             : 'border-transparent text-white hover:text-yellow-300 hover:border-yellow-300/75 focus:outline-none focus:text-white focus:border-yellow-300/75' }}">
                                         <div><i class="fas fa-users-cog mr-2"></i>Manajemen Tim</div>
@@ -93,13 +92,34 @@ if (count($words) >= 2) {
                                     <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
                                         @if(Auth::user()->isSuperAdmin())
                                             <x-dropdown-link :href="route('admin.units.index')" :active="request()->routeIs('admin.units.*')">Manajemen Unit</x-dropdown-link>
-                                            <x-dropdown-link :href="route('admin.api_keys.index')" :active="request()->routeIs('admin.api_keys.*')">Manajemen Integrasi</x-dropdown-link>
-                                            <x-dropdown-link :href="route('admin.activities.index')" :active="request()->routeIs('admin.activities.index')">Log Aktivitas</x-dropdown-link>
                                         @endif
                                         <x-dropdown-link :href="route('users.index')" :active="request()->routeIs('users.*')">Manajemen Pengguna</x-dropdown-link>
                                         <div class="border-t border-gray-200"></div>
                                         <x-dropdown-link :href="route('peminjaman-requests.my-requests')" :active="request()->routeIs('peminjaman-requests.*')">Peminjaman Anggota</x-dropdown-link>
                                         <x-dropdown-link :href="route('resource-pool.index')" :active="request()->routeIs('resource-pool.index')">Resource Pool</x-dropdown-link>
+                                    </div>
+                                </x-slot>
+                            </x-dropdown>
+                        </div>
+                    @endif
+
+                    {{-- Dropdown Pengaturan Sistem (Hanya untuk Superadmin) --}}
+                    @if(Auth::user()->isSuperAdmin())
+                        <div class="hidden sm:flex sm:items-center">
+                            <x-dropdown align="left" width="60">
+                                <x-slot name="trigger">
+                                    <button class="inline-flex items-center h-full px-3 py-2 border-b-2 text-sm font-medium leading-5 transition duration-150 ease-in-out
+                                        {{ request()->routeIs(['admin.api_keys.*', 'admin.activities.index'])
+                                            ? 'border-yellow-300 text-white bg-green-700/50'
+                                            : 'border-transparent text-white hover:text-yellow-300 hover:border-yellow-300/75 focus:outline-none focus:text-white focus:border-yellow-300/75' }}">
+                                        <div><i class="fas fa-cogs mr-2"></i>Pengaturan Sistem</div>
+                                        <div class="ms-1"><svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" /></svg></div>
+                                    </button>
+                                </x-slot>
+                                <x-slot name="content">
+                                    <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
+                                        <x-dropdown-link :href="route('admin.api_keys.index')" :active="request()->routeIs('admin.api_keys.*')">Manajemen Integrasi</x-dropdown-link>
+                                        <x-dropdown-link :href="route('admin.activities.index')" :active="request()->routeIs('admin.activities.index')">Log Aktivitas</x-dropdown-link>
                                     </div>
                                 </x-slot>
                             </x-dropdown>

--- a/tests/Feature/Admin/ApiKeyManagementTest.php
+++ b/tests/Feature/Admin/ApiKeyManagementTest.php
@@ -28,6 +28,16 @@ class ApiKeyManagementTest extends TestCase
         $response->assertSee('API Key Management');
     }
 
+    public function test_superadmin_sees_new_system_settings_menu()
+    {
+        $response = $this->actingAs($this->superadmin)->get(route('dashboard'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Pengaturan Sistem');
+        $response->assertSee('Manajemen Integrasi');
+        $response->assertSee('Log Aktivitas');
+    }
+
     public function test_superadmin_can_access_api_docs_page()
     {
         $response = $this->actingAs($this->superadmin)->get(route('admin.api_keys.docs'));


### PR DESCRIPTION
This commit refactors the admin navigation menu to improve its logical structure, as requested by the user.

- A new 'Pengaturan Sistem' (System Settings) dropdown menu has been created.
- The 'Manajemen Integrasi' (Integration Management) and 'Log Aktivitas' (Activity Log) links have been moved from the 'Manajemen Tim' (Team Management) menu to the new 'Pengaturan Sistem' menu.
- The new menu is only visible to users with the 'superadmin' role.
- A feature test has been added to verify that a superadmin can see the new menu and its links on the dashboard.