### PR TITLE
fix: Add AuthorizesRequests trait to LampiranController

### DIFF
--- a/app/Http/Controllers/LampiranController.php
+++ b/app/Http/Controllers/LampiranController.php
@@ -5,9 +5,12 @@ namespace App\Http\Controllers;
 use App\Models\LampiranSurat;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class LampiranController extends Controller
 {
+    use AuthorizesRequests;
+
     public function show(LampiranSurat $lampiranSurat)
     {
         $this->authorize('view', $lampiranSurat);


### PR DESCRIPTION
This commit resolves a fatal error when viewing letter attachments. The `authorize()` method was being called, but it was not available because the `LampiranController` was missing the `AuthorizesRequests` trait.

This patch adds the trait to the controller, enabling the policy-based authorization check to function correctly.