### PR TITLE
fix: Implement secure route for viewing attachments

### DIFF
--- a/app/Http/Controllers/LampiranController.php
+++ b/app/Http/Controllers/LampiranController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\LampiranSurat;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class LampiranController extends Controller
+{
+    public function show(LampiranSurat $lampiranSurat)
+    {
+        $this->authorize('view', $lampiranSurat);
+
+        if (!Storage::disk('public')->exists($lampiranSurat->path_file)) {
+            abort(404, 'File tidak ditemukan.');
+        }
+
+        return Storage::disk('public')->response($lampiranSurat->path_file);
+    }
+}

--- a/app/Policies/LampiranSuratPolicy.php
+++ b/app/Policies/LampiranSuratPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\LampiranSurat;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class LampiranSuratPolicy
+{
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, LampiranSurat $lampiranSurat): bool
+    {
+        $surat = $lampiranSurat->surat;
+
+        // Allow if the user is the creator of the letter
+        if ($user->id === $surat->pembuat_id) {
+            return true;
+        }
+
+        // Allow if the user is the approver of the letter
+        if ($user->id === $surat->penyetuju_id) {
+            return true;
+        }
+
+        // Allow if the user has received a disposition for this letter
+        return $surat->disposisi()->where('penerima_id', $user->id)->exists();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -11,6 +11,8 @@ use App\Models\User;
 use App\Policies\PeminjamanRequestPolicy;
 use App\Policies\ProjectPolicy;
 use App\Policies\SpecialAssignmentPolicy;
+use App\Models\LampiranSurat;
+use App\Policies\LampiranSuratPolicy;
 use App\Policies\TaskPolicy;
 use App\Policies\UnitPolicy;
 use App\Policies\UserPolicy;
@@ -31,6 +33,7 @@ class AuthServiceProvider extends ServiceProvider
         User::class => UserPolicy::class,
         PeminjamanRequest::class => PeminjamanRequestPolicy::class,
         SpecialAssignment::class => SpecialAssignmentPolicy::class,
+        LampiranSurat::class => LampiranSuratPolicy::class,
     ];
 
     /**

--- a/resources/views/suratkeluar/show.blade.php
+++ b/resources/views/suratkeluar/show.blade.php
@@ -33,9 +33,9 @@
                              @php $lampiran = $surat->lampiran->first(); @endphp
                             <h3 class="text-lg font-bold text-gray-800 mb-4">Lampiran Surat</h3>
                             @if (Str::contains($lampiran->tipe_file, 'pdf'))
-                                <iframe src="{{ Storage::url($lampiran->path_file) }}" class="w-full h-screen rounded-lg border"></iframe>
+                                <iframe src="{{ route('lampiran.show', $lampiran) }}" class="w-full h-screen rounded-lg border"></iframe>
                             @else
-                                <a href="{{ Storage::url($lampiran->path_file) }}" target="_blank" class="text-indigo-600 hover:underline">
+                                <a href="{{ route('lampiran.show', $lampiran) }}" target="_blank" class="text-indigo-600 hover:underline">
                                     Lihat Lampiran: {{ $lampiran->nama_file }}
                                 </a>
                             @endif

--- a/resources/views/suratmasuk/show.blade.php
+++ b/resources/views/suratmasuk/show.blade.php
@@ -23,11 +23,11 @@
                             @php $lampiran = $surat->lampiran->first(); @endphp
                             <h3 class="text-lg font-bold text-gray-800 mb-4">Lampiran Surat</h3>
                             @if (Str::contains($lampiran->tipe_file, 'pdf'))
-                                <iframe src="{{ Storage::url($lampiran->path_file) }}" class="w-full h-screen rounded-lg border"></iframe>
+                                <iframe src="{{ route('lampiran.show', $lampiran) }}" class="w-full h-screen rounded-lg border"></iframe>
                             @elseif (Str::contains($lampiran->tipe_file, 'image'))
-                                <img src="{{ Storage::url($lampiran->path_file) }}" alt="Lampiran" class="w-full h-auto rounded-lg border">
+                                <img src="{{ route('lampiran.show', $lampiran) }}" alt="Lampiran" class="w-full h-auto rounded-lg border">
                             @else
-                                <a href="{{ Storage::url($lampiran->path_file) }}" target="_blank" class="text-indigo-600 hover:underline">
+                                <a href="{{ route('lampiran.show', $lampiran) }}" target="_blank" class="text-indigo-600 hover:underline">
                                     Lihat Lampiran: {{ $lampiran->nama_file }}
                                 </a>
                             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -202,6 +202,9 @@ Route::middleware(['auth'])->group(function () {
     // Routes for Incoming Letters & Dispositions
     Route::resource('surat-masuk', \App\Http\Controllers\SuratMasukController::class)->only(['index', 'create', 'store', 'show']);
     Route::post('/surat-masuk/{surat}/disposisi', [\App\Http\Controllers\DisposisiController::class, 'store'])->name('disposisi.store');
+
+    // Route for viewing attachments securely
+    Route::get('/lampiran/{lampiranSurat}', [\App\Http\Controllers\LampiranController::class, 'show'])->name('lampiran.show');
 });
 
 use App\Http\Controllers\Admin\ApiKeyController;


### PR DESCRIPTION
This commit resolves a 403 Forbidden error when accessing letter attachments.

Instead of linking directly to the public storage path, a new secure workflow has been implemented:
- A new `LampiranController@show` method is created to handle file serving.
- A new route `GET /lampiran/{lampiranSurat}` is registered for this purpose.
- A `LampiranSuratPolicy` is created and registered to authorize that the current user is allowed to view the attachment (e.g., they are the creator, approver, or a recipient of a disposition).
- The `suratmasuk.show` and `suratkeluar.show` views have been updated to use this new secure route.