### PR TITLE
Refactor(Core): Finalize role separation and fix migration error

### DIFF
--- a/database/migrations/2025_08_19_201200_remove_role_from_jabatans_table.php
+++ b/database/migrations/2025_08_19_201200_remove_role_from_jabatans_table.php
@@ -12,17 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('jabatans', function (Blueprint $table) {
-            // Drop the index first to avoid potential issues
-            $sm = Schema::getConnection()->getDoctrineSchemaManager();
-            $indexes = $sm->listTableIndexes('jabatans');
-            if (array_key_exists('jabatans_role_index', $indexes)) {
-                $table->dropIndex('jabatans_role_index');
-            }
-
-            // Then drop the column
-            if (Schema::hasColumn('jabatans', 'role')) {
-                $table->dropColumn('role');
-            }
+            // Drop the index first, then the column. This is the standard, safe way.
+            $table->dropIndex(['role']);
+            $table->dropColumn('role');
         });
     }
 
@@ -32,7 +24,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('jabatans', function (Blueprint $table) {
-            $table->string('role')->nullable()->after('type')->comment('The role associated with this position, defining permissions.');
+            $table->string('role')->nullable()->after('name')->comment('The role associated with this position, defining permissions.');
             $table->index('role');
         });
     }


### PR DESCRIPTION
This commit completes the major refactoring to separate functional `Jabatan` from structural `Role` and fixes a critical migration error discovered during testing.

Key changes:
1.  **Fixed Migration Error:** The migration to remove the `role` column from `jabatans` was rewritten to use standard Laravel Schema methods, removing a Doctrine DBAL dependency that caused an error on PostgreSQL.

2.  **Completed Role/Jabatan Refactor:**
    - A migration now correctly removes the `role` column from `jabatans`.
    - The `Jabatan` model is cleaned of `role`, `type` attributes.
    - `UserController` now derives a user's role solely from their `Unit`.
    - `UnitController` and its view are simplified to no longer assign a `role` to a `Jabatan`.

3.  **Restored Delegated Permission:**
    - The `can_manage_users` permission functionality was restored by re-adding the column to `jabatans` (via a new migration), updating the model, and restoring the UI and controller logic.

4.  **Bug Fixes:**
    - Addressed a date format validation error (`Y-m-d`).
    - Fixed an `Undefined array key` error when updating a user.