### PR TITLE
Hotfix: Correct Undefined Method Call in My Dashboard

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\RedirectResponse;
 use App\Http\Controllers\ExecutiveSummaryController;
 use App\Http\Controllers\GlobalDashboardController;
 use App\Services\InsightService;
+use App\Models\Activity;
 
 class HomeController extends Controller
 {
@@ -52,7 +53,11 @@ class HomeController extends Controller
         ];
 
         // 3. Get recent activities initiated by the user
-        $myActivities = $user->activities()->with('subject')->latest()->take(10)->get();
+        $myActivities = Activity::where('user_id', $user->id)
+            ->with('subject')
+            ->latest()
+            ->take(10)
+            ->get();
 
         return view('my-dashboard', compact('tasks', 'stats', 'myActivities'));
     }


### PR DESCRIPTION
This commit fixes a `BadMethodCallException` that occurred on the 'My Dashboard' page.

The root cause was that the `myDashboard` method in `HomeController` was incorrectly trying to call an `activities()` relationship on the `User` model (`$user->activities()`), which does not exist.

The query has been corrected to fetch activities from the `Activity` model directly, filtered by the user's ID (`Activity::where('user_id', ...)`). The necessary `use App\Models\Activity;` statement has also been added.

This resolves the crash and allows the 'My Dashboard' page to load correctly.