### PR TITLE
fix: Use @json to pass template content to JavaScript

### DIFF
--- a/resources/views/suratkeluar/create-step2.blade.php
+++ b/resources/views/suratkeluar/create-step2.blade.php
@@ -56,7 +56,7 @@
     @push('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            const templateContent = `{!! $template->konten !!}`;
+            const templateContent = @json($template->konten);
             const placeholderContainer = document.getElementById('placeholder-inputs');
             const noPlaceholderMessage = document.getElementById('no-placeholder-message');
             const finalContentTextarea = document.getElementById('konten_final');


### PR DESCRIPTION
This commit resolves a fatal error on the "create letter from template" page (`create-step2.blade.php`).

The `{!! $template->konten !!}` directive was being used to pass the template's content to a JavaScript variable. This caused the Blade engine to incorrectly try and evaluate any `{{...}}` placeholders within the content as PHP code, leading to an "Undefined constant" error.

The fix replaces the raw output with the `@json` directive, which safely encodes the data for JavaScript consumption, preventing it from being parsed by Blade.