### PR TITLE
refactor(Core): Sync user role with head of unit status

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -99,7 +99,27 @@ class UnitController extends Controller
             }
         }
 
+        $oldKepalaUnitId = $unit->kepala_unit_id;
+
         $unit->update($validated);
+
+        $newKepalaUnitId = $unit->fresh()->kepala_unit_id;
+
+        // Recalculate roles if the head of unit has changed.
+        if ($oldKepalaUnitId !== $newKepalaUnitId) {
+            if ($oldKepalaUnitId) {
+                $oldKepala = \App\Models\User::find($oldKepalaUnitId);
+                if ($oldKepala) {
+                    \App\Models\User::recalculateAndSaveRole($oldKepala);
+                }
+            }
+            if ($newKepalaUnitId) {
+                $newKepala = \App\Models\User::find($newKepalaUnitId);
+                if ($newKepala) {
+                    \App\Models\User::recalculateAndSaveRole($newKepala);
+                }
+            }
+        }
 
         return redirect()->route('admin.units.edit', $unit)->with('success', 'Unit berhasil diperbarui.');
     }

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -113,17 +113,6 @@ function form_textarea($label, $name, $user, $is_required = false) {
         @can('manageUsers', App\Models\User::class)
         <div class="border-t my-6"></div>
         <div class="mb-4">
-            <label for="role" class="block font-semibold text-sm text-gray-700 mb-1">Peran Struktural (Role) <span class="text-red-500 font-bold">*</span></label>
-            <select name="role" id="role" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-                @foreach(App\Models\User::ROLES as $role)
-                    @if(Auth::user()->isSuperAdmin() || $role['name'] !== 'Superadmin')
-                    <option value="{{ $role['name'] }}" @selected(old('role', $user->role ?? '') == $role['name'])>{{ $role['name'] }}</option>
-                    @endif
-                @endforeach
-            </select>
-            <p class="mt-1 text-xs text-gray-500">Mengubah peran ini akan memengaruhi hak akses pengguna.</p>
-        </div>
-        <div class="mb-4">
             <label for="is_kepala_unit" class="flex items-center">
                 <input type="checkbox" name="is_kepala_unit" id="is_kepala_unit" value="1" @checked(old('is_kepala_unit', $user->id && $user->unit && $user->id === $user->unit->kepala_unit_id)) class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500">
                 <span class="ml-2 text-sm text-gray-600 font-semibold">Jadikan Kepala Unit</span>


### PR DESCRIPTION
This commit implements a major refactoring of the user role and unit leadership logic based on detailed user feedback. The new system replaces all manual and conflicting logic with a new, streamlined approach where the 'Head of Unit' status is the single source of truth for determining a user's structural role.

Key Changes:
1.  **New Role Logic:** A user's role is now automatically calculated.
    - If a user is set as 'Head of Unit', their role is determined by the unit's level in the hierarchy.
    - If they are not a 'Head of Unit', their role defaults to 'Staf'.
    - A centralized method `User::recalculateAndSaveRole()` was created to handle this logic.

2.  **Updated UI:**
    - The manual 'Role' dropdown has been removed from the user forms.
    - A 'Jadikan Kepala Unit' checkbox on the user form and a 'Kepala Unit' dropdown on the unit form are now the primary controls.

3.  **Controller Updates:**
    - `UserController` and `UnitController` have been updated to call the new role calculation logic whenever a user's unit or leadership status changes.

This commit also includes all previous fixes and UI enhancements from this session, including the interactive unit tree view and colored role badges.