### PR TITLE
fix: Implement index page for outgoing letters

### DIFF
--- a/app/Http/Controllers/SuratKeluarController.php
+++ b/app/Http/Controllers/SuratKeluarController.php
@@ -15,7 +15,8 @@ class SuratKeluarController extends Controller
 {
     public function index()
     {
-        // Placeholder
+        $suratKeluar = Surat::where('jenis', 'keluar')->latest()->paginate(15);
+        return view('suratkeluar.index', compact('suratKeluar'));
     }
 
     public function create(Request $request)

--- a/resources/views/suratkeluar/index.blade.php
+++ b/resources/views/suratkeluar/index.blade.php
@@ -1,0 +1,69 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Arsip Surat Keluar') }}
+            </h2>
+            <a href="{{ route('surat-keluar.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-lg font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg">
+                <i class="fas fa-plus-circle mr-2"></i> {{ __('Buat Surat Baru') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12 bg-gray-50">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    @if (session('success'))
+                        <div class="mb-6 bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-lg relative shadow-md" role="alert">
+                            <span class="block sm:inline">{{ session('success') }}</span>
+                        </div>
+                    @endif
+
+                    <div class="overflow-x-auto border border-gray-200 rounded-lg">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-100">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Nomor Surat</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Perihal</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Tanggal Surat</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Status</th>
+                                    <th scope="col" class="px-6 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">Aksi</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-100">
+                                @forelse ($suratKeluar as $surat)
+                                    <tr class="hover:bg-gray-50">
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-700">{{ $surat->nomor_surat ?? 'DRAFT' }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ Str::limit($surat->perihal, 50) }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{{ $surat->tanggal_surat->format('d M Y') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                            <span class="px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full
+                                                @if($surat->status == 'draft') bg-yellow-100 text-yellow-800 @endif
+                                                @if($surat->status == 'disetujui') bg-green-100 text-green-800 @endif
+                                            ">
+                                                {{ ucfirst($surat->status) }}
+                                            </span>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                            <a href="{{ route('surat-keluar.show', $surat) }}" class="text-indigo-600 hover:text-indigo-900">Detail</a>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="px-6 py-8 text-center text-gray-500 text-lg">
+                                            Tidak ada surat keluar yang ditemukan.
+                                        </td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="mt-6">
+                        {{ $suratKeluar->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
This commit fixes a bug that caused a blank white screen when accessing the outgoing letters index page.

The `index` method in `SuratKeluarController` was a placeholder and did not return a view, causing a fatal error.

This patch:
- Implements the `index` method to fetch and paginate outgoing letters.
- Creates the `suratkeluar.index.blade.php` view to display the letters in a table.