### PR TITLE
feat: Implement manual control for roles and unit heads

### DIFF
--- a/resources/views/admin/units/partials/form-fields.blade.php
+++ b/resources/views/admin/units/partials/form-fields.blade.php
@@ -21,4 +21,20 @@
         @error('parent_unit_id') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
     </div>
 
+    @if(isset($usersInUnit))
+    <div class="md:col-span-2">
+        <label for="kepala_unit_id" class="block font-semibold text-sm text-gray-700 mb-1">
+            <i class="fas fa-user-tie mr-2 text-gray-500"></i> Kepala Unit (Opsional)
+        </label>
+        <select name="kepala_unit_id" id="kepala_unit_id" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150">
+            <option value="">-- Tidak ada / Kosongkan --</option>
+            @foreach($usersInUnit as $user)
+                <option value="{{ $user->id }}" @selected(old('kepala_unit_id', $unit->kepala_unit_id ?? '') == $user->id)>
+                    {{ $user->name }} ({{ $user->jabatan->name ?? 'N/A' }})
+                </option>
+            @endforeach
+        </select>
+        @error('kepala_unit_id') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+    </div>
+    @endif
 </div>

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -82,6 +82,7 @@ function form_textarea($label, $name, $user, $is_required = false) {
                 @endforeach
             </select>
         </div>
+
         <div class="mb-4">
             <label for="eselon_ii" class="block font-semibold text-sm text-gray-700 mb-1">2. Unit Eselon II</label>
             <select id="eselon_ii" class="unit-select block mt-1 w-full rounded-lg shadow-sm border-gray-300" data-level="2" data-placeholder="-- Pilih Unit Eselon II --" disabled><option value="">-- Pilih Unit Eselon I Dahulu --</option></select>
@@ -108,6 +109,29 @@ function form_textarea($label, $name, $user, $is_required = false) {
                 @endforeach
             </select>
         </div>
+
+        @can('manageUsers', App\Models\User::class)
+        <div class="border-t my-6"></div>
+        <div class="mb-4">
+            <label for="role" class="block font-semibold text-sm text-gray-700 mb-1">Peran Struktural (Role) <span class="text-red-500 font-bold">*</span></label>
+            <select name="role" id="role" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                @foreach(App\Models\User::ROLES as $role)
+                    @if(Auth::user()->isSuperAdmin() || $role['name'] !== 'Superadmin')
+                    <option value="{{ $role['name'] }}" @selected(old('role', $user->role ?? '') == $role['name'])>{{ $role['name'] }}</option>
+                    @endif
+                @endforeach
+            </select>
+            <p class="mt-1 text-xs text-gray-500">Mengubah peran ini akan memengaruhi hak akses pengguna.</p>
+        </div>
+        <div class="mb-4">
+            <label for="is_kepala_unit" class="flex items-center">
+                <input type="checkbox" name="is_kepala_unit" id="is_kepala_unit" value="1" @checked(old('is_kepala_unit', $user->id && $user->unit && $user->id === $user->unit->kepala_unit_id)) class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500">
+                <span class="ml-2 text-sm text-gray-600 font-semibold">Jadikan Kepala Unit</span>
+            </label>
+            <p class="mt-1 text-xs text-gray-500 ml-6">Menetapkan pengguna ini sebagai kepala dari unit kerja mereka saat ini.</p>
+        </div>
+        @endcan
+
         <div class="mb-4">
             <label for="password" class="block font-semibold text-sm text-gray-700 mb-1">Password</label>
             <input id="password" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300" type="password" name="password" autocomplete="new-password">


### PR DESCRIPTION
This commit completes a major refactoring to provide full manual control over user roles and unit head assignments, replacing the previous automatic, and often incorrect, logic.

Key Changes:
1.  **Manual Role Assignment:**
    - A 'Role' dropdown is added to the User Create/Edit forms, allowing authorized users to directly set a user's structural role.
    - The old logic of calculating roles based on unit depth has been removed.

2.  **Manual Head of Unit Assignment:**
    - A checkbox 'Jadikan Kepala Unit' is added to the User Create/Edit forms.
    - A dropdown to select the Head of Unit is added to the Unit Edit form.
    - The old logic of automatically assigning a head based on a leadership role has been removed.

3.  **Authorization:**
    - All new manual controls are restricted to Superadmins or users with the `can_manage_users` permission.

This also includes all previous fixes from this session, such as the date format validation fix, seeder updates, and migration fixes.