### PR TITLE
Fix: Resolve undefined column 'status' error in ExecutiveSummaryContr…

### DIFF
--- a/app/Http/Controllers/ExecutiveSummaryController.php
+++ b/app/Http/Controllers/ExecutiveSummaryController.php
@@ -169,12 +169,14 @@ class ExecutiveSummaryController extends Controller
             $labels[] = $date->format('M Y');
             
             // --- Kalkulasi Progres ---
+            $completedStatusId = \App\Models\TaskStatus::where('key', 'completed')->value('id');
+
             $totalTasks = Task::whereIn('project_id', $projectIds)
                               ->where('created_at', '<=', $date)
                               ->count();
                               
             $completedTasks = Task::whereIn('project_id', $projectIds)
-                                  ->where('status', 'completed')
+                                  ->where('task_status_id', $completedStatusId)
                                   ->where('updated_at', '<=', $date)
                                   ->count();
 


### PR DESCRIPTION
…oller.

This commit fixes a runtime QueryException that occurred when viewing the executive summary page. The error was caused by the `getPerformanceTrends` method still querying the old, now-deleted `status` column on the `tasks` table.

The query has been updated to use the new `task_status_id` foreign key, fetching the ID for the 'completed' status from the `task_statuses` table first. This aligns the controller with the new dynamic status system and resolves the final known bug.