### PR TITLE
fix: Prevent Blade parsing of placeholder in JS comment

### DIFF
--- a/resources/views/suratkeluar/create-step2.blade.php
+++ b/resources/views/suratkeluar/create-step2.blade.php
@@ -66,7 +66,7 @@
             previewContainer.innerHTML = templateContent;
             finalContentTextarea.value = templateContent;
 
-            // Regex to find placeholders like {{placeholder_name}}
+            // Regex to find placeholders like {placeholder_name}
             const placeholderRegex = /\{\{([a-zA-Z0-9_]+)\}\}/g;
             let placeholders = new Set(); // Use a Set to store unique placeholders
             let match;


### PR DESCRIPTION
This commit resolves a recurring "Undefined constant" fatal error on the `suratkeluar.create-step2` view.

The root cause was a `{{...}}` placeholder inside a JavaScript comment that was intended as an example. The Blade engine was incorrectly parsing this comment as executable code.

The fix rephrases the comment to avoid using the double-curly-brace syntax, which prevents Blade from parsing it and resolves the error.