### PR TITLE
fix: Add download button for approved letters

### DIFF
--- a/resources/views/suratkeluar/show.blade.php
+++ b/resources/views/suratkeluar/show.blade.php
@@ -74,7 +74,15 @@
                         </div>
                     </div>
 
-                    @if ($surat->status === 'draft')
+                    @if ($surat->status === 'disetujui' && $surat->final_pdf_path)
+                        <div class="bg-white p-6 rounded-lg shadow-xl text-center">
+                            <h3 class="text-lg font-bold text-gray-800 mb-2">Dokumen Final</h3>
+                            <p class="text-sm text-gray-500 mb-4">Surat telah disetujui dan PDF final telah dibuat.</p>
+                            <a href="{{ Storage::url($surat->final_pdf_path) }}" target="_blank" class="w-full inline-flex justify-center items-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-700">
+                                <i class="fas fa-download mr-2"></i> Unduh PDF Final
+                            </a>
+                        </div>
+                    @elseif ($surat->status === 'draft')
                         <div class="bg-white p-6 rounded-lg shadow-xl">
                             <h3 class="text-lg font-bold text-gray-800 border-b pb-2 mb-4">Aksi Persetujuan</h3>
                             <form action="{{ route('surat-keluar.approve', $surat) }}" method="POST">


### PR DESCRIPTION
This commit addresses a UX oversight where users could not download the final PDF after a letter was approved.

The `suratkeluar/show.blade.php` view has been updated to conditionally display a "Download PDF Final" panel when the letter's status is 'disetujui' and a `final_pdf_path` exists.

The button links directly to the publicly accessible file in storage.