### PR TITLE
feat: Add classification CRUD and refactor mail navigation

### DIFF
--- a/app/Http/Controllers/Admin/KlasifikasiSuratController.php
+++ b/app/Http/Controllers/Admin/KlasifikasiSuratController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\KlasifikasiSurat;
+use Illuminate\Http\Request;
+
+class KlasifikasiSuratController extends Controller
+{
+    public function index()
+    {
+        $klasifikasi = KlasifikasiSurat::with('parent')->orderBy('kode')->paginate(20);
+        return view('admin.klasifikasi.index', compact('klasifikasi'));
+    }
+
+    public function create()
+    {
+        $parents = KlasifikasiSurat::orderBy('kode')->get();
+        return view('admin.klasifikasi.create', compact('parents'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'kode' => 'required|string|max:255|unique:klasifikasi_surat,kode',
+            'deskripsi' => 'required|string|max:255',
+            'parent_id' => 'nullable|exists:klasifikasi_surat,id',
+        ]);
+
+        KlasifikasiSurat::create($validated);
+
+        return redirect()->route('admin.klasifikasi.index')->with('success', 'Klasifikasi berhasil ditambahkan.');
+    }
+
+    public function edit(KlasifikasiSurat $klasifikasi)
+    {
+        $parents = KlasifikasiSurat::where('id', '!=', $klasifikasi->id)->orderBy('kode')->get();
+        return view('admin.klasifikasi.edit', compact('klasifikasi', 'parents'));
+    }
+
+    public function update(Request $request, KlasifikasiSurat $klasifikasi)
+    {
+        $validated = $request->validate([
+            'kode' => 'required|string|max:255|unique:klasifikasi_surat,kode,' . $klasifikasi->id,
+            'deskripsi' => 'required|string|max:255',
+            'parent_id' => 'nullable|exists:klasifikasi_surat,id',
+        ]);
+
+        $klasifikasi->update($validated);
+
+        return redirect()->route('admin.klasifikasi.index')->with('success', 'Klasifikasi berhasil diperbarui.');
+    }
+
+    public function destroy(KlasifikasiSurat $klasifikasi)
+    {
+        // Add a check to prevent deletion if it has children? For now, we allow it.
+        $klasifikasi->delete();
+        return redirect()->route('admin.klasifikasi.index')->with('success', 'Klasifikasi berhasil dihapus.');
+    }
+}

--- a/resources/views/admin/klasifikasi/create.blade.php
+++ b/resources/views/admin/klasifikasi/create.blade.php
@@ -1,0 +1,52 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Tambah Klasifikasi Surat Baru') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form action="{{ route('admin.klasifikasi.store') }}" method="POST">
+                        @csrf
+                        <div class="space-y-6">
+                            <div>
+                                <label for="kode" class="block font-semibold text-sm text-gray-700 mb-1">Kode Klasifikasi <span class="text-red-500">*</span></label>
+                                <input type="text" name="kode" id="kode" value="{{ old('kode') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                @error('kode') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+
+                            <div>
+                                <label for="deskripsi" class="block font-semibold text-sm text-gray-700 mb-1">Deskripsi <span class="text-red-500">*</span></label>
+                                <input type="text" name="deskripsi" id="deskripsi" value="{{ old('deskripsi') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                @error('deskripsi') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+
+                            <div>
+                                <label for="parent_id" class="block font-semibold text-sm text-gray-700 mb-1">Induk Klasifikasi (Opsional)</label>
+                                <select name="parent_id" id="parent_id" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">
+                                    <option value="">Tidak ada induk</option>
+                                    @foreach($parents as $parent)
+                                        <option value="{{ $parent->id }}" {{ old('parent_id') == $parent->id ? 'selected' : '' }}>
+                                            {{ $parent->kode }} - {{ $parent->deskripsi }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                @error('parent_id') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+                        </div>
+
+                        <div class="flex items-center justify-end mt-8 pt-6 border-t border-gray-200">
+                            <a href="{{ route('admin.klasifikasi.index') }}" class="text-sm font-medium text-gray-600 hover:text-gray-900 mr-4">Batal</a>
+                            <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md">
+                                Simpan
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/klasifikasi/edit.blade.php
+++ b/resources/views/admin/klasifikasi/edit.blade.php
@@ -1,0 +1,53 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Klasifikasi Surat') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form action="{{ route('admin.klasifikasi.update', $klasifikasi) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+                        <div class="space-y-6">
+                            <div>
+                                <label for="kode" class="block font-semibold text-sm text-gray-700 mb-1">Kode Klasifikasi <span class="text-red-500">*</span></label>
+                                <input type="text" name="kode" id="kode" value="{{ old('kode', $klasifikasi->kode) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                @error('kode') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+
+                            <div>
+                                <label for="deskripsi" class="block font-semibold text-sm text-gray-700 mb-1">Deskripsi <span class="text-red-500">*</span></label>
+                                <input type="text" name="deskripsi" id="deskripsi" value="{{ old('deskripsi', $klasifikasi->deskripsi) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                @error('deskripsi') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+
+                            <div>
+                                <label for="parent_id" class="block font-semibold text-sm text-gray-700 mb-1">Induk Klasifikasi (Opsional)</label>
+                                <select name="parent_id" id="parent_id" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">
+                                    <option value="">Tidak ada induk</option>
+                                    @foreach($parents as $parent)
+                                        <option value="{{ $parent->id }}" {{ old('parent_id', $klasifikasi->parent_id) == $parent->id ? 'selected' : '' }}>
+                                            {{ $parent->kode }} - {{ $parent->deskripsi }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                @error('parent_id') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                            </div>
+                        </div>
+
+                        <div class="flex items-center justify-end mt-8 pt-6 border-t border-gray-200">
+                            <a href="{{ route('admin.klasifikasi.index') }}" class="text-sm font-medium text-gray-600 hover:text-gray-900 mr-4">Batal</a>
+                            <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md">
+                                Perbarui
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/klasifikasi/index.blade.php
+++ b/resources/views/admin/klasifikasi/index.blade.php
@@ -1,0 +1,64 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Manajemen Klasifikasi Surat') }}
+            </h2>
+            <a href="{{ route('admin.klasifikasi.create') }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-semibold text-sm hover:bg-blue-700">
+                <i class="fas fa-plus mr-2"></i> Tambah Klasifikasi Baru
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    @if (session('success'))
+                        <div class="mb-4 bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+                            <span class="block sm:inline">{{ session('success') }}</span>
+                        </div>
+                    @endif
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Kode</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Deskripsi</th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Induk</th>
+                                    <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Aksi</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($klasifikasi as $item)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $item->kode }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-800">{{ $item->deskripsi }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $item->parent->kode ?? '-' }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                            <a href="{{ route('admin.klasifikasi.edit', $item) }}" class="text-indigo-600 hover:text-indigo-900">Edit</a>
+                                            <form action="{{ route('admin.klasifikasi.destroy', $item) }}" method="POST" class="inline-block ml-4" onsubmit="return confirm('Yakin ingin menghapus klasifikasi ini?');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="text-red-600 hover:text-red-900">Hapus</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-12 text-center text-gray-500">Tidak ada data klasifikasi.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="mt-6">
+                        {{ $klasifikasi->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -45,11 +45,33 @@ if (count($words) >= 2) {
                                 <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
                                     <x-dropdown-link :href="route('global.dashboard')" :active="request()->routeIs('global.dashboard')">Daftar Kegiatan</x-dropdown-link>
                                     <div class="border-t border-gray-200"></div>
+                                    <x-dropdown-link :href="route('adhoc-tasks.index')" :active="request()->routeIs('adhoc-tasks.*')">Tugas Harian</x-dropdown-link>
+                                    <x-dropdown-link :href="route('special-assignments.index')" :active="request()->routeIs('special-assignments.*')">SK Penugasan</x-dropdown-link>
+                                </div>
+                            </x-slot>
+                        </x-dropdown>
+                    </div>
+
+                    {{-- Dropdown Persuratan --}}
+                    <div class="hidden sm:flex sm:items-center">
+                        <x-dropdown align="left" width="60">
+                            <x-slot name="trigger">
+                                <button class="inline-flex items-center h-full px-3 py-2 border-b-2 text-sm font-medium leading-5 transition duration-150 ease-in-out
+                                    {{ request()->routeIs(['surat-masuk.*', 'surat-keluar.*', 'templatesurat.*', 'admin.klasifikasi.*'])
+                                        ? 'border-yellow-300 text-white bg-green-700/50'
+                                        : 'border-transparent text-white hover:text-yellow-300 hover:border-yellow-300/75 focus:outline-none focus:text-white focus:border-yellow-300/75' }}">
+                                    <div><i class="fas fa-envelope-open-text mr-2"></i>Persuratan</div>
+                                    <div class="ms-1"><svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" /></svg></div>
+                                </button>
+                            </x-slot>
+                            <x-slot name="content">
+                                <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
                                     <x-dropdown-link :href="route('surat-masuk.index')" :active="request()->routeIs('surat-masuk.*')">Surat Masuk</x-dropdown-link>
                                     <x-dropdown-link :href="route('surat-keluar.index')" :active="request()->routeIs('surat-keluar.*')">Surat Keluar</x-dropdown-link>
                                     <div class="border-t border-gray-200"></div>
-                                    <x-dropdown-link :href="route('adhoc-tasks.index')" :active="request()->routeIs('adhoc-tasks.*')">Tugas Harian</x-dropdown-link>
-                                    <x-dropdown-link :href="route('special-assignments.index')" :active="request()->routeIs('special-assignments.*')">SK Penugasan</x-dropdown-link>
+                                    <x-dropdown-link :href="route('templatesurat.index')" :active="request()->routeIs('templatesurat.*')">Template Surat</x-dropdown-link>
+                                    <x-dropdown-link :href="route('admin.klasifikasi.index')" :active="request()->routeIs('admin.klasifikasi.*')">Manajemen Klasifikasi</x-dropdown-link>
+                                    <x-dropdown-link href="#">Arsip Digital</x-dropdown-link> {{-- Placeholder --}}
                                 </div>
                             </x-slot>
                         </x-dropdown>
@@ -130,9 +152,6 @@ if (count($words) >= 2) {
                                 <x-slot name="content">
                                      <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
                                         <x-dropdown-link :href="route('admin.settings.index')" :active="request()->routeIs('admin.settings.*')">Pengaturan Umum</x-dropdown-link>
-                                        <div class="border-t border-gray-200"></div>
-                                        <x-dropdown-link :href="route('templatesurat.index')" :active="request()->routeIs('templatesurat.*')">Manajemen Template Surat</x-dropdown-link>
-                                        <div class="border-t border-gray-200"></div>
                                         @if(Auth::user()->canManageLeaveSettings())
                                             <x-dropdown-link :href="route('admin.approval-workflows.index')" :active="request()->routeIs('admin.approval-workflows.*')">Manajemen Alur Persetujuan</x-dropdown-link>
                                             <x-dropdown-link :href="route('admin.cuti-bersama.index')" :active="request()->routeIs('admin.cuti-bersama.*')">Manajemen Cuti Bersama</x-dropdown-link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -255,6 +255,10 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     // General Settings
     Route::get('settings', [\App\Http\Controllers\Admin\SettingController::class, 'index'])->name('settings.index');
     Route::post('settings', [\App\Http\Controllers\Admin\SettingController::class, 'update'])->name('settings.update');
+
+    // Classification Management
+    Route::resource('klasifikasi', \App\Http\Controllers\Admin\KlasifikasiSuratController::class)->names('klasifikasi');
+
     Route::post('api_keys/{client}/tokens', [ApiKeyController::class, 'generateToken'])->name('api_keys.tokens.store');
     Route::delete('api_keys/{client}/tokens/{tokenId}', [ApiKeyController::class, 'revokeToken'])->name('api_keys.tokens.destroy');
     Route::patch('api_keys/{client}/status', [ApiKeyController::class, 'update'])->name('api_keys.status.update');


### PR DESCRIPTION
This commit refactors the main navigation and adds a new CRUD for mail classifications.

- A new 'Persuratan' (Mail) dropdown menu has been added to the main navigation to centralize all mail-related features.
- Existing links for Incoming Mail, Outgoing Mail, and Templates have been moved into this new menu.
- A full CRUD (Create, Read, Update, Delete) interface has been created for managing 'Klasifikasi Surat' (Mail Classifications). This includes the controller, routes, and views.
- The new classification management page is now accessible from the 'Persuratan' menu.