### PR TITLE
fix: Implement secure route for final PDF downloads

### DIFF
--- a/app/Http/Controllers/SuratKeluarController.php
+++ b/app/Http/Controllers/SuratKeluarController.php
@@ -175,4 +175,15 @@ class SuratKeluarController extends Controller
 
         return redirect()->route('surat-keluar.index')->with('success', 'Surat keluar berhasil dihapus.');
     }
+
+    public function download(Surat $surat)
+    {
+        $this->authorize('download', $surat);
+
+        if (!$surat->final_pdf_path || !Storage::disk('public')->exists($surat->final_pdf_path)) {
+            return back()->with('error', 'File PDF final tidak ditemukan.');
+        }
+
+        return Storage::disk('public')->download($surat->final_pdf_path);
+    }
 }

--- a/app/Policies/SuratPolicy.php
+++ b/app/Policies/SuratPolicy.php
@@ -9,6 +9,28 @@ use Illuminate\Auth\Access\Response;
 class SuratPolicy
 {
     /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Surat $surat): bool
+    {
+        // Allow if the user is the creator, approver, or a disposition recipient
+        if ($user->id === $surat->pembuat_id || $user->id === $surat->penyetuju_id) {
+            return true;
+        }
+
+        return $surat->disposisi()->where('penerima_id', $user->id)->exists();
+    }
+
+    /**
+     * Determine whether the user can download the final PDF.
+     */
+    public function download(User $user, Surat $surat): bool
+    {
+        // The logic for viewing and downloading is the same.
+        return $this->view($user, $surat);
+    }
+
+    /**
      * Determine whether the user can delete the model.
      */
     public function delete(User $user, Surat $surat): bool

--- a/resources/views/suratkeluar/show.blade.php
+++ b/resources/views/suratkeluar/show.blade.php
@@ -78,7 +78,7 @@
                         <div class="bg-white p-6 rounded-lg shadow-xl text-center">
                             <h3 class="text-lg font-bold text-gray-800 mb-2">Dokumen Final</h3>
                             <p class="text-sm text-gray-500 mb-4">Surat telah disetujui dan PDF final telah dibuat.</p>
-                            <a href="{{ Storage::url($surat->final_pdf_path) }}" target="_blank" class="w-full inline-flex justify-center items-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-700">
+                            <a href="{{ route('surat-keluar.download', $surat) }}" class="w-full inline-flex justify-center items-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-700">
                                 <i class="fas fa-download mr-2"></i> Unduh PDF Final
                             </a>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -198,6 +198,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/{surat}', [\App\Http\Controllers\SuratKeluarController::class, 'show'])->name('show');
         Route::delete('/{surat}', [\App\Http\Controllers\SuratKeluarController::class, 'destroy'])->name('destroy');
         Route::post('/{surat}/approve', [\App\Http\Controllers\SuratKeluarController::class, 'approve'])->name('approve');
+        Route::get('/{surat}/download', [\App\Http\Controllers\SuratKeluarController::class, 'download'])->name('download');
     });
 
     // Routes for Incoming Letters & Dispositions


### PR DESCRIPTION
This commit resolves a 403 Forbidden error when downloading a finalized outgoing letter. The issue was identical to a previous bug with attachments, where a direct storage link was being used.

This patch implements a secure workflow for downloads:
- A `download` method has been added to `SuratPolicy` to authorize the action.
- A new route, `GET /surat-keluar/{surat}/download`, has been registered.
- A new `download` method in `SuratKeluarController` handles the authorization check and serves the file via `Storage::download()`.
- The `show` view has been updated to use this new secure route for the download button.