### PR TITLE
Feat: Add NIK to users and allow login via NIK

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -104,6 +104,7 @@ class UserController extends Controller
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'nik' => ['nullable', 'string', 'digits:16', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
             'jabatan_id' => ['nullable', Rule::exists('jabatans', 'id')->whereNull('user_id')],
             'is_kepala_unit' => ['nullable', 'boolean'],
@@ -215,6 +216,7 @@ class UserController extends Controller
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
+            'nik' => ['nullable', 'string', 'digits:16', Rule::unique('users', 'nik')->ignore($user->id)],
             'password' => ['nullable', 'confirmed', Rules\Password::defaults()],
             'jabatan_id' => ['nullable', 'exists:jabatans,id'],
             'is_kepala_unit' => ['nullable', 'boolean'],

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -92,7 +92,13 @@ class LoginRequest extends FormRequest
     {
         $identity = $this->input('identity');
 
-        $fieldName = filter_var($identity, FILTER_VALIDATE_EMAIL) ? 'email' : 'nip';
+        if (filter_var($identity, FILTER_VALIDATE_EMAIL)) {
+            $fieldName = 'email';
+        } elseif (is_numeric($identity) && strlen($identity) === 16) {
+            $fieldName = 'nik';
+        } else {
+            $fieldName = 'nip';
+        }
 
         return [
             $fieldName => $identity,

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -25,6 +25,12 @@ class ProfileUpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
+            'nik' => [
+                'nullable',
+                'string',
+                'digits:16',
+                Rule::unique(User::class, 'nik')->ignore($this->user()->id)
+            ],
             'signature_image' => ['nullable', 'image', 'mimes:png', 'max:1024'], // Max 1MB, PNG only
         ];
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,6 +55,7 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
+        'nik',
         'password',
         'role',
         'atasan_id',

--- a/database/migrations/2025_08_31_173000_add_nik_to_users_table.php
+++ b/database/migrations/2025_08_31_173000_add_nik_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('nik')->unique()->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('nik');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -174,7 +174,7 @@
         <x-auth-session-status class="mb-4" :status="session('status')" />
 
         <div class="input-group">
-          <input type="text" name="identity" placeholder="Email atau NIP" :value="old('identity')" required autofocus>
+          <input type="text" name="identity" placeholder="Email, NIK, atau NIP" :value="old('identity')" required autofocus>
           <i class="fas fa-user"></i>
           <x-input-error :messages="$errors->get('identity')" class="mt-2" />
         </div>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -46,6 +46,14 @@
         </div>
 
         <div>
+            <label for="nik" class="block font-semibold text-sm text-gray-700 mb-1">
+                <i class="fas fa-id-card mr-2 text-gray-500"></i> {{ __('NIK') }}
+            </label>
+            <input id="nik" name="nik" type="text" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" value="{{ old('nik', $user->nik) }}" autocomplete="off" />
+            @error('nik') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+        </div>
+
+        <div>
             <label for="signature_image" class="block font-semibold text-sm text-gray-700 mb-1">
                 <i class="fas fa-signature mr-2 text-gray-500"></i> {{ __('Gambar Tanda Tangan') }}
             </label>

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -37,6 +37,7 @@ function form_textarea($label, $name, $user, $is_required = false) {
         <h3 class="text-lg font-medium text-gray-900 border-b pb-2 mb-4">Informasi Pribadi</h3>
         {{ form_input('Nama Lengkap', 'name', $user, 'text', true) }}
         {{ form_input('Email', 'email', $user, 'email', true) }}
+        {{ form_input('NIK', 'nik', $user, 'text', false, 'placeholder="16 digit NIK"') }}
         {{ form_input('NIP', 'nip', $user, 'text', true) }}
         {{ form_input('Tempat Lahir', 'tempat_lahir', $user) }}
         {{ form_input('Tgl. Lahir', 'tgl_lahir', $user, 'text', true, 'placeholder="YYYY-MM-DD"') }}


### PR DESCRIPTION
This commit introduces a new feature allowing users to have a NIK (Nomor Induk Kependudukan) and to log in using it. It also includes a menu refactoring and a bug fix.

Feature: NIK Implementation
- Adds a `nik` column to the `users` table via a new migration.
- Updates the User model, controllers, and validation requests to handle the `nik` field.
- Adds a NIK input field to the user creation, edit, and profile forms.
- Modifies the authentication logic to accept email, NIK (16 digits), or NIP as the login identity.
- Updates the login page placeholder to "Email, NIK, atau NIP" to reflect this.

Refactor: Navigation Menu
- Moves "Surat Masuk" and "Surat Keluar" from the "Kerja" menu to a new, dedicated "Persuratan" menu for better organization.

Fix: User Creation Page
- Resolves a crash on the user creation page by ensuring the "Manage Leave Balance" button only appears on the edit page for existing users.