### PR TITLE
fix: Use SVG format for QR codes to avoid imagick dependency

### DIFF
--- a/app/Http/Controllers/SuratKeluarController.php
+++ b/app/Http/Controllers/SuratKeluarController.php
@@ -131,7 +131,8 @@ class SuratKeluarController extends Controller
 
         // 2. Siapkan data untuk PDF
         $verificationUrl = route('surat.verify', ['id' => $surat->id]); // Asumsi ada route verifikasi
-        $qrCode = base64_encode(QrCode::format('png')->size(100)->generate($verificationUrl));
+        // Generate SVG instead of PNG to avoid imagick dependency
+        $qrCode = base64_encode(QrCode::format('svg')->size(100)->generate($verificationUrl));
 
         $signatureImagePath = null;
         if ($request->boolean('with_signature') && $penyetuju->signature_image_path) {

--- a/resources/views/pdf/surat.blade.php
+++ b/resources/views/pdf/surat.blade.php
@@ -56,7 +56,7 @@
         <div class="footer clearfix">
             <div class="qr-code">
                 {{-- QR code will be injected here as an image --}}
-                <img src="data:image/png;base64, {!! $qrCode !!}" alt="QR Code">
+                <img src="data:image/svg+xml;base64, {!! $qrCode !!}" alt="QR Code">
             </div>
             <div class="signature-section">
                 <p>Hormat kami,</p>


### PR DESCRIPTION
This commit resolves a fatal error caused by the missing `imagick` PHP extension in the user's environment.

The QR code generation was previously set to output a PNG file, which requires either the `imagick` or `gd` extension. To make the feature more robust and less dependent on specific PHP extensions, the QR code generation has been switched to the SVG format.

- `SuratKeluarController@approve` now generates a base64-encoded SVG.
- `pdf/surat.blade.php` is updated to correctly embed a base64-encoded SVG image in the final PDF.