### PR TITLE
fix: Correct data usage in weekly workload view

### DIFF
--- a/app/Http/Controllers/WeeklyWorkloadController.php
+++ b/app/Http/Controllers/WeeklyWorkloadController.php
@@ -46,7 +46,8 @@ class WeeklyWorkloadController extends Controller
         $teamMembers = $subordinatesQuery->paginate(20)->withQueryString();
     
         // 7. Hitung beban kerja untuk setiap anggota tim yang ditampilkan
-        $workloadData = $teamMembers->map(function ($member) {
+        $standardHours = 37.5; // Standard weekly hours
+        $workloadData = $teamMembers->map(function ($member) use ($standardHours) {
             $today = Carbon::now();
             $startOfWeek = $today->copy()->startOfWeek();
             $endOfWeek = $today->copy()->endOfWeek();
@@ -83,6 +84,7 @@ class WeeklyWorkloadController extends Controller
             return [
                 'user' => $member,
                 'assigned_hours' => round($totalWeeklyHours, 1),
+                'effective_hours' => $effectiveWeeklyHours,
                 'workload_percentage' => round($workloadPercentage)
             ];
         });
@@ -91,6 +93,7 @@ class WeeklyWorkloadController extends Controller
         return view('weekly_workload.index', [
             'workloadData' => $workloadData, // Gunakan data yang sudah dihitung
             'teamMembers' => $teamMembers, // Kirim juga data paginasi untuk link
+            'standardHours' => $standardHours,
             'search' => $search
         ]);
     }

--- a/resources/views/weekly_workload/index.blade.php
+++ b/resources/views/weekly_workload/index.blade.php
@@ -43,21 +43,16 @@
                                 </tr>
                             </thead>
                             <tbody class="bg-white divide-y divide-gray-100"> {{-- Divider lebih halus --}}
-                                @forelse ($teamMembers as $member)
+                                @forelse ($workloadData as $data)
                                 @php
-                                    // Lakukan kalkulasi persentase di sini, karena data sudah di-eager load
-                                    $assignedHours = $member->total_assigned_hours ?? 0;
-                                    $workloadPercentage = ($standardHours > 0)
-                                        ? ($assignedHours / $standardHours) * 100
-                                        : 0;
-                                    $workloadPercentage = round($workloadPercentage);
+                                    $workloadPercentage = $data['workload_percentage'];
                                 @endphp
                                 <tr class="hover:bg-gray-50 transition-colors duration-150">
                                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800 flex items-center">
-                                        <i class="fas fa-user-tag mr-2 text-gray-500"></i> {{ $member->name }}
+                                        <i class="fas fa-user-tag mr-2 text-gray-500"></i> {{ $data['user']->name }}
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-                                        <span class="font-semibold">{{ number_format($assignedHours, 1) }}</span> jam
+                                        <span class="font-semibold">{{ number_format($data['assigned_hours'], 1) }}</span> jam
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap">
                                         <div class="flex items-center">


### PR DESCRIPTION
This commit fixes a bug in the weekly workload view (`weekly_workload/index.blade.php`) that caused an 'Undefined variable' error.

The view was using stale logic, attempting to recalculate workload percentages using the `$teamMembers` collection and a missing `$standardHours` variable. This was out of sync with the controller, which already prepares a pre-calculated `$workloadData` collection.

- The view has been refactored to loop through the correct `$workloadData` collection.
- It now uses the pre-calculated `assigned_hours` and `workload_percentage` values from the controller, removing the redundant and buggy calculations from the Blade file.
- The controller has also been updated to explicitly pass `$standardHours` to the view for the descriptive text, resolving the undefined variable error.