### PR TITLE
feat: Implement scope-based API access control

### DIFF
--- a/app/Http/Controllers/Admin/ApiKeyController.php
+++ b/app/Http/Controllers/Admin/ApiKeyController.php
@@ -17,7 +17,15 @@ class ApiKeyController extends Controller
         // Eager load the tokens relationship
         $clients = ApiClient::with('tokens')->get();
 
-        return view('admin.api_keys.index', compact('clients'));
+        $availableScopes = [
+            'read:projects' => 'Baca Data Proyek',
+            'read:tasks' => 'Baca Data Tugas',
+            'read:users' => 'Baca Data Pengguna & Unit',
+            'read:assignments' => 'Baca Data Penugasan Khusus',
+            'read:budgets' => 'Baca Data Anggaran',
+        ];
+
+        return view('admin.api_keys.index', compact('clients', 'availableScopes'));
     }
 
     /**

--- a/resources/views/admin/api_keys/index.blade.php
+++ b/resources/views/admin/api_keys/index.blade.php
@@ -93,10 +93,15 @@
                                             <div>
                                                 <p class="text-sm font-mono">
                                                     <span class="font-semibold">{{ $token->name }}</span>
-                                                    (ID: {{ $token->id }})
                                                 </p>
                                                 <p class="text-xs text-gray-500">
-                                                    Scopes: {{ $token->abilities ? implode(', ', $token->abilities) : 'none' }} |
+                                                    <strong class="font-semibold">Hak Akses:</strong>
+                                                    @if(empty($token->abilities) || in_array('*', $token->abilities))
+                                                        <span class="italic">Akses Penuh</span>
+                                                    @else
+                                                        {{ implode(', ', $token->abilities) }}
+                                                    @endif
+                                                    |
                                                     Created: {{ $token->created_at->format('Y-m-d') }}
                                                 </p>
                                             </div>
@@ -112,11 +117,22 @@
                                 </div>
 
                                 {{-- Generate New Token Form --}}
-                                <form method="POST" action="{{ route('admin.api_keys.tokens.store', $client) }}" class="mt-4">
+                                <form method="POST" action="{{ route('admin.api_keys.tokens.store', $client) }}" class="mt-6">
                                     @csrf
+                                    <div class="mb-4">
+                                        <h6 class="font-medium text-sm text-gray-700">Pilih Hak Akses (Scopes)</h6>
+                                        <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                            @foreach($availableScopes as $scope => $description)
+                                                <label class="flex items-center space-x-2 p-2 rounded-md hover:bg-gray-50">
+                                                    <input type="checkbox" name="scopes[]" value="{{ $scope }}" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500">
+                                                    <span>{{ $description }} <span class="text-xs text-gray-500">({{ $scope }})</span></span>
+                                                </label>
+                                            @endforeach
+                                        </div>
+                                        <p class="mt-2 text-xs text-gray-500">Jika tidak ada yang dipilih, kunci akan memiliki akses penuh.</p>
+                                    </div>
                                     <div class="flex items-center gap-4">
                                         <x-primary-button>Generate New Key</x-primary-button>
-                                        {{-- Optional: Add scope selection here in the future --}}
                                     </div>
                                 </form>
                             </div>

--- a/tests/Feature/Admin/ApiKeyManagementTest.php
+++ b/tests/Feature/Admin/ApiKeyManagementTest.php
@@ -60,15 +60,20 @@ class ApiKeyManagementTest extends TestCase
         $this->assertDatabaseHas('api_clients', ['name' => 'Test Client']);
     }
 
-    public function test_superadmin_can_generate_a_token_for_a_client()
+    public function test_superadmin_can_generate_a_token_for_a_client_with_scopes()
     {
         $client = ApiClient::factory()->create();
+        $scopes = ['read:projects', 'read:tasks'];
 
         $response = $this->actingAs($this->superadmin)
-            ->post(route('admin.api-keys.tokens.store', $client));
+            ->post(route('admin.api_keys.tokens.store', $client), [
+                'scopes' => $scopes,
+            ]);
 
         $response->assertSessionHas('newApiKey');
         $this->assertCount(1, $client->tokens);
+        $token = $client->tokens->first();
+        $this->assertEquals($scopes, $token->abilities);
     }
 
     public function test_superadmin_can_revoke_a_token()


### PR DESCRIPTION
This commit enhances the API by introducing a scope-based authorization system, allowing superadmins to grant fine-grained permissions to each API key.

Key changes include:
- **UI for Scope Selection:** The 'Manajemen Integrasi' page is updated with checkboxes, enabling superadmins to select which scopes (e.g., `read:projects`, `read:users`) a new API key will have. The assigned scopes are also displayed for existing keys.
- **Middleware Enforcement:** The `AuthenticateApiClient` middleware is updated to check if an authenticated token has the required scope for the requested endpoint. Requests are rejected with a 403 Forbidden error if the scope is missing.
- **Scoped Routes:** The API routes in `routes/api.php` are now grouped by their required scope, and the middleware is configured to pass the required scope for enforcement.
- **Updated Tests:** The admin and API feature tests have been updated to cover the new scope functionality, including tests for assigning scopes and verifying that access is correctly granted or denied based on the token's abilities.