### PR TITLE
fix: Add AuthorizesRequests trait to SuratKeluarController

### DIFF
--- a/app/Http/Controllers/SuratKeluarController.php
+++ b/app/Http/Controllers/SuratKeluarController.php
@@ -11,9 +11,12 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Barryvdh\DomPDF\Facade\Pdf;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class SuratKeluarController extends Controller
 {
+    use AuthorizesRequests;
+
     public function index()
     {
         $suratKeluar = Surat::where('jenis', 'keluar')->latest()->paginate(15);


### PR DESCRIPTION
This commit resolves a fatal error when deleting outgoing letters. The `authorize()` method was being called in the `destroy` method, but it was not available because the `SuratKeluarController` was missing the `AuthorizesRequests` trait.

This patch adds the trait to the controller.