### PR TITLE
fix: Hide leave balance link on user creation page

### DIFF
--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -121,12 +121,14 @@ function form_textarea($label, $name, $user, $is_required = false) {
             <p class="mt-1 text-xs text-gray-500 ml-6">Menetapkan pengguna ini sebagai kepala dari unit kerja mereka saat ini.</p>
         </div>
 
+        @if ($user->exists)
         <div class="mb-4">
             <a href="{{ route('admin.users.leave-balance.edit', $user) }}" class="inline-flex items-center px-4 py-2 bg-slate-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-slate-700">
                 <i class="fas fa-calculator mr-2"></i> Atur Saldo Cuti
             </a>
             <p class="mt-1 text-xs text-gray-500">Mengatur sisa cuti tahunan dari tahun sebelumnya secara manual.</p>
         </div>
+        @endif
         @endcan
 
         <div class="mb-4">


### PR DESCRIPTION
The "Manage Leave Balance" link was causing a fatal error on the user creation page because it requires a user ID that doesn't exist yet. This commit wraps the link in a conditional to ensure it only appears on the user edit page.