### PR TITLE
Fix: Resolve seeder error by dropping legacy columns.

### DIFF
--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -20,9 +20,6 @@ class Task extends Model
         'estimated_hours',
         'task_status_id',
         'priority_level_id',
-        // Keep old columns for data migration, they will be dropped later
-        'status',
-        'priority',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_09_01_225730_drop_old_status_priority_columns_from_tasks_table.php
+++ b/database/migrations/2025_09_01_225730_drop_old_status_priority_columns_from_tasks_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // This migration assumes the data has already been migrated to the new columns
+        // in the 2025_09_01_191500_alter_tasks_table_add_status_and_priority_ids.php migration.
+        Schema::table('tasks', function (Blueprint $table) {
+            if (Schema::hasColumn('tasks', 'status')) {
+                $table->dropColumn('status');
+            }
+            if (Schema::hasColumn('tasks', 'priority')) {
+                $table->dropColumn('priority');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->string('status')->nullable();
+            $table->string('priority')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
This commit fixes a fatal error (`Attempt to read property "key" on string`) that occurred in the `TimeLogSeeder`.

The root cause was a conflict between the old `status` string column on the `tasks` table and the new `status()` relationship method on the `Task` model. Laravel's magic property access was retrieving the string from the column instead of the relationship object.

This has been resolved by:
1.  Creating a new migration to permanently drop the old `status` and `priority` columns from the `tasks` table.
2.  Removing `status` and `priority` from the `$fillable` array in the `Task` model.

This ensures that the `status` and `priority` properties on a Task instance will now always correctly resolve to their respective relationship objects, allowing the seeders to run successfully.