### PR TITLE
feat: Add menu link for Cuti Bersama management

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -279,6 +279,11 @@ class User extends Authenticatable
         return in_array($this->role, [self::ROLE_MENTERI, self::ROLE_SUPERADMIN, self::ROLE_ESELON_I, self::ROLE_ESELON_II, self::ROLE_KOORDINATOR]);
     }
 
+    public function canManageLeaveSettings(): bool
+    {
+        return $this->isSuperAdmin() || ($this->jabatan && $this->jabatan->can_manage_users);
+    }
+
     public function isSuperAdmin(): bool
     {
         return $this->role === self::ROLE_SUPERADMIN;

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -119,6 +119,10 @@ if (count($words) >= 2) {
                                 </x-slot>
                                 <x-slot name="content">
                                     <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
+                                        @if(Auth::user()->canManageLeaveSettings())
+                                            <x-dropdown-link :href="route('admin.cuti-bersama.index')" :active="request()->routeIs('admin.cuti-bersama.*')">Manajemen Cuti Bersama</x-dropdown-link>
+                                            <div class="border-t border-gray-200"></div>
+                                        @endif
                                         <x-dropdown-link :href="route('admin.api_keys.index')" :active="request()->routeIs('admin.api_keys.index')">Manajemen Integrasi</x-dropdown-link>
                                         <x-dropdown-link :href="route('admin.api_keys.query_helper')" :active="request()->routeIs('admin.api_keys.query_helper')">API Query Helper</x-dropdown-link>
                                         <div class="border-t border-gray-200"></div>


### PR DESCRIPTION
This commit adds a link to the 'Manajemen Cuti Bersama' page in the 'Pengaturan Sistem' (System Settings) navigation dropdown.

- A new `canManageLeaveSettings()` method has been added to the User model to encapsulate the specific permissions required to view this link.
- The navigation view is updated to use this method, ensuring the link is only visible to authorized users (Super Admins or users with the `can_manage_users` permission).