### PR TITLE
Fix: Remove dead link to deleted route from navigation menu.

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -152,7 +152,6 @@ if (count($words) >= 2) {
                                 <x-slot name="content">
                                      <div class="rounded-xl shadow-2xl py-1 bg-white ring-1 ring-black ring-opacity-10">
                                         <x-dropdown-link :href="route('admin.settings.index')" :active="request()->routeIs('admin.settings.index')">Pengaturan Umum</x-dropdown-link>
-                                        <x-dropdown-link :href="route('admin.settings.formulas')" :active="request()->routeIs('admin.settings.formulas')">Pengaturan Rumus</x-dropdown-link>
                                         <div class="border-t border-gray-200"></div>
                                         @if(Auth::user()->canManageLeaveSettings())
                                             <x-dropdown-link :href="route('admin.approval-workflows.index')" :active="request()->routeIs('admin.approval-workflows.*')">Manajemen Alur Persetujuan</x-dropdown-link>


### PR DESCRIPTION
This commit resolves a `RouteNotFoundException` for the route `admin.settings.formulas`.

This error occurred because the route was deleted in a previous refactoring, but the link to it in the main navigation layout (`navigation.blade.php`) was not removed.

This patch removes the dead link from the admin settings dropdown menu, fixing the error and ensuring UI consistency.