### PR TITLE
feat: Add Unit Types and refine role calculation

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -49,6 +49,7 @@ class UnitController extends Controller
         $validated = $request->validate([
             'name' => 'required|string|max:255|unique:units,name',
             'parent_unit_id' => 'nullable|exists:units,id',
+            'type' => ['required', Rule::in(['Struktural', 'Fungsional'])],
         ]);
 
         Unit::create($validated);
@@ -81,6 +82,7 @@ class UnitController extends Controller
             'name' => ['required', 'string', 'max:255', Rule::unique('units')->ignore($unit->id)],
             'parent_unit_id' => 'nullable|exists:units,id',
             'kepala_unit_id' => ['nullable', 'exists:users,id'],
+            'type' => ['required', Rule::in(['Struktural', 'Fungsional'])],
         ]);
 
         // Additional check to ensure the selected head is actually a member of the unit.

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -31,6 +31,7 @@ class Unit extends Model
     protected $fillable = [
         'name',
         'level',
+        'type',
         'parent_unit_id',
         'kepala_unit_id',
     ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,8 @@ class User extends Authenticatable
     public const ROLE_SUPERADMIN = 'Superadmin';
     public const ROLE_ESELON_I = 'Eselon I';
     public const ROLE_ESELON_II = 'Eselon II';
+    public const ROLE_ESELON_III = 'Eselon III';
+    public const ROLE_ESELON_IV = 'Eselon IV';
     public const ROLE_KOORDINATOR = 'Koordinator';
     public const ROLE_SUB_KOORDINATOR = 'Sub Koordinator';
     public const ROLE_STAF = 'Staf';
@@ -39,6 +41,8 @@ class User extends Authenticatable
         ['name' => self::ROLE_SUPERADMIN],
         ['name' => self::ROLE_ESELON_I],
         ['name' => self::ROLE_ESELON_II],
+        ['name' => self::ROLE_ESELON_III],
+        ['name' => self::ROLE_ESELON_IV],
         ['name' => self::ROLE_KOORDINATOR],
         ['name' => self::ROLE_SUB_KOORDINATOR],
         ['name' => self::ROLE_STAF],
@@ -417,15 +421,17 @@ class User extends Authenticatable
      */
     private static function calculateRoleFromUnit(Unit $unit): string
     {
-        // The depth is the number of ancestors. Root is 0.
         $depth = $unit->ancestors()->count();
+        $isStruktural = $unit->type === 'Struktural';
 
-        return match ($depth) {
-            1 => self::ROLE_ESELON_I,
-            2 => self::ROLE_ESELON_II,
-            3 => self::ROLE_KOORDINATOR,
-            4 => self::ROLE_SUB_KOORDINATOR,
-            default => self::ROLE_STAF, // Default for top-level (Menteri) or deep units
+        return match (true) {
+            $depth === 1 => self::ROLE_ESELON_I,
+            $depth === 2 => self::ROLE_ESELON_II,
+            $depth === 3 && $isStruktural => self::ROLE_ESELON_III,
+            $depth === 3 && !$isStruktural => self::ROLE_KOORDINATOR,
+            $depth === 4 && $isStruktural => self::ROLE_ESELON_IV,
+            $depth === 4 && !$isStruktural => self::ROLE_SUB_KOORDINATOR,
+            default => self::ROLE_STAF,
         };
     }
 }

--- a/database/migrations/2025_08_20_173700_add_type_to_units_table.php
+++ b/database/migrations/2025_08_20_173700_add_type_to_units_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->string('type')->default('Fungsional')->after('name')->comment('The type of the unit, e.g., Struktural or Fungsional.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            if (Schema::hasColumn('units', 'type')) {
+                $table->dropColumn('type');
+            }
+        });
+    }
+};

--- a/resources/views/admin/units/partials/form-fields.blade.php
+++ b/resources/views/admin/units/partials/form-fields.blade.php
@@ -8,6 +8,17 @@
     </div>
 
     <div>
+        <label for="type" class="block font-semibold text-sm text-gray-700 mb-1">
+            <i class="fas fa-tags mr-2 text-gray-500"></i> Tipe Unit <span class="text-red-500">*</span>
+        </label>
+        <select name="type" id="type" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" required>
+            <option value="Fungsional" @selected(old('type', $unit->type ?? '') == 'Fungsional')>Fungsional</option>
+            <option value="Struktural" @selected(old('type', $unit->type ?? '') == 'Struktural')>Struktural</option>
+        </select>
+        @error('type') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+    </div>
+
+    <div>
         <label for="parent_unit_id" class="block font-semibold text-sm text-gray-700 mb-1">
             <i class="fas fa-building-circle-arrow-up mr-2 text-gray-500"></i> Unit Atasan (Opsional)
         </label>


### PR DESCRIPTION
This commit implements the final piece of a major refactoring of the app's role and position logic. It introduces the concept of a Unit 'type' ('Struktural' vs. 'Fungsional') to allow the system to correctly differentiate between roles at the same hierarchy level.

Key Changes:
1.  **Unit Type:**
    - A `type` column has been added to the `units` table via a new migration.
    - The Unit create/edit forms have been updated to allow admins to set this type.

2.  **Refined Role Logic:**
    - The `User::calculateRoleFromUnit` method now uses the unit's `type` to distinguish between assigning, for example, 'Eselon III' (for Struktural units) and 'Koordinator' (for Fungsional units) at the same hierarchy level.
    - New `ROLE_ESELON_III` and `ROLE_ESELON_IV` constants were added to the `User` model.

This commit builds upon the previous refactoring that made 'Head of Unit' status the source of truth for role assignment. The system for managing user roles and positions is now robust, flexible, and accurately reflects the user's business logic.