### PR TITLE
feat: Add upload workflow for outgoing letters

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -46,7 +46,7 @@
         @include('partials.about-us-modal') 
 
         <footer class="w-full text-center py-4 bg-gray-100 border-t border-gray-200 text-gray-500 text-sm">
-            &copy; Pusat Data dan Teknologi Informasi Ketenagakerjaan <span class="font-bold text-indigo-700"> - oleh Arif Budi Setiawan - 2025</span>
+            &copy; Konsep & Visualisasi oleh <span class="font-bold text-indigo-700">PSI 2025</span>
         </footer>
     </div>
 

--- a/resources/views/suratkeluar/create-step2.blade.php
+++ b/resources/views/suratkeluar/create-step2.blade.php
@@ -12,6 +12,7 @@
                     <form action="{{ route('surat-keluar.store') }}" method="POST">
                         @csrf
                         <input type="hidden" name="template_id" value="{{ $template->id }}">
+                        <input type="hidden" name="submission_type" value="template">
 
                         <div class="space-y-6">
                             <div>

--- a/resources/views/suratkeluar/create-upload.blade.php
+++ b/resources/views/suratkeluar/create-upload.blade.php
@@ -1,0 +1,55 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Buat Surat Keluar - Upload Dokumen Jadi') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 bg-gray-50">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
+                <div class="p-6 sm:p-8 text-gray-900">
+                    <form action="{{ route('surat-keluar.store') }}" method="POST" enctype="multipart/form-data">
+                        @csrf
+                        <input type="hidden" name="submission_type" value="upload">
+                        <div class="space-y-6">
+                            <div>
+                                <label for="perihal" class="block font-semibold text-sm text-gray-700 mb-1">Perihal Surat <span class="text-red-500">*</span></label>
+                                <input type="text" name="perihal" id="perihal" value="{{ old('perihal') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                @error('perihal') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                <div>
+                                    <label for="nomor_surat" class="block font-semibold text-sm text-gray-700 mb-1">Nomor Surat (Opsional)</label>
+                                    <input type="text" name="nomor_surat" id="nomor_surat" value="{{ old('nomor_surat') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">
+                                    <p class="text-xs text-gray-500 mt-1">Isi jika surat sudah memiliki nomor.</p>
+                                    @error('nomor_surat') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
+                                <div>
+                                    <label for="tanggal_surat" class="block font-semibold text-sm text-gray-700 mb-1">Tanggal Surat <span class="text-red-500">*</span></label>
+                                    <input type="date" name="tanggal_surat" id="tanggal_surat" value="{{ old('tanggal_surat', date('Y-m-d')) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                    @error('tanggal_surat') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
+                            </div>
+
+                            <div>
+                                <label for="lampiran" class="block font-semibold text-sm text-gray-700 mb-1">Upload File Surat (PDF) <span class="text-red-500">*</span></label>
+                                <input id="lampiran" name="lampiran" type="file" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" required accept=".pdf">
+                                <p class="text-xs text-gray-500 mt-1">Hanya file PDF. Maksimal 5MB.</p>
+                                @error('lampiran') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+                        </div>
+
+                        <div class="flex items-center justify-end mt-8 pt-6 border-t border-gray-200">
+                            <a href="{{ route('surat-keluar.create') }}" class="text-sm font-medium text-gray-600 hover:text-gray-900 mr-4">Kembali</a>
+                            <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg">
+                                <i class="fas fa-archive mr-2"></i> Simpan & Arsipkan
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/suratkeluar/pilih-metode.blade.php
+++ b/resources/views/suratkeluar/pilih-metode.blade.php
@@ -1,0 +1,38 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Buat Surat Keluar Baru') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 bg-gray-50">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
+                <div class="p-6 sm:p-8 text-gray-900 text-center">
+                    <h3 class="text-2xl font-bold text-gray-800 mb-2">Pilih Metode Pembuatan Surat</h3>
+                    <p class="text-gray-600 mb-8">Anda dapat membuat surat baru menggunakan template yang sudah ada, atau mengunggah dokumen yang sudah jadi.</p>
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                        {{-- Opsi 1: Buat dari Template --}}
+                        <a href="{{ route('surat-keluar.create.from-template') }}" class="block p-8 bg-indigo-50 border-2 border-transparent rounded-lg shadow-lg hover:shadow-2xl hover:border-indigo-500 transition-all duration-300 transform hover:-translate-y-2">
+                            <div class="text-center">
+                                <i class="fas fa-file-alt fa-4x text-indigo-500 mb-4"></i>
+                                <h4 class="font-bold text-xl text-indigo-800">Buat dari Template</h4>
+                                <p class="text-sm text-gray-600 mt-2">Gunakan editor di dalam aplikasi untuk membuat surat dari template yang telah disetujui.</p>
+                            </div>
+                        </a>
+
+                        {{-- Opsi 2: Upload Dokumen Jadi --}}
+                        <a href="{{ route('surat-keluar.create.upload') }}" class="block p-8 bg-green-50 border-2 border-transparent rounded-lg shadow-lg hover:shadow-2xl hover:border-green-500 transition-all duration-300 transform hover:-translate-y-2">
+                            <div class="text-center">
+                                <i class="fas fa-file-upload fa-4x text-green-500 mb-4"></i>
+                                <h4 class="font-bold text-xl text-green-800">Upload Dokumen Jadi</h4>
+                                <p class="text-sm text-gray-600 mt-2">Unggah file PDF surat yang sudah final untuk diarsipkan dan didisposisikan melalui sistem.</p>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/suratkeluar/show.blade.php
+++ b/resources/views/suratkeluar/show.blade.php
@@ -25,9 +25,23 @@
                 {{-- Kolom utama untuk konten surat --}}
                 <div class="lg:col-span-2 bg-white overflow-hidden shadow-xl sm:rounded-lg">
                     <div class="p-6 sm:p-8">
-                        <div class="prose max-w-none">
-                            {!! $surat->konten !!}
-                        </div>
+                        @if ($surat->konten)
+                            <div class="prose max-w-none">
+                                {!! $surat->konten !!}
+                            </div>
+                        @elseif ($surat->lampiran->isNotEmpty())
+                             @php $lampiran = $surat->lampiran->first(); @endphp
+                            <h3 class="text-lg font-bold text-gray-800 mb-4">Lampiran Surat</h3>
+                            @if (Str::contains($lampiran->tipe_file, 'pdf'))
+                                <iframe src="{{ Storage::url($lampiran->path_file) }}" class="w-full h-screen rounded-lg border"></iframe>
+                            @else
+                                <a href="{{ Storage::url($lampiran->path_file) }}" target="_blank" class="text-indigo-600 hover:underline">
+                                    Lihat Lampiran: {{ $lampiran->nama_file }}
+                                </a>
+                            @endif
+                        @else
+                            <p class="text-gray-500">Tidak ada konten atau lampiran untuk ditampilkan.</p>
+                        @endif
                     </div>
                 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -192,6 +192,8 @@ Route::middleware(['auth'])->group(function () {
     Route::prefix('surat-keluar')->name('surat-keluar.')->group(function () {
         Route::get('/', [\App\Http\Controllers\SuratKeluarController::class, 'index'])->name('index');
         Route::get('/create', [\App\Http\Controllers\SuratKeluarController::class, 'create'])->name('create');
+        Route::get('/create/from-template', [\App\Http\Controllers\SuratKeluarController::class, 'createFromTemplate'])->name('create.from-template');
+        Route::get('/create/upload', [\App\Http\Controllers\SuratKeluarController::class, 'createUpload'])->name('create.upload');
         Route::post('/', [\App\Http\Controllers\SuratKeluarController::class, 'store'])->name('store');
         Route::get('/{surat}', [\App\Http\Controllers\SuratKeluarController::class, 'show'])->name('show');
         Route::post('/{surat}/approve', [\App\Http\Controllers\SuratKeluarController::class, 'approve'])->name('approve');


### PR DESCRIPTION
This commit enhances the outgoing letter module by adding a secondary workflow.

Previously, users could only generate letters from pre-defined templates. Now, users are presented with a choice:
1.  Generate from Template (existing workflow).
2.  Upload a finished document (new workflow).

This allows users to archive and manage outgoing letters that were created outside the system.

Changes include:
- Refactoring `SuratKeluarController` to handle both workflows.
- Adding new views for the method selection and the upload form.
- Updating the `store` method to differentiate between submission types.
- Updating the `show` view to conditionally display either generated HTML or an embedded PDF attachment.