### PR TITLE
Fix Tom Select Initialization on Add Task Form

### DIFF
--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -308,27 +308,36 @@
                     runningTaskGlobal: {{ optional(Auth::user()->timeLogs()->whereNull('end_time')->first())->task_id ?? 'null' }},
                     activeTab: 'tasks',
                     isChartInitialized: false,
+                    isTomSelectInitialized: false,
                     init() {
                         console.log('Initializing projectDetail component...');
-                        this.initTomSelect();
+
                         this.$watch('activeTab', value => {
                             console.log('activeTab changed to:', value);
                             if (value === 'info' && !this.isChartInitialized) {
-                                this.$nextTick(() => this.initChart()); // Memastikan DOM sudah render chart canvas
+                                this.$nextTick(() => this.initChart());
+                            }
+                            // Initialize TomSelect only when the 'add' tab is clicked for the first time.
+                            if (value === 'add' && !this.isTomSelectInitialized) {
+                                this.$nextTick(() => {
+                                    this.initTomSelect();
+                                    this.isTomSelectInitialized = true;
+                                });
                             }
                         });
+
                         // Jika ada hash di URL, coba aktifkan tab yang sesuai
                         if (window.location.hash) {
                             const hash = window.location.hash.substring(1);
                             if (hash === 'info') {
                                 this.activeTab = 'info';
-                                this.$nextTick(() => this.initChart()); // Inisialisasi chart segera jika tab info aktif dari hash
                             } else if (hash === 'add') {
                                 this.activeTab = 'add';
                             }
                         }
                     },
                     initTomSelect() {
+                         console.log('Initializing TomSelect for #add_assignees');
                          new TomSelect('#add_assignees', { plugins: ['remove_button'], create: false });
                     },
                     initChart() {


### PR DESCRIPTION
This commit fixes a bug where the Tom Select component for the "Assign To" field was not initializing correctly on the "Add New Task" form in the project detail view.

The issue was caused by the initialization script running on page load, at which time the target `<select>` element was hidden within an inactive tab, preventing Tom Select from attaching to it properly.

The fix refactors the AlpineJS script to initialize Tom Select lazily. The component is now initialized only when the "Add New Task" tab is activated for the first time, ensuring the target element is visible in the DOM. This provides the intended modern user experience for multi-selecting assignees.