### PR TITLE
Fix: Resolve error in task card component by using status relationship.

### DIFF
--- a/database/migrations/2025_09_01_191430_create_task_statuses_table.php
+++ b/database/migrations/2025_09_01_191430_create_task_statuses_table.php
@@ -13,15 +13,16 @@ return new class extends Migration
             $table->id();
             $table->string('key')->unique();
             $table->string('label');
+            $table->string('color_class')->default('bg-gray-100 text-gray-800');
             $table->timestamps();
         });
 
         DB::table('task_statuses')->insert([
-            ['key' => 'pending', 'label' => 'Pending', 'created_at' => now(), 'updated_at' => now()],
-            ['key' => 'in_progress', 'label' => 'In Progress', 'created_at' => now(), 'updated_at' => now()],
-            ['key' => 'for_review', 'label' => 'For Review', 'created_at' => now(), 'updated_at' => now()],
-            ['key' => 'completed', 'label' => 'Completed', 'created_at' => now(), 'updated_at' => now()],
-            ['key' => 'cancelled', 'label' => 'Cancelled', 'created_at' => now(), 'updated_at' => now()],
+            ['key' => 'pending', 'label' => 'Pending', 'color_class' => 'bg-yellow-100 text-yellow-800', 'created_at' => now(), 'updated_at' => now()],
+            ['key' => 'in_progress', 'label' => 'In Progress', 'color_class' => 'bg-blue-100 text-blue-800', 'created_at' => now(), 'updated_at' => now()],
+            ['key' => 'for_review', 'label' => 'For Review', 'color_class' => 'bg-orange-100 text-orange-800', 'created_at' => now(), 'updated_at' => now()],
+            ['key' => 'completed', 'label' => 'Completed', 'color_class' => 'bg-green-100 text-green-800', 'created_at' => now(), 'updated_at' => now()],
+            ['key' => 'cancelled', 'label' => 'Cancelled', 'color_class' => 'bg-gray-100 text-gray-800', 'created_at' => now(), 'updated_at' => now()],
         ]);
     }
 

--- a/resources/views/components/task-card.blade.php
+++ b/resources/views/components/task-card.blade.php
@@ -18,9 +18,9 @@
             </p>
         </div>
         <div class="flex items-center space-x-2 flex-shrink-0">
-            <span class="badge-status text-xs font-semibold px-3 py-1 rounded-full {{ $task->status_color_class }}">{{ \Illuminate\Support\Str::title(str_replace('_', ' ', $task->status)) }}</span>
+            <span class="badge-status text-xs font-semibold px-3 py-1 rounded-full {{ $task->status->color_class ?? 'bg-gray-100 text-gray-800' }}">{{ $task->status->label ?? 'N/A' }}</span>
             @can('update', $task)
-                @if ($task->status !== 'completed')
+                @if ($task->status->key !== 'completed')
                     <button @click.prevent="quickComplete({{ $task->id }})" title="Tandai Selesai" class="inline-flex items-center justify-center h-6 w-6 text-xs font-semibold text-green-800 bg-green-100 rounded-full hover:bg-green-200 transition-colors">
                         <i class="fas fa-check"></i>
                     </button>
@@ -42,7 +42,7 @@
         <div class="flex justify-between mb-1 items-center">
             <span class="text-base font-medium text-blue-700">Progress</span>
             <div>
-                @if($task->status === 'for_review')
+                @if($task->status->key === 'for_review')
                     <span class="px-2 py-1 text-xs font-semibold text-orange-800 bg-orange-200 rounded-full">Menunggu Review</span>
                 @endif
                 <span class="text-sm font-medium text-blue-700 ml-2">{{ $task->progress }}%</span>


### PR DESCRIPTION
This commit fixes a runtime error (`Attempt to read property "key" on string` or similar JSON output) that occurred when displaying tasks in the UI.

The root cause was the `task-card.blade.php` component attempting to display `$task->status` as a string, when it is now an Eloquent relationship object.

The fix involves:
1.  Updating the component to display `$task->status->label` for the status text.
2.  Updating all conditional checks (e.g., for 'completed' or 'for_review' status) to use `$task->status->key`.
3.  Adding a `color_class` column to the `task_statuses` migration and seeder to ensure the status badge color is also dynamic and correctly sourced from the relationship, fixing a related issue.