### PR TITLE
fix: Improve UX of the letter template editor

### DIFF
--- a/resources/views/templatesurat/create.blade.php
+++ b/resources/views/templatesurat/create.blade.php
@@ -11,24 +11,49 @@
                 <div class="p-6 sm:p-8 text-gray-900">
                     <form action="{{ route('templatesurat.store') }}" method="POST">
                         @csrf
-                        <div class="space-y-6">
-                            <div>
-                                <label for="judul" class="block font-semibold text-sm text-gray-700 mb-1">Judul Template <span class="text-red-500">*</span></label>
-                                <input type="text" name="judul" id="judul" value="{{ old('judul') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-                                @error('judul') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                            {{-- Kolom Utama (Kiri) --}}
+                            <div class="lg:col-span-2 space-y-6">
+                                <div>
+                                    <label for="judul" class="block font-semibold text-sm text-gray-700 mb-1">Judul Template <span class="text-red-500">*</span></label>
+                                    <input type="text" name="judul" id="judul" value="{{ old('judul') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                    @error('judul') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
+
+                                <div>
+                                    <label for="deskripsi" class="block font-semibold text-sm text-gray-700 mb-1">Deskripsi (Opsional)</label>
+                                    <textarea name="deskripsi" id="deskripsi" rows="3" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">{{ old('deskripsi') }}</textarea>
+                                    @error('deskripsi') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
+
+                                <div>
+                                    <label for="konten" class="block font-semibold text-sm text-gray-700 mb-1">Konten Template <span class="text-red-500">*</span></label>
+                                    <textarea name="konten" id="konten" rows="20" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 font-mono">{{ old('konten') }}</textarea>
+                                    @error('konten') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
                             </div>
 
-                            <div>
-                                <label for="deskripsi" class="block font-semibold text-sm text-gray-700 mb-1">Deskripsi (Opsional)</label>
-                                <textarea name="deskripsi" id="deskripsi" rows="3" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">{{ old('deskripsi') }}</textarea>
-                                @error('deskripsi') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
-                            </div>
-
-                            <div>
-                                <label for="konten" class="block font-semibold text-sm text-gray-700 mb-1">Konten Template <span class="text-red-500">*</span></label>
-                                <p class="text-xs text-gray-500 mb-2">Gunakan placeholder seperti <code>{{ '{nama_penerima}' }}</code> atau <code>{{ '{tanggal_surat}' }}</code>. Placeholder ini akan diganti dengan data sebenarnya saat surat dibuat.</p>
-                                <textarea name="konten" id="konten" rows="15" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 font-mono">{{ old('konten') }}</textarea>
-                                @error('konten') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            {{-- Kolom Samping (Kanan) --}}
+                            <div class="space-y-6">
+                                <div class="p-4 bg-indigo-50 border border-indigo-200 rounded-lg shadow-sm">
+                                    <h4 class="font-bold text-gray-800 mb-2">Bantuan Placeholder</h4>
+                                    <p class="text-xs text-gray-600 mb-2">
+                                        Gunakan placeholder untuk bagian surat yang akan diisi secara dinamis. Cukup ketik nama placeholder (tanpa spasi, gunakan underscore jika perlu) lalu klik "Sisipkan".
+                                    </p>
+                                    <div class="space-y-2">
+                                        <label for="placeholder_name" class="sr-only">Nama Placeholder</label>
+                                        <input type="text" id="placeholder_name" placeholder="cth: nama_kegiatan" class="block w-full text-sm rounded-md border-gray-300 shadow-sm">
+                                        <button type="button" id="insert_placeholder_btn" class="w-full inline-flex justify-center items-center px-3 py-2 bg-indigo-500 text-white text-xs font-semibold rounded-md hover:bg-indigo-600">
+                                            <i class="fas fa-plus-circle mr-2"></i> Sisipkan Placeholder
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="p-4 bg-gray-50 border border-gray-200 rounded-lg shadow-sm">
+                                     <h4 class="font-bold text-gray-800 mb-2">Contoh</h4>
+                                     <p class="text-xs text-gray-600">
+                                         Menugaskan Sdr. <code class="bg-gray-200 text-red-600 p-0.5 rounded">@{{nama_pegawai}}</code> untuk mengikuti kegiatan...
+                                     </p>
+                                </div>
                             </div>
                         </div>
 
@@ -46,10 +71,27 @@
     @push('scripts')
         <script src="https://cdn.tiny.cloud/1/{{ config('services.tinymce.api_key', 'no-api-key') }}/tinymce/7/tinymce.min.js" referrerpolicy="origin"></script>
         <script>
-            tinymce.init({
-                selector: 'textarea#konten',
-                plugins: 'code table lists wordcount',
-                toolbar: 'undo redo | blocks | bold italic | alignleft aligncenter alignright | indent outdent | bullist numlist | code | table'
+            document.addEventListener('DOMContentLoaded', function () {
+                tinymce.init({
+                    selector: 'textarea#konten',
+                    plugins: 'code table lists wordcount',
+                    toolbar: 'undo redo | blocks | bold italic | alignleft aligncenter alignright | indent outdent | bullist numlist | code | table',
+                    setup: function (editor) {
+                        document.getElementById('insert_placeholder_btn').addEventListener('click', function () {
+                            const placeholderName = document.getElementById('placeholder_name').value;
+                            if (placeholderName) {
+                                // Sanitize placeholder name to be safe (alphanumeric and underscores)
+                                const sanitized = placeholderName.replace(/[^a-zA-Z0-9_]/g, '');
+                                if (sanitized) {
+                                    editor.execCommand('mceInsertContent', false, `{{${sanitized}}}`);
+                                } else {
+                                    alert('Nama placeholder hanya boleh berisi huruf, angka, dan underscore.');
+                                }
+                                document.getElementById('placeholder_name').value = ''; // Clear input
+                            }
+                        });
+                    }
+                });
             });
         </script>
     @endpush

--- a/resources/views/templatesurat/edit.blade.php
+++ b/resources/views/templatesurat/edit.blade.php
@@ -12,24 +12,49 @@
                     <form action="{{ route('templatesurat.update', $templatesurat) }}" method="POST">
                         @csrf
                         @method('PUT')
-                        <div class="space-y-6">
-                            <div>
-                                <label for="judul" class="block font-semibold text-sm text-gray-700 mb-1">Judul Template <span class="text-red-500">*</span></label>
-                                <input type="text" name="judul" id="judul" value="{{ old('judul', $templatesurat->judul) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-                                @error('judul') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                            {{-- Kolom Utama (Kiri) --}}
+                            <div class="lg:col-span-2 space-y-6">
+                                <div>
+                                    <label for="judul" class="block font-semibold text-sm text-gray-700 mb-1">Judul Template <span class="text-red-500">*</span></label>
+                                    <input type="text" name="judul" id="judul" value="{{ old('judul', $templatesurat->judul) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                    @error('judul') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
+
+                                <div>
+                                    <label for="deskripsi" class="block font-semibold text-sm text-gray-700 mb-1">Deskripsi (Opsional)</label>
+                                    <textarea name="deskripsi" id="deskripsi" rows="3" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">{{ old('deskripsi', $templatesurat->deskripsi) }}</textarea>
+                                    @error('deskripsi') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
+
+                                <div>
+                                    <label for="konten" class="block font-semibold text-sm text-gray-700 mb-1">Konten Template <span class="text-red-500">*</span></label>
+                                    <textarea name="konten" id="konten" rows="20" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 font-mono">{{ old('konten', $templatesurat->konten) }}</textarea>
+                                    @error('konten') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                </div>
                             </div>
 
-                            <div>
-                                <label for="deskripsi" class="block font-semibold text-sm text-gray-700 mb-1">Deskripsi (Opsional)</label>
-                                <textarea name="deskripsi" id="deskripsi" rows="3" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">{{ old('deskripsi', $templatesurat->deskripsi) }}</textarea>
-                                @error('deskripsi') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
-                            </div>
-
-                            <div>
-                                <label for="konten" class="block font-semibold text-sm text-gray-700 mb-1">Konten Template <span class="text-red-500">*</span></label>
-                                <p class="text-xs text-gray-500 mb-2">Gunakan placeholder seperti <code>{{ '{nama_penerima}' }}</code> atau <code>{{ '{tanggal_surat}' }}</code>. Placeholder ini akan diganti dengan data sebenarnya saat surat dibuat.</p>
-                                <textarea name="konten" id="konten" rows="15" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 font-mono">{{ old('konten', $templatesurat->konten) }}</textarea>
-                                @error('konten') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            {{-- Kolom Samping (Kanan) --}}
+                            <div class="space-y-6">
+                                <div class="p-4 bg-indigo-50 border border-indigo-200 rounded-lg shadow-sm">
+                                    <h4 class="font-bold text-gray-800 mb-2">Bantuan Placeholder</h4>
+                                    <p class="text-xs text-gray-600 mb-2">
+                                        Gunakan placeholder untuk bagian surat yang akan diisi secara dinamis. Cukup ketik nama placeholder (tanpa spasi, gunakan underscore jika perlu) lalu klik "Sisipkan".
+                                    </p>
+                                    <div class="space-y-2">
+                                        <label for="placeholder_name" class="sr-only">Nama Placeholder</label>
+                                        <input type="text" id="placeholder_name" placeholder="cth: nama_kegiatan" class="block w-full text-sm rounded-md border-gray-300 shadow-sm">
+                                        <button type="button" id="insert_placeholder_btn" class="w-full inline-flex justify-center items-center px-3 py-2 bg-indigo-500 text-white text-xs font-semibold rounded-md hover:bg-indigo-600">
+                                            <i class="fas fa-plus-circle mr-2"></i> Sisipkan Placeholder
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="p-4 bg-gray-50 border border-gray-200 rounded-lg shadow-sm">
+                                     <h4 class="font-bold text-gray-800 mb-2">Contoh</h4>
+                                     <p class="text-xs text-gray-600">
+                                         Menugaskan Sdr. <code class="bg-gray-200 text-red-600 p-0.5 rounded">@{{nama_pegawai}}</code> untuk mengikuti kegiatan...
+                                     </p>
+                                </div>
                             </div>
                         </div>
 
@@ -47,10 +72,27 @@
     @push('scripts')
         <script src="https://cdn.tiny.cloud/1/{{ config('services.tinymce.api_key', 'no-api-key') }}/tinymce/7/tinymce.min.js" referrerpolicy="origin"></script>
         <script>
-            tinymce.init({
-                selector: 'textarea#konten',
-                plugins: 'code table lists wordcount',
-                toolbar: 'undo redo | blocks | bold italic | alignleft aligncenter alignright | indent outdent | bullist numlist | code | table'
+            document.addEventListener('DOMContentLoaded', function () {
+                tinymce.init({
+                    selector: 'textarea#konten',
+                    plugins: 'code table lists wordcount',
+                    toolbar: 'undo redo | blocks | bold italic | alignleft aligncenter alignright | indent outdent | bullist numlist | code | table',
+                    setup: function (editor) {
+                        document.getElementById('insert_placeholder_btn').addEventListener('click', function () {
+                            const placeholderName = document.getElementById('placeholder_name').value;
+                            if (placeholderName) {
+                                // Sanitize placeholder name to be safe (alphanumeric and underscores)
+                                const sanitized = placeholderName.replace(/[^a-zA-Z0-9_]/g, '');
+                                if (sanitized) {
+                                    editor.execCommand('mceInsertContent', false, `{{${sanitized}}}`);
+                                } else {
+                                    alert('Nama placeholder hanya boleh berisi huruf, angka, dan underscore.');
+                                }
+                                document.getElementById('placeholder_name').value = ''; // Clear input
+                            }
+                        });
+                    }
+                });
             });
         </script>
     @endpush


### PR DESCRIPTION
This commit addresses user confusion regarding the creation of dynamic letter templates. The previous implementation required users to manually type `{{placeholder}}` syntax, which was not intuitive.

Changes:
- The `templatesurat/create` and `templatesurat/edit` views have been redesigned with a two-column layout.
- A new "Placeholder Helper" panel has been added. It contains an input field for a placeholder name and an "Insert" button.
- JavaScript has been added to take the name from the input, format it into `{{name}}`, and insert it into the TinyMCE editor at the current cursor position.
- A more detailed instruction panel has also been added.

This makes the process of creating dynamic templates much clearer and more user-friendly.