### PR TITLE
feat: Adjust seeders for more proportional results

### DIFF
--- a/database/seeders/AdHocTaskSeeder.php
+++ b/database/seeders/AdHocTaskSeeder.php
@@ -25,7 +25,7 @@ class AdHocTaskSeeder extends Seeder
             return;
         }
 
-        for ($i = 0; $i < 25; $i++) { // Membuat 25 record
+        for ($i = 0; $i < 15; $i++) { // Membuat 15 record
             // Temporarily authenticate as a random user to be the task creator
             $creator = $users->random();
             Auth::login($creator);

--- a/database/seeders/ProjectSeeder.php
+++ b/database/seeders/ProjectSeeder.php
@@ -21,7 +21,7 @@ class ProjectSeeder extends Seeder
 
         Project::truncate();
 
-        for ($i = 0; $i < 40; $i++) {
+        for ($i = 0; $i < 20; $i++) {
             $leader = $potential_leaders->random();
             $project = Project::factory()->create([
                 'owner_id' => $leader->id,

--- a/database/seeders/SpecialAssignmentSeeder.php
+++ b/database/seeders/SpecialAssignmentSeeder.php
@@ -25,7 +25,7 @@ class SpecialAssignmentSeeder extends Seeder
             return;
         }
 
-        for ($i = 0; $i < 40; $i++) {
+        for ($i = 0; $i < 15; $i++) {
             $assignment = SpecialAssignment::create([
                 'title' => 'SK ' . $faker->sentence(3),
                 'description' => $faker->realText(200),

--- a/database/seeders/TaskSeeder.php
+++ b/database/seeders/TaskSeeder.php
@@ -25,8 +25,8 @@ class TaskSeeder extends Seeder
                 continue; // Lewati proyek tanpa anggota
             }
 
-            // Buat 5 sampai 15 tugas untuk setiap proyek
-            $numberOfTasks = rand(5, 15);
+            // Buat 5 sampai 10 tugas untuk setiap proyek
+            $numberOfTasks = rand(5, 10);
 
             for ($i = 0; $i < $numberOfTasks; $i++) {
                 $task = Task::factory()->create([
@@ -37,27 +37,6 @@ class TaskSeeder extends Seeder
                 $assignees = $project->members->random(rand(1, min(3, $project->members->count())));
                 $task->assignees()->attach($assignees->pluck('id'));
             }
-        }
-
-        // --- Logic to overload the test user ---
-        $this->command->info('Overloading test user...');
-        $testUser = User::where('email', 'staf.test@example.com')->first();
-        $project = Project::first(); // Assign to the first project
-
-        if ($testUser && $project) {
-            if (!$project->members->contains($testUser)) {
-                $project->members()->attach($testUser->id);
-            }
-
-            for ($i = 0; $i < 10; $i++) {
-                $task = Task::factory()->create([
-                    'project_id' => $project->id,
-                    'estimated_hours' => 20, // 10 tasks * 20 hours = 200 hours
-                    'title' => 'Tugas Beban Kerja Ekstra ' . ($i + 1),
-                ]);
-                $task->assignees()->attach($testUser->id);
-            }
-            $this->command->info('Test user has been overloaded with 10 extra tasks.');
         }
     }
 }

--- a/database/seeders/TimeLogSeeder.php
+++ b/database/seeders/TimeLogSeeder.php
@@ -42,15 +42,9 @@ class TimeLogSeeder extends Seeder
                 $estimated = $task->estimated_hours;
                 $actualHours = 0;
 
-                // --- Logic to sabotage the test user ---
-                if ($assignee->email === 'staf.test@example.com') {
-                    // Make this user inefficient
-                    $actualHours = $estimated * 1.5; // 150% of estimated time
-                } else {
-                    // Other users remain realistic
-                    $variance = (rand(-20, 20) / 100); // Variansi antara -20% dan +20%
-                    $actualHours = $estimated * (1 + $variance);
-                }
+                // Other users remain realistic
+                $variance = (rand(-20, 20) / 100); // Variansi antara -20% dan +20%
+                $actualHours = $estimated * (1 + $variance);
 
                 $actualHours = max(1, round($actualHours, 1));
 


### PR DESCRIPTION
This commit adjusts the database seeders to generate more realistic and proportional data for the workload analysis and executive summary.

- Reduces the number of projects, special assignments, and ad-hoc tasks.
- Removes the logic that intentionally overloaded a test user with tasks.
- Removes the logic that made the test user's time logs inefficient.