### PR TITLE
Fix: Refactor OrganizationalDataImporterService to use dynamic roles.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,89 @@
+# Dokumentasi Teknis Aplikasi Tasmen
+
+Dokumen ini menjelaskan aspek teknis dari fitur-fitur baru dan yang telah dimodifikasi untuk meningkatkan fleksibilitas dan modularitas aplikasi.
+
+## 1. Struktur Database Dinamis
+
+Beberapa logika bisnis yang sebelumnya di-hardcode kini telah dipindahkan ke dalam database. Berikut adalah rincian tabel-tabel baru yang mengelola konfigurasi ini.
+
+### `performance_settings`
+Tabel ini menyimpan berbagai parameter yang digunakan dalam perhitungan kinerja (IKI/NKF) dan beban kerja.
+
+- **Struktur:**
+  - `id`: Primary Key
+  - `key` (string, unique): Pengenal unik untuk pengaturan (misal: `manager_weights`, `efficiency_cap`).
+  - `value` (json): Nilai dari pengaturan, disimpan dalam format JSON untuk fleksibilitas.
+- **Contoh Keys:**
+  - `manager_weights`: Menyimpan bobot manajerial untuk setiap peran.
+  - `efficiency_cap`: Menyimpan batas minimum dan maksimum untuk faktor efisiensi.
+  - `rating_thresholds`: Menyimpan ambang batas untuk predikat kinerja (misal: 'excellent', 'satisfactory').
+  - `weekly_workload_thresholds`: Menyimpan ambang batas untuk visualisasi beban kerja mingguan.
+
+### `roles`
+Menggantikan sistem peran berbasis string. Tabel ini mendefinisikan peran pengguna dan atributnya.
+
+- **Struktur:**
+  - `id`: Primary Key
+  - `name` (string, unique): Nama sistem untuk peran (misal: `eselon_i`, `staf`).
+  - `label` (string): Nama yang ditampilkan di UI (misal: "Eselon I", "Staf").
+  - `managerial_weight` (decimal): Bobot antara 0.00 dan 1.00 yang digunakan dalam perhitungan NKF pimpinan.
+- **Relasi:** Terhubung ke tabel `users` melalui `role_id`.
+
+### `task_statuses`
+Menyimpan daftar status yang dapat dimiliki oleh sebuah tugas.
+
+- **Struktur:**
+  - `id`: Primary Key
+  - `key` (string, unique): Pengenal unik untuk status (misal: `in_progress`).
+  - `label` (string): Nama yang ditampilkan di UI (misal: "Dalam Proses").
+- **Relasi:** Terhubung ke tabel `tasks` melalui `task_status_id`.
+
+### `priority_levels`
+Menyimpan daftar level prioritas untuk tugas.
+
+- **Struktur:**
+  - `id`: Primary Key
+  - `key` (string, unique): Pengenal unik untuk prioritas (misal: `high`).
+  - `label` (string): Nama yang ditampilkan di UI (misal: "Tinggi").
+  - `weight` (integer): Bobot numerik yang merepresentasikan tingkat prioritas.
+- **Relasi:** Terhubung ke tabel `tasks` melalui `priority_level_id`.
+
+### `notification_templates`
+Menyimpan template untuk konten notifikasi (email, database, dll).
+
+- **Struktur:**
+  - `id`: Primary Key
+  - `key` (string, unique): Pengenal unik untuk template (misal: `task_assigned`).
+  - `subject` (string): Judul/subjek notifikasi.
+  - `body` (text): Isi notifikasi dengan placeholder (misal: `{{user_name}}`).
+  - `description` (text): Penjelasan tentang template dan placeholder yang tersedia.
+
+### `job_types` & `workload_components` (Modul ABK)
+Tabel-tabel ini membentuk dasar dari Modul Analisis Beban Kerja (ABK).
+
+- **`job_types`:**
+  - `id`: Primary Key
+  - `name` (string): Nama jabatan atau jenis pekerjaan utama.
+- **`workload_components`:**
+  - `id`: Primary Key
+  - `job_type_id`: Foreign key ke `job_types`.
+  - `name` (string): Uraian dari komponen pekerjaan.
+  - `volume` (integer): Jumlah output yang dihasilkan per tahun.
+  - `output_unit` (string): Satuan dari output (misal: "dokumen", "laporan").
+  - `time_norm` (decimal): Waktu standar (dalam jam) yang dibutuhkan untuk menyelesaikan satu unit output.
+
+---
+
+## 2. Antarmuka Pengelolaan Admin
+
+Untuk setiap tabel master di atas, telah dibuat antarmuka pengguna (UI) di dalam area Admin untuk melakukan operasi CRUD (Create, Read, Update, Delete). Ini memungkinkan administrator untuk mengkonfigurasi perilaku aplikasi secara langsung tanpa perlu mengubah kode.
+
+Lokasi UI:
+- `/admin/performance-settings`
+- `/admin/roles`
+- `/admin/task-statuses`
+- `/admin/priority-levels`
+- `/admin/notification-templates`
+- `/admin/abk`
+
+Setiap halaman dilindungi oleh `Gate::authorize('manage_settings')` untuk memastikan hanya pengguna yang berwenang yang dapat mengaksesnya.

--- a/app/Services/OrganizationalDataImporterService.php
+++ b/app/Services/OrganizationalDataImporterService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\User;
 use App\Models\Unit;
 use App\Models\Jabatan;
+use App\Models\Role;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
@@ -14,11 +15,14 @@ class OrganizationalDataImporterService
 {
     private $unitCache = [];
     private $userCache = [];
+    private $roleCache = [];
     private $command;
 
     public function __construct($command = null)
     {
         $this->command = $command;
+        // Cache roles on construction
+        $this->roleCache = Role::pluck('id', 'name')->toArray();
     }
 
     public function processData(array $data): void
@@ -28,7 +32,6 @@ class OrganizationalDataImporterService
             $this->command->getOutput()->progressStart(count($data));
         }
 
-        // Cache existing users to avoid re-hashing passwords on updates.
         $this->userCache = User::pluck('id', 'nip')->toArray();
         $this->unitCache = Unit::pluck('id', 'name')->toArray();
 
@@ -46,8 +49,6 @@ class OrganizationalDataImporterService
             }
         }
         
-        // After all units and users are created, we can safely update supervisors
-        // without worrying about a recursive loop during the creation process.
         $this->updateSupervisorForAllUsers();
         Unit::rebuildPaths();
 
@@ -59,30 +60,27 @@ class OrganizationalDataImporterService
 
     private function processItem(object $item): void
     {
-        // 1. Get or Create Unit
         $unit = $this->getOrCreateUnit($item);
         if (!$unit) {
             $this->logInfo('Skipping item due to missing unit information for NIP: ' . $item->NIP);
             return;
         }
 
-        // 2. Determine Role
-        $role = $this->determineRole($item, $unit);
+        $roleName = $this->determineRoleName($item, $unit);
+        $roleId = $this->roleCache[$roleName] ?? null;
 
-        // 3. Prepare User Data
-        $userData = $this->prepareUserData($item, $unit->id, $role);
+        if (!$roleId) {
+            $this->logError("Could not find role ID for role name '{$roleName}'. Skipping user.");
+            return;
+        }
 
-        // 4. Update or Create User
-        $user = User::updateOrCreate(
-            ['nip' => $item->NIP],
-            $userData
-        );
+        $userData = $this->prepareUserData($item, $unit->id, $roleId);
 
-        // 5. Get or Create Jabatan and link to User
-        $this->getOrCreateJabatan($item, $unit->id, $user->id, $role);
+        $user = User::updateOrCreate(['nip' => $item->NIP], $userData);
 
-        // 6. If user is a structural head, update the unit
-        if ($this->isStructuralHead($role)) {
+        $this->getOrCreateJabatan($item, $unit->id, $user->id);
+
+        if ($this->isStructuralHead($roleName)) {
             $unit->kepala_unit_id = $user->id;
             $unit->save();
         }
@@ -94,7 +92,6 @@ class OrganizationalDataImporterService
             'Unit Kerja Eselon I', 'Unit Kerja Eselon II',
             'Unit Kerja Koordinator', 'Unit Kerja Sub Koordinator'
         ];
-
         $parentUnitId = null;
         $lastUnit = null;
 
@@ -117,35 +114,32 @@ class OrganizationalDataImporterService
         return $lastUnit;
     }
 
-    private function determineRole(object $item, Unit $unit): string
+    private function determineRoleName(object $item, Unit $unit): string
     {
-        // Priority 1: Use the explicit "Eselon" field if it's a structural one.
         if (!empty($item->Eselon)) {
-            $role = match ($item->Eselon) {
-                '1-A' => User::ROLE_ESELON_I,
-                '2-A' => User::ROLE_ESELON_II,
-                '3-A' => User::ROLE_KOORDINATOR,
-                '4-A' => User::ROLE_SUB_KOORDINATOR,
-                default => null, // Not a recognized structural eselon, so we'll ignore it.
+            $roleName = match ($item->Eselon) {
+                '1-A' => 'eselon_i',
+                '2-A' => 'eselon_ii',
+                '3-A' => 'koordinator',
+                '4-A' => 'sub_koordinator',
+                default => null,
             };
-            if ($role) {
-                return $role;
+            if ($roleName) {
+                return $roleName;
             }
         }
 
-        // Priority 2: Infer the role from the depth of the unit for functional staff
-        // or structural staff without a clear Eselon mapping.
         $depth = $unit->ancestors()->count();
         return match ($depth) {
-            1 => User::ROLE_ESELON_I,
-            2 => User::ROLE_ESELON_II,
-            3 => User::ROLE_KOORDINATOR,
-            4 => User::ROLE_SUB_KOORDINATOR,
-            default => User::ROLE_STAF,
+            1 => 'eselon_i',
+            2 => 'eselon_ii',
+            3 => 'koordinator',
+            4 => 'sub_koordinator',
+            default => 'staf',
         };
     }
 
-    private function prepareUserData(object $item, int $unitId, string $role): array
+    private function prepareUserData(object $item, int $unitId, int $roleId): array
     {
         $baseEmail = strtolower(str_replace(' ', '.', preg_replace('/[^a-zA-Z0-9\s]/', '', $item->Nama))) . '@example.com';
         $email = $baseEmail;
@@ -159,7 +153,7 @@ class OrganizationalDataImporterService
             'name' => $item->Nama,
             'email' => $item->email ?? $email,
             'unit_id' => $unitId,
-            'role' => $role,
+            'role_id' => $roleId,
             'status' => 'active',
             'tempat_lahir' => $item->{'Tempat Lahir'},
             'alamat' => $item->Alamat,
@@ -177,12 +171,10 @@ class OrganizationalDataImporterService
             'jenis_jabatan' => $item->{'Jenis Jabatan'},
         ];
 
-        // Add password only if creating a new user
         if (!isset($this->userCache[$item->NIP])) {
             $data['password'] = Hash::make('password');
         }
 
-        // Convert date formats
         $dateFields = [
             'tgl_lahir' => 'Tgl. Lahir',
             'tmt_eselon' => 'TMT ESELON',
@@ -204,29 +196,24 @@ class OrganizationalDataImporterService
         return $data;
     }
 
-    private function getOrCreateJabatan(object $item, int $unitId, int $userId, string $role): Jabatan
+    private function getOrCreateJabatan(object $item, int $unitId, int $userId): Jabatan
     {
         $jabatanName = $item->Jabatan;
         if (empty($jabatanName)) {
             $this->logError("Skipping Jabatan creation for User ID: {$userId} due to empty Jabatan name.");
-            // Create a default placeholder Jabatan to avoid crashes downstream
             return Jabatan::firstOrCreate(
                 ['user_id' => $userId],
                 ['name' => 'Jabatan Belum Diatur', 'unit_id' => $unitId]
             );
         }
 
-        // First, check if this specific user is already in a Jabatan with this name/unit.
         $existingJabatan = Jabatan::where('name', 'like', $jabatanName)
                                 ->where('unit_id', $unitId)
                                 ->where('user_id', $userId)
                                 ->first();
 
-        if ($existingJabatan) {
-            return $existingJabatan;
-        }
+        if ($existingJabatan) return $existingJabatan;
 
-        // The user is not in this Jabatan. Let's see if there's a vacant one.
         $vacantJabatan = Jabatan::where('name', 'like', $jabatanName)
                                ->where('unit_id', $unitId)
                                ->whereNull('user_id')
@@ -238,7 +225,6 @@ class OrganizationalDataImporterService
             return $vacantJabatan;
         }
 
-        // No vacant slots found. We must create a new Jabatan slot for this user.
         return Jabatan::create([
             'name'      => $jabatanName,
             'unit_id'   => $unitId,
@@ -246,21 +232,16 @@ class OrganizationalDataImporterService
         ]);
     }
 
-    private function isStructuralHead(string $role): bool
+    private function isStructuralHead(string $roleName): bool
     {
-        return in_array($role, [
-            User::ROLE_MENTERI,
-            User::ROLE_ESELON_I,
-            User::ROLE_ESELON_II,
-            User::ROLE_KOORDINATOR,
-            User::ROLE_SUB_KOORDINATOR
+        return in_array($roleName, [
+            'menteri', 'eselon_i', 'eselon_ii', 'koordinator', 'sub_koordinator'
         ]);
     }
 
     private function updateSupervisorForAllUsers(): void
     {
         $this->logInfo('Updating supervisor relationships...');
-        // Eager load units to reduce queries and find all unit heads first.
         $users = User::with('unit.parentUnit')->get();
         $unitHeads = Unit::whereNotNull('kepala_unit_id')->pluck('kepala_unit_id', 'id')->toArray();
         $updates = [];
@@ -269,13 +250,9 @@ class OrganizationalDataImporterService
             if (!$user->unit) continue;
 
             $supervisorId = null;
-
-            // Find the head of the user's own unit
             if (isset($unitHeads[$user->unit->id]) && $unitHeads[$user->unit->id] !== $user->id) {
-                // If there is a head of this unit, and it's not the user themselves, that's the supervisor.
                 $supervisorId = $unitHeads[$user->unit->id];
             } elseif ($user->unit->parentUnit && isset($unitHeads[$user->unit->parentUnit->id])) {
-                // Otherwise, the supervisor is the head of the parent unit.
                 $supervisorId = $unitHeads[$user->unit->parentUnit->id];
             }
 


### PR DESCRIPTION
This commit fixes a fatal error that occurred during database seeding (`db:seed`). The error was caused by the `OrganizationalDataImporterService` still using hard-coded role constants (e.g., `User::ROLE_ESELON_I`) that were removed in a previous refactoring.

The service has been updated to:
- Determine a role 'name' (e.g., 'eselon_i') instead of a constant.
- Use a cached list of roles from the `roles` table to find the correct `role_id`.
- Assign the `role_id` to new or updated users, aligning the seeder with the new dynamic role system.