### PR TITLE
Fix: Correct logic in TimeLogSeeder to handle new status relationship.

### DIFF
--- a/database/seeders/TimeLogSeeder.php
+++ b/database/seeders/TimeLogSeeder.php
@@ -34,7 +34,7 @@ class TimeLogSeeder extends Seeder
             }
 
             // Jangan buat log untuk tugas yang belum dimulai
-            if ($task->status === 'pending' || $task->progress === 0) {
+            if (!$task->status || $task->status->key === 'pending' || $task->progress === 0) {
                 continue;
             }
 


### PR DESCRIPTION
The `TimeLogSeeder` was failing to create any time logs because it was checking for task status using the old property access (`$task->status === 'pending'`). After the refactoring, `$task->status` is now a relationship object.

This commit updates the seeder to check the status correctly using the relationship's key (`$task->status->key === 'pending'`). This ensures that the seeder can now correctly identify tasks that are in progress and create the appropriate time log data for them.