### PR TITLE
Refactor: Make PeminjamanRequest status dynamic.

### DIFF
--- a/app/Http/Controllers/GlobalDashboardController.php
+++ b/app/Http/Controllers/GlobalDashboardController.php
@@ -51,9 +51,10 @@ class GlobalDashboardController extends Controller
         ];
 
         if (!$currentUser->isStaff()) {
+            $pendingStatusId = \App\Models\PeminjamanRequestStatus::where('key', 'pending')->value('id');
             $stats['total_users'] = (clone $userQuery)->count();
             $stats['active_users'] = (clone $userQuery)->where('status', 'active')->count();
-            $stats['pending_requests'] = PeminjamanRequest::where('status', 'pending')
+            $stats['pending_requests'] = PeminjamanRequest::where('status_id', $pendingStatusId)
                                         ->whereIn('approver_id', (clone $userQuery)->pluck('id'))
                                         ->count();
         }

--- a/app/Models/PeminjamanRequest.php
+++ b/app/Models/PeminjamanRequest.php
@@ -15,11 +15,18 @@ class PeminjamanRequest extends Model
         'requester_id',
         'requested_user_id',
         'approver_id',
-        'status',
+        'status_id',
         'message',
         'rejection_reason',
         'due_date',
     ];
+
+    protected $with = ['status'];
+
+    public function status(): BelongsTo
+    {
+        return $this->belongsTo(PeminjamanRequestStatus::class, 'status_id');
+    }
 
     public function project(): BelongsTo
     {

--- a/app/Models/PeminjamanRequestStatus.php
+++ b/app/Models/PeminjamanRequestStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PeminjamanRequestStatus extends Model
+{
+    use HasFactory;
+
+    protected $table = 'peminjaman_request_statuses';
+    protected $fillable = ['key', 'label'];
+
+    public function peminjamanRequests()
+    {
+        return $this->hasMany(PeminjamanRequest::class, 'status_id');
+    }
+}

--- a/database/migrations/2025_09_02_000840_create_peminjaman_request_statuses_table.php
+++ b/database/migrations/2025_09_02_000840_create_peminjaman_request_statuses_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('peminjaman_request_statuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('label');
+            $table->timestamps();
+        });
+
+        DB::table('peminjaman_request_statuses')->insert([
+            ['key' => 'pending', 'label' => 'Pending', 'created_at' => now(), 'updated_at' => now()],
+            ['key' => 'approved', 'label' => 'Approved', 'created_at' => now(), 'updated_at' => now()],
+            ['key' => 'rejected', 'label' => 'Rejected', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('peminjaman_request_statuses');
+    }
+};

--- a/database/migrations/2025_09_02_000930_alter_peminjaman_requests_table_add_status_id.php
+++ b/database/migrations/2025_09_02_000930_alter_peminjaman_requests_table_add_status_id.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use App\Models\PeminjamanRequest;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('peminjaman_requests', function (Blueprint $table) {
+            $table->foreignId('status_id')->nullable()->after('status')->constrained('peminjaman_request_statuses');
+        });
+
+        // Data migration
+        $statuses = DB::table('peminjaman_request_statuses')->pluck('id', 'key');
+        PeminjamanRequest::all()->each(function ($request) use ($statuses) {
+            $statusId = $statuses[strtolower($request->status)] ?? null;
+            if ($statusId) {
+                $request->update(['status_id' => $statusId]);
+            }
+        });
+
+        // Make the new column not nullable and drop the old one
+        Schema::table('peminjaman_requests', function (Blueprint $table) {
+            $table->foreignId('status_id')->nullable(false)->change();
+            $table->dropColumn('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('peminjaman_requests', function (Blueprint $table) {
+            $table->enum('status', ['pending', 'approved', 'rejected'])->default('pending')->after('status_id');
+        });
+
+        // Restore old data
+        $statuses = DB::table('peminjaman_request_statuses')->pluck('key', 'id');
+        PeminjamanRequest::all()->each(function ($request) use ($statuses) {
+            $statusKey = $statuses[$request->status_id] ?? 'pending';
+            $request->update(['status' => $statusKey]);
+        });
+
+        Schema::table('peminjaman_requests', function (Blueprint $table) {
+            $table->dropForeign(['status_id']);
+            $table->dropColumn('status_id');
+        });
+    }
+};


### PR DESCRIPTION
This commit refactors the status system for the `PeminjamanRequest` model to be database-driven, removing the hard-coded enum column.

This is part of a larger effort to make all status-like fields in the application dynamic and configurable.

Changes:
- Created a `peminjaman_request_statuses` table and `PeminjamanRequestStatus` model.
- Created a migration to alter the `peminjaman_requests` table, adding a `status_id` foreign key, migrating existing data, and dropping the old `status` column.
- Refactored the `PeminjamanRequest` model to use the new relationship.
- Updated `PeminjamanRequestController` and `GlobalDashboardController` to use the new `status_id` for all queries and logic.