### PR TITLE
fix: Make leave management menu visible to all users

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -52,6 +52,14 @@ if (count($words) >= 2) {
                         </x-dropdown>
                     </div>
 
+                    {{-- Menu Cuti --}}
+                    <x-nav-link :href="route('leaves.index')" :active="request()->routeIs('leaves.*')" class="text-white hover:text-yellow-300 transition duration-150 ease-in-out">
+                        <div class="flex items-center">
+                            <i class="fas fa-calendar-alt mr-2"></i>
+                            <span>Manajemen Cuti</span>
+                        </div>
+                    </x-nav-link>
+
                     {{-- Dropdown Laporan & Analisis --}}
                     @if (Auth::user()->isTopLevelManager())
                         <div class="hidden sm:flex sm:items-center">
@@ -94,7 +102,6 @@ if (count($words) >= 2) {
                                             <x-dropdown-link :href="route('admin.units.index')" :active="request()->routeIs('admin.units.*')">Manajemen Unit</x-dropdown-link>
                                         @endif
                                         <x-dropdown-link :href="route('users.index')" :active="request()->routeIs('users.*')">Manajemen Pengguna</x-dropdown-link>
-                                        <x-dropdown-link :href="route('leaves.index')" :active="request()->routeIs('leaves.*')">Manajemen Cuti</x-dropdown-link>
                                         <div class="border-t border-gray-200"></div>
                                         <x-dropdown-link :href="route('peminjaman-requests.my-requests')" :active="request()->routeIs('peminjaman-requests.*')">Peminjaman Anggota</x-dropdown-link>
                                         <x-dropdown-link :href="route('resource-pool.index')" :active="request()->routeIs('resource-pool.index')">Resource Pool</x-dropdown-link>


### PR DESCRIPTION
This commit fixes a critical bug where the 'Manajemen Cuti' (Leave Management) menu item was only visible to managers, preventing staff from applying for leave.

The link was incorrectly placed inside a dropdown menu that was restricted to users with the `canManageUsers` permission.

- The 'Manajemen Cuti' link has been moved out of the restricted dropdown.
- It is now a top-level navigation item, visible to all authenticated users, ensuring that both staff and managers can access the leave management page.