### PR TITLE
feat: Izinkan login dengan NIP

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -27,7 +27,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email'],
+            'identity' => ['required', 'string'],
             'password' => ['required', 'string'],
         ];
     }
@@ -41,11 +41,11 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+        if (! Auth::attempt($this->getCredentials(), $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
-                'email' => trans('auth.failed'),
+                'identity' => trans('auth.failed'),
             ]);
         }
 
@@ -68,7 +68,7 @@ class LoginRequest extends FormRequest
         $seconds = RateLimiter::availableIn($this->throttleKey());
 
         throw ValidationException::withMessages([
-            'email' => trans('auth.throttle', [
+            'identity' => trans('auth.throttle', [
                 'seconds' => $seconds,
                 'minutes' => ceil($seconds / 60),
             ]),
@@ -80,6 +80,23 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+        return Str::transliterate(Str::lower($this->string('identity')).'|'.$this->ip());
+    }
+
+    /**
+     * Get the credentials for authentication.
+     *
+     * @return array
+     */
+    protected function getCredentials(): array
+    {
+        $identity = $this->input('identity');
+
+        $fieldName = filter_var($identity, FILTER_VALIDATE_EMAIL) ? 'email' : 'nip';
+
+        return [
+            $fieldName => $identity,
+            'password' => $this->input('password'),
+        ];
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -174,9 +174,9 @@
         <x-auth-session-status class="mb-4" :status="session('status')" />
 
         <div class="input-group">
-          <input type="email" name="email" placeholder="Email" :value="old('email')" required autofocus>
+          <input type="text" name="identity" placeholder="Email atau NIP" :value="old('identity')" required autofocus>
           <i class="fas fa-user"></i>
-          <x-input-error :messages="$errors->get('email')" class="mt-2" />
+          <x-input-error :messages="$errors->get('identity')" class="mt-2" />
         </div>
         <div class="input-group">
           <input type="password" name="password" placeholder="Password" required autocomplete="current-password">


### PR DESCRIPTION
Commit ini memodifikasi proses autentikasi untuk memungkinkan pengguna login menggunakan NIP atau alamat email mereka.

- `LoginRequest` telah diperbarui untuk secara dinamis menentukan apakah identitas yang diberikan adalah email atau NIP dan membangun kredensial autentikasi yang sesuai.
- Input field pada form login telah diubah dari 'email' menjadi 'identity' dan labelnya telah diperbarui menjadi "Email atau NIP".
- Aturan validasi dan pembatasan laju (rate limiting) telah disesuaikan untuk menggunakan field 'identity' yang baru.