### PR TITLE
feat: Add leave request seeder and disable email notifications

### DIFF
--- a/app/Notifications/LeaveRequestForwarded.php
+++ b/app/Notifications/LeaveRequestForwarded.php
@@ -27,7 +27,7 @@ class LeaveRequestForwarded extends Notification
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'mail'];
+        return ['database'];
     }
 
     /**

--- a/app/Notifications/LeaveRequestStatusUpdated.php
+++ b/app/Notifications/LeaveRequestStatusUpdated.php
@@ -27,7 +27,7 @@ class LeaveRequestStatusUpdated extends Notification
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'mail'];
+        return ['database'];
     }
 
     /**

--- a/app/Notifications/LeaveRequestSubmitted.php
+++ b/app/Notifications/LeaveRequestSubmitted.php
@@ -27,7 +27,7 @@ class LeaveRequestSubmitted extends Notification
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'mail'];
+        return ['database'];
     }
 
     /**

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             OrganizationalDataSeeder::class,
             LeaveTypesSeeder::class,
+            LeaveRequestSeeder::class,
             ProjectSeeder::class,
             TaskSeeder::class,
             TimeLogSeeder::class,

--- a/database/seeders/LeaveRequestSeeder.php
+++ b/database/seeders/LeaveRequestSeeder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\LeaveType;
+use App\Models\LeaveRequest;
+use App\Services\LeaveDurationService;
+use Carbon\Carbon;
+
+class LeaveRequestSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $this->command->info('Seeding dummy leave requests...');
+
+        $users = User::where('role', User::ROLE_STAF)->whereNotNull('atasan_id')->get();
+        if ($users->isEmpty()) {
+            $this->command->warn('No staff users with supervisors found. Skipping leave request seeding.');
+            return;
+        }
+
+        $leaveTypes = LeaveType::all();
+        if ($leaveTypes->isEmpty()) {
+            $this->command->warn('No leave types found. Please run LeaveTypesSeeder first. Skipping leave request seeding.');
+            return;
+        }
+
+        $statuses = ['pending', 'approved', 'rejected', 'approved_by_supervisor'];
+
+        for ($i = 0; $i < 30; $i++) {
+            $user = $users->random();
+            $leaveType = $leaveTypes->random();
+
+            $startDate = Carbon::now()->subDays(rand(-30, 30)); // Random start date around today
+            $endDate = $startDate->copy()->addDays(rand(0, 10));
+
+            $duration = LeaveDurationService::calculate($startDate, $endDate);
+            // Ensure duration is at least 1 day for this seeder
+            if ($duration <= 0) {
+                $endDate->addDay();
+                $duration = LeaveDurationService::calculate($startDate, $endDate);
+                 if ($duration <= 0) continue; // Skip if still invalid
+            }
+
+            $status = $statuses[array_rand($statuses)];
+            $approverId = null;
+            $rejectionReason = null;
+
+            if ($status !== 'pending') {
+                $approverId = $user->atasan_id;
+            }
+            if ($status === 'rejected') {
+                $rejectionReason = 'Alasan penolakan otomatis dari seeder.';
+            }
+
+            LeaveRequest::create([
+                'user_id' => $user->id,
+                'leave_type_id' => $leaveType->id,
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+                'duration_days' => $duration,
+                'reason' => 'Permintaan cuti otomatis dari seeder.',
+                'address_during_leave' => 'Jl. Seeder No. ' . ($i + 1),
+                'status' => $status,
+                'current_approver_id' => ($status === 'pending' || $status === 'approved_by_supervisor') ? $user->atasan_id : null,
+                'rejection_reason' => $rejectionReason,
+            ]);
+        }
+
+        $this->command->info('Dummy leave requests have been seeded successfully.');
+    }
+}


### PR DESCRIPTION
This commit addresses two final user requests for the leave management module:

1.  **Disable Email Notifications:**
    -   The `via()` method in `LeaveRequestSubmitted`, `LeaveRequestForwarded`, and `LeaveRequestStatusUpdated` notification classes has been modified to only use the `database` channel.
    -   This resolves a `TransportException` error caused by a missing mail server configuration in the user's environment.

2.  **Add Leave Request Seeder:**
    -   A new `LeaveRequestSeeder` has been created to populate the database with 30 sample leave requests.
    -   This seeder generates random requests for staff users with varying statuses and dates, which will be useful for testing and demonstration purposes.
    -   The seeder has been added to the main `DatabaseSeeder`.