### PR TITLE
fix: Resolve fatal errors in correspondence module

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,7 +36,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->register(\SimpleSoftwareIO\QrCode\QrCodeServiceProvider::class);
     }
 
     /**
@@ -44,6 +44,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+        $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);
+
         Gate::before(function ($user, $ability) {
             if ($user->role === 'Superadmin') {
                 return true;


### PR DESCRIPTION
This commit addresses two separate fatal errors that were discovered during testing of the new correspondence system.

1.  **Undefined method authorize() in LampiranController:** The `LampiranController` was missing the `AuthorizesRequests` trait, which caused a fatal error when trying to check policies for viewing attachments. The trait has been added to the controller.

2.  **Class "QrCode" not found:** The `simple-qrcode` package's service provider and facade were not being loaded correctly, likely due to an environment issue preventing package auto-discovery or `config/app.php` modification. A workaround has been implemented to register the provider and alias dynamically within `AppServiceProvider`.