### PR TITLE
fix: Add AuthorizesRequests trait to LeaveController

### DIFF
--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -16,9 +16,12 @@ use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class LeaveController extends Controller
 {
+    use AuthorizesRequests;
+
     public function index(Request $request)
     {
         $user = Auth::user();


### PR DESCRIPTION
This commit fixes a fatal error (`Call to undefined method authorize()`) that occurred when viewing the leave request detail page.

The error was caused by the `LeaveController` calling the `authorize()` method without using the necessary `AuthorizesRequests` trait.

This has been resolved by adding `use Illuminate\Foundation\Auth\Access\AuthorizesRequests;` and using the trait within the `LeaveController` class.