### PR TITLE
Implement Tom Select for Edit Forms

### DIFF
--- a/resources/views/projects/edit.blade.php
+++ b/resources/views/projects/edit.blade.php
@@ -1,6 +1,7 @@
 <x-app-layout>
     {{-- Slot untuk style TomSelect yang sudah diimpor di project.blade.php --}}
     <x-slot name="styles">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.min.css">
         <style>
             /* Style kustom untuk Tom Select (menggunakan tema default) */
             .ts-control {

--- a/resources/views/projects/partials/form.blade.php
+++ b/resources/views/projects/partials/form.blade.php
@@ -73,7 +73,7 @@
             @endif
         </div>
 
-        <select name="members[]" id="members" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 tom-select" multiple required> {{-- Menambahkan kelas tom-select --}}
+        <select name="members[]" id="members" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 tom-select" multiple required placeholder="Pilih Anggota Tim...">
             @php
                 $projectMemberIds = collect(old('members', isset($project) ? $project->members->pluck('id')->all() : []));
             @endphp
@@ -83,7 +83,6 @@
                 </option>
             @endforeach
         </select>
-        <p class="text-xs text-gray-500 mt-1">Tahan tombol Ctrl (atau Cmd di Mac) untuk memilih lebih dari satu anggota.</p>
         <div id="membersWorkloadInfo" class="mt-2 text-sm text-gray-600 p-2 bg-gray-50 rounded-md shadow-sm"></div> {{-- Styling info beban kerja --}}
     </div>
 </div>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -1,5 +1,6 @@
 <x-app-layout>
     <x-slot name="styles">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.min.css">
         <style>
             /* Style kustom untuk Tom Select (dari project.blade.php) */
             .ts-control {
@@ -119,7 +120,7 @@
                                     <i class="fas fa-users-line mr-2 text-gray-500"></i> Ditugaskan Kepada <span class="text-red-500">*</span>
                                 </label>
                                 @if (auth()->user()->can('update', $task) && !auth()->user()->isStaff())
-                                    <select name="assignees[]" id="assignees" class="block mt-1 w-full tom-select-multiple" multiple required>
+                                    <select name="assignees[]" id="assignees" class="block mt-1 w-full tom-select-multiple" multiple required placeholder="Pilih Anggota Tim...">
                                         @foreach ($projectMembers as $member)
                                             <option value="{{ $member->id }}" @selected(in_array($member->id, old('assignees', $task->assignees->pluck('id')->toArray())))>
                                                 {{ $member->name }} ({{ $member->role }})


### PR DESCRIPTION
This commit applies the modern Tom Select component to the 'members' and 'assignees' fields on the 'Edit Project' and 'Edit Task' pages, respectively. This ensures a consistent and improved user experience across all forms where users are selected.

Changes include:
- Loading the Tom Select CSS stylesheet via CDN on `projects.edit` and `tasks.edit` views.
- Adding a `placeholder` attribute to the `<select>` elements to provide a user-friendly hint.
- Removing the obsolete "Hold Ctrl to select" hint text from the 'Edit Project' form.