### PR TITLE
Refactor hard-coded values and fix application-wide bugs

### DIFF
--- a/database/seeders/SpecialAssignmentSeeder.php
+++ b/database/seeders/SpecialAssignmentSeeder.php
@@ -17,8 +17,12 @@ class SpecialAssignmentSeeder extends Seeder
     public function run(): void
     {
         $faker = Faker::create('id_ID');
-        $users = User::where('role', '!=', User::ROLE_SUPERADMIN)->get();
-        $managers = User::whereIn('role', [User::ROLE_ESELON_I, User::ROLE_ESELON_II, User::ROLE_KOORDINATOR])->get();
+        $users = User::whereDoesntHave('roles', function ($query) {
+            $query->where('name', 'Superadmin');
+        })->get();
+        $managers = User::whereHas('roles', function ($query) {
+            $query->whereIn('name', ['Eselon I', 'Eselon II', 'Koordinator']);
+        })->get();
 
         if ($users->count() < 2 || $managers->isEmpty()) {
             $this->command->info('Not enough users or managers to create special assignments.');


### PR DESCRIPTION
This commit addresses the findings of a comprehensive code audit by refactoring numerous hard-coded values throughout the application. It also completes a partially implemented feature for task priorities and fixes several bugs in the database seeders, migration order, and service constructors that were discovered during testing.

The following major changes were implemented:

- **Database-Driven User Roles**: Replaced the hard-coded role constants in the User model with a database-driven system using `roles` and `role_user` tables. All authorization checks and related logic in controllers, services, and seeders have been updated.

- **Database-Driven Task Statuses & Priorities**: Resolved major inconsistencies by creating `task_statuses` and `priority_levels` tables and models. The `Task` model and related logic were updated to use these new systems, fixing a fatal error in the `TaskFactory`.

- **Fixed Migration Order**: Corrected the timestamp on the `create_priority_levels_table` migration to ensure it runs before the migration that depends on it, resolving a foreign key constraint error.

- **Fixed Service Constructor Bug**: Refactored `PerformanceCalculatorService` to lazily load its settings, preventing a crash during `migrate:fresh --seed` when the `settings` table does not yet exist.

- **Centralized Configuration**: Created a new `config/tasmen.php` file to centralize application-specific settings like file upload rules, loan request due dates, and pagination settings.

- **Dynamic Leave Logic**: Refactored the leave management system to use an `is_annual` flag and a `default_days` column in the `leave_types` table.

- **Status Enums**: Replaced hard-coded status strings in the Leave and Loan Request modules with a type-safe PHP Enum.

- **Code Cleanup**: Removed an obsolete artisan command and fixed bugs in all relevant seeders.

These changes significantly improve the application's architecture, maintainability, and stability, and allow the `migrate:fresh --seed` command to complete successfully.