### PR TITLE
Hotfix: Add Missing AuthorizesRequests Trait to Controller

### DIFF
--- a/app/Http/Controllers/PeminjamanRequestController.php
+++ b/app/Http/Controllers/PeminjamanRequestController.php
@@ -15,9 +15,12 @@ use App\Scopes\HierarchicalScope;
 use App\Notifications\PeminjamanRequested;
 use App\Notifications\PeminjamanApproved;
 use App\Notifications\PeminjamanRejected;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class PeminjamanRequestController extends Controller
 {
+    use AuthorizesRequests;
+
     public function index()
     {
         return redirect()->route('peminjaman-requests.my-requests');


### PR DESCRIPTION
This commit resolves a `BadMethodCallException: Call to undefined method ...::authorize()` that occurred when creating a Peminjaman Request.

The root cause was that the `PeminjamanRequestController` was missing the `Illuminate\Foundation\Auth\Access\AuthorizesRequests` trait, which provides the `authorize()` method used for policy checks.

The fix adds the `use AuthorizesRequests;` trait to the controller class definition, resolving the fatal error and allowing the authorization logic to execute correctly.