### PR TITLE
Fix(User): Standardize date format validation to Y-m-d

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -109,13 +109,13 @@ class UserController extends Controller
             'status' => ['nullable', 'in:active,suspended'],
             'nip' => ['required', 'string', 'max:255', 'unique:'.User::class],
             'tempat_lahir' => ['nullable', 'string', 'max:255'],
-            'tgl_lahir' => ['required', 'date_format:d-m-Y'],
+            'tgl_lahir' => ['required', 'date_format:Y-m-d'],
             'alamat' => ['nullable', 'string'],
             'jenis_kelamin' => ['nullable', 'in:L,P'],
             'agama' => ['nullable', 'string', 'max:255'],
             'golongan' => ['nullable', 'string', 'max:255'],
             'eselon' => ['nullable', 'string', 'max:255'],
-            'tmt_eselon' => ['nullable', 'date_format:d-m-Y'],
+            'tmt_eselon' => ['nullable', 'date_format:Y-m-d'],
             'grade' => ['nullable', 'string', 'max:255'],
             'no_hp' => ['nullable', 'string', 'max:255'],
             'telepon' => ['nullable', 'string', 'max:255'],
@@ -124,8 +124,8 @@ class UserController extends Controller
             'pendidikan_jurusan' => ['nullable', 'string', 'max:255'],
             'pendidikan_universitas' => ['nullable', 'string', 'max:255'],
             'jenis_jabatan' => ['nullable', 'string', 'max:255'],
-            'tmt_cpns' => ['nullable', 'date_format:d-m-Y'],
-            'tmt_pns' => ['nullable', 'date_format:d-m-Y'],
+            'tmt_cpns' => ['nullable', 'date_format:Y-m-d'],
+            'tmt_pns' => ['nullable', 'date_format:Y-m-d'],
         ]);
 
         $userData = $validated;
@@ -161,7 +161,8 @@ class UserController extends Controller
         
         foreach(['tgl_lahir', 'tmt_eselon', 'tmt_cpns', 'tmt_pns'] as $dateField) {
             if (!empty($userData[$dateField])) {
-                $userData[$dateField] = Carbon::createFromFormat('d-m-Y', $userData[$dateField])->format('Y-m-d');
+                // Ensure the date is a Carbon instance for the model, but no re-formatting is needed.
+                $userData[$dateField] = Carbon::parse($userData[$dateField]);
             }
         }
 
@@ -219,13 +220,13 @@ class UserController extends Controller
             'status' => ['nullable', 'in:active,suspended'],
             'nip' => ['required', 'string', 'max:255', Rule::unique('users')->ignore($user->id)],
             'tempat_lahir' => ['nullable', 'string', 'max:255'],
-            'tgl_lahir' => ['required', 'date_format:d-m-Y'],
+            'tgl_lahir' => ['required', 'date_format:Y-m-d'],
             'alamat' => ['nullable', 'string'],
             'jenis_kelamin' => ['nullable', 'in:L,P'],
             'agama' => ['nullable', 'string', 'max:255'],
             'golongan' => ['nullable', 'string', 'max:255'],
             'eselon' => ['nullable', 'string', 'max:255'],
-            'tmt_eselon' => ['nullable', 'date_format:d-m-Y'],
+            'tmt_eselon' => ['nullable', 'date_format:Y-m-d'],
             'grade' => ['nullable', 'string', 'max:255'],
             'no_hp' => ['nullable', 'string', 'max:255'],
             'telepon' => ['nullable', 'string', 'max:255'],
@@ -234,8 +235,8 @@ class UserController extends Controller
             'pendidikan_jurusan' => ['nullable', 'string', 'max:255'],
             'pendidikan_universitas' => ['nullable', 'string', 'max:255'],
             'jenis_jabatan' => ['nullable', 'string', 'max:255'],
-            'tmt_cpns' => ['nullable', 'date_format:d-m-Y'],
-            'tmt_pns' => ['nullable', 'date_format:d-m-Y'],
+            'tmt_cpns' => ['nullable', 'date_format:Y-m-d'],
+            'tmt_pns' => ['nullable', 'date_format:Y-m-d'],
         ]);
 
         $newJabatan = \App\Models\Jabatan::find($validated['jabatan_id']);
@@ -294,7 +295,8 @@ class UserController extends Controller
         
             foreach(['tgl_lahir', 'tmt_eselon', 'tmt_cpns', 'tmt_pns'] as $dateField) {
                 if (!empty($updateData[$dateField])) {
-                    $updateData[$dateField] = Carbon::createFromFormat('d-m-Y', $updateData[$dateField])->format('Y-m-d');
+                    // Ensure the date is a Carbon instance for the model, but no re-formatting is needed.
+                    $updateData[$dateField] = Carbon::parse($updateData[$dateField]);
                 }
             }
         

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -39,7 +39,7 @@ function form_textarea($label, $name, $user, $is_required = false) {
         {{ form_input('Email', 'email', $user, 'email', true) }}
         {{ form_input('NIP', 'nip', $user, 'text', true) }}
         {{ form_input('Tempat Lahir', 'tempat_lahir', $user) }}
-        {{ form_input('Tgl. Lahir', 'tgl_lahir', $user, 'text', true, 'placeholder="DD-MM-YYYY"') }}
+        {{ form_input('Tgl. Lahir', 'tgl_lahir', $user, 'text', true, 'placeholder="YYYY-MM-DD"') }}
         {{ form_textarea('Alamat', 'alamat', $user) }}
         <div class="mb-4">
             <label for="jenis_kelamin" class="block font-semibold text-sm text-gray-700 mb-1">Jenis Kelamin</label>
@@ -60,14 +60,14 @@ function form_textarea($label, $name, $user, $is_required = false) {
         <h3 class="text-lg font-medium text-gray-900 border-b pb-2 mb-4">Informasi Kepegawaian</h3>
         {{ form_input('Golongan', 'golongan', $user) }}
         {{ form_input('Eselon', 'eselon', $user) }}
-        {{ form_input('TMT Eselon', 'tmt_eselon', $user, 'text', false, 'placeholder="DD-MM-YYYY"') }}
+        {{ form_input('TMT Eselon', 'tmt_eselon', $user, 'text', false, 'placeholder="YYYY-MM-DD"') }}
         {{ form_input('Jenis Jabatan', 'jenis_jabatan', $user) }}
         {{ form_input('Grade', 'grade', $user) }}
         {{ form_input('Pendidikan Terakhir', 'pendidikan_terakhir', $user) }}
         {{ form_input('Jurusan', 'pendidikan_jurusan', $user) }}
         {{ form_input('Universitas', 'pendidikan_universitas', $user) }}
-        {{ form_input('TMT CPNS', 'tmt_cpns', $user, 'text', false, 'placeholder="DD-MM-YYYY"') }}
-        {{ form_input('TMT PNS', 'tmt_pns', $user, 'text', false, 'placeholder="DD-MM-YYYY"') }}
+        {{ form_input('TMT CPNS', 'tmt_cpns', $user, 'text', false, 'placeholder="YYYY-MM-DD"') }}
+        {{ form_input('TMT PNS', 'tmt_pns', $user, 'text', false, 'placeholder="YYYY-MM-DD"') }}
     </div>
 
     {{-- Kolom Kanan: Unit & Akses --}}


### PR DESCRIPTION
The user creation and update forms triggered a validation error because the backend expected a different date format than what some browsers' native date pickers submit.

This patch standardizes the process by:
1. Updating the validation rules in the user controller for both storing and updating to require a consistent date format.
2. Adjusting the date parsing logic to correctly handle the standardized format without needing reformatting.
3. Changing the frontend input field placeholders to guide the user.