### PR TITLE
feat: Add leave management permissions and manual balance form

### DIFF
--- a/app/Http/Middleware/CheckCanManageLeaveSettings.php
+++ b/app/Http/Middleware/CheckCanManageLeaveSettings.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Auth;
+
+class CheckCanManageLeaveSettings
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!Auth::check()) {
+            return redirect('login');
+        }
+
+        $user = Auth::user();
+
+        // Allow if user is Super Admin
+        if ($user->isSuperAdmin()) {
+            return $next($request);
+        }
+
+        // Allow if user's position (jabatan) can manage users
+        if ($user->jabatan && $user->jabatan->can_manage_users) {
+            return $next($request);
+        }
+
+        abort(403, 'ANDA TIDAK MEMILIKI HAK AKSES.');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -21,6 +21,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'superadmin' => \App\Http\Middleware\CheckSuperadmin::class,
+            'can.manage.leave.settings' => \App\Http\Middleware\CheckCanManageLeaveSettings::class,
             'auth.apikey' => \App\Http\Middleware\AuthenticateApiClient::class,
             'log.api' => \App\Http\Middleware\LogApiActivity::class,
         ]);

--- a/resources/views/admin/users/leave_balance.blade.php
+++ b/resources/views/admin/users/leave_balance.blade.php
@@ -1,0 +1,47 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Saldo Cuti: ') }} {{ $user->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 bg-gray-50">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+
+            @if(session('success'))
+                <div class="mb-6 bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-lg relative" role="alert">
+                    {{ session('success') }}
+                </div>
+            @endif
+
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
+                <div class="p-6 sm:p-8 bg-white border-b border-gray-200">
+                    <form action="{{ route('admin.users.leave-balance.update', $user) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+
+                        <div class="space-y-6">
+                            <div>
+                                <label for="carried_over_days" class="block text-sm font-medium text-gray-700">Sisa Cuti Tahun Lalu ({{ $balance->year - 1 }})</label>
+                                <input type="number" name="carried_over_days" id="carried_over_days" value="{{ old('carried_over_days', $balance->carried_over_days) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                                <p class="mt-2 text-sm text-gray-500">Masukkan jumlah hari sisa cuti dari tahun sebelumnya yang dibawa ke tahun ini.</p>
+                                @error('carried_over_days')
+                                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <div class="flex items-center justify-end mt-8">
+                            <a href="{{ route('users.edit', $user) }}" class="inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-800 uppercase tracking-widest hover:bg-gray-300">
+                                Kembali ke Profil
+                            </a>
+                            <button type="submit" class="ml-4 inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700">
+                                Simpan Saldo Cuti
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -119,6 +119,13 @@ function form_textarea($label, $name, $user, $is_required = false) {
             </label>
             <p class="mt-1 text-xs text-gray-500 ml-6">Menetapkan pengguna ini sebagai kepala dari unit kerja mereka saat ini.</p>
         </div>
+
+        <div class="mb-4">
+            <a href="{{ route('admin.users.leave-balance.edit', $user) }}" class="inline-flex items-center px-4 py-2 bg-slate-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-slate-700">
+                <i class="fas fa-calculator mr-2"></i> Atur Saldo Cuti
+            </a>
+            <p class="mt-1 text-xs text-gray-500">Mengatur sisa cuti tahunan dari tahun sebelumnya secara manual.</p>
+        </div>
         @endcan
 
         <div class="mb-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -209,6 +209,10 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     Route::get('/users/{user}/impersonate', [UserController::class, 'impersonate'])->name('users.impersonate');
     Route::get('/users/impersonate/leave', [UserController::class, 'leaveImpersonate'])->name('users.impersonate.leave');
 
+    // Manual Leave Balance Management
+    Route::get('/users/{user}/leave-balance/edit', [UserController::class, 'editLeaveBalance'])->name('users.leave-balance.edit');
+    Route::put('/users/{user}/leave-balance', [UserController::class, 'updateLeaveBalance'])->name('users.leave-balance.update');
+
     // Activity Log Route
     Route::get('/activities', [\App\Http\Controllers\ActivityController::class, 'index'])->name('activities.index');
 
@@ -219,7 +223,9 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     Route::post('api_keys/{client}/tokens', [ApiKeyController::class, 'generateToken'])->name('api_keys.tokens.store');
     Route::delete('api_keys/{client}/tokens/{tokenId}', [ApiKeyController::class, 'revokeToken'])->name('api_keys.tokens.destroy');
     Route::patch('api_keys/{client}/status', [ApiKeyController::class, 'update'])->name('api_keys.status.update');
+});
 
+Route::middleware(['auth', 'can.manage.leave.settings'])->prefix('admin')->name('admin.')->group(function () {
     // Cuti Bersama Management
     Route::resource('cuti-bersama', CutiBersamaController::class)->parameters(['cuti-bersama' => 'cutiBersama']);
 });


### PR DESCRIPTION
This commit implements two follow-up requests for the leave management module:

1.  **Cuti Bersama Authorization:**
    -   A new middleware, `CheckCanManageLeaveSettings`, is created to grant access to users who are either Super Admins or have the `can_manage_users` permission.
    -   This middleware is now used to protect the admin routes for managing 'Cuti Bersama' (collective leave), making the permission more flexible as requested.

2.  **Manual Leave Balance Form:**
    -   Adds a new admin page to manually edit a user's carried-over leave days (`carried_over_days`).
    -   This is crucial for migrating existing users into the system who may have remaining leave from the previous year.
    -   Includes the necessary routes, controller methods, and views for this functionality, with a link from the user's main edit page.