### PR TITLE
Hotfix: Fix 500 Error on Create Peminjaman Request

### DIFF
--- a/app/Http/Controllers/PeminjamanRequestController.php
+++ b/app/Http/Controllers/PeminjamanRequestController.php
@@ -113,7 +113,7 @@ class PeminjamanRequestController extends Controller
             // Cari approver (Koordinator atau Eselon II) di unit saat ini.
             $approver = User::where('unit_id', $currentUnit->id)
                 ->whereIn('role', [User::ROLE_KOORDINATOR, User::ROLE_ESELON_II])
-                ->orderByRaw("FIELD(role, '".User::ROLE_KOORDINATOR."', '".User::ROLE_ESELON_II."')") // Prioritaskan Koordinator
+                ->orderByRaw("CASE role WHEN ? THEN 1 WHEN ? THEN 2 ELSE 3 END", [User::ROLE_KOORDINATOR, User::ROLE_ESELON_II])
                 ->first();
 
             if ($approver) {


### PR DESCRIPTION
This commit resolves a 500 Internal Server Error that occurred when a user tried to request a team member from another team ('Cari & Minta dari Tim Lain').

The root cause was that the `findCoordinator` method in `PeminjamanRequestController` used the MySQL-specific `FIELD()` function in an `orderByRaw` clause. This caused a fatal SQL syntax error because the application's database is PostgreSQL.

The fix replaces the `FIELD()` function with a database-agnostic `CASE ... WHEN ... END` statement to achieve the same role prioritization in the query. This ensures the query is compatible with PostgreSQL and prevents the crash.