### PR TITLE
Fix: Remove duplicate 'use' statement in web.php

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -302,14 +302,11 @@ Route::middleware(['auth', 'can.manage.leave.settings'])->prefix('admin')->name(
 Route::get('/api/units/{unit}/vacant-jabatans', [UnitController::class, 'getVacantJabatans'])->name('api.units.vacant-jabatans')->middleware('auth');
 Route::get('/api/units/{unit}/users', [UserController::class, 'getUsersByUnitFromModel'])->name('api.units.users')->middleware('auth');
 
-use App\Http\Controllers\PerformanceSettingController;
-use Illuminate\Support\Facades\Route;
-
 Route::middleware(['web', 'auth'])->group(function () {
     Route::prefix('admin/performance-settings')
          ->as('admin.performance_settings.')
          ->group(function () {
-             Route::get('/', [PerformanceSettingController::class, 'index'])->name('index');
-             Route::post('/', [PerformanceSettingController::class, 'update'])->name('update');
+             Route::get('/', [\App\Http\Controllers\PerformanceSettingController::class, 'index'])->name('index');
+             Route::post('/', [\App\Http\Controllers\PerformanceSettingController::class, 'update'])->name('update');
          });
 });


### PR DESCRIPTION
This commit removes a redundant `use Illuminate\Support\Facades\Route;` statement that was incorrectly added to the middle of the `routes/web.php` file.

This duplicate declaration caused a fatal PHP error when running `php artisan` commands, preventing the application from booting correctly.