### PR TITLE
feat: Integrate Special Assignments with automatic SK generation

### DIFF
--- a/app/Models/SpecialAssignment.php
+++ b/app/Models/SpecialAssignment.php
@@ -41,4 +41,13 @@ class SpecialAssignment extends Model
                     ->withPivot('role_in_sk')
                     ->withTimestamps();
     }
+
+    /**
+     * Get the assignment's official letter (SK).
+     * Ini adalah relasi polimorfik one-to-one.
+     */
+    public function surat()
+    {
+        return $this->morphOne(Surat::class, 'suratable');
+    }
 }

--- a/resources/views/special-assignments/_form.blade.php
+++ b/resources/views/special-assignments/_form.blade.php
@@ -23,6 +23,7 @@
     function assignmentForm() {
         return {
             members: @json($existingMembers),
+            create_sk: {{ old('create_sk') ? 'true' : 'false' }}, // Inisialisasi dari old input
             init() {
                 // Ensure initial Alpine.js data matches Laravel's old() values for select elements
                 this.members = this.members.map(member => ({
@@ -64,7 +65,52 @@
             @error('title') <span class="text-sm text-red-600 mt-1">{{ $message }}</span> @enderror
         </div>
 
-        <div>
+        <div class="p-4 border rounded-lg bg-gray-50/50 my-4">
+            <div class="flex items-start">
+                <div class="flex items-center h-5">
+                    <input id="create_sk" name="create_sk" type="checkbox" value="1"
+                           class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
+                           x-model="create_sk" @if(old('create_sk')) checked @endif>
+                </div>
+                <div class="ml-3 text-sm">
+                    <label for="create_sk" class="font-medium text-gray-800">Buatkan SK Penugasan secara otomatis?</label>
+                    <p class="text-gray-500">Jika dicentang, sistem akan men-generate Surat Keputusan (SK) resmi dan nomor surat akan dibuat secara otomatis.</p>
+                </div>
+            </div>
+
+            <div x-show="create_sk" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 transform -translate-y-2" x-transition:enter-end="opacity-100 transform translate-y-0" class="mt-4">
+                <label for="template_surat_id" class="block font-semibold text-sm text-gray-700 mb-1">Pilih Template SK <span class="text-red-600">*</span></label>
+                <select name="template_surat_id" id="template_surat_id" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150 @error('template_surat_id') border-red-500 @enderror">
+                    <option value="">-- Pilih Template --</option>
+                    @isset($skTemplates)
+                        @foreach($skTemplates as $template)
+                            <option value="{{ $template->id }}" @selected(old('template_surat_id') == $template->id)>
+                                {{ $template->judul }}
+                            </option>
+                        @endforeach
+                    @endisset
+                </select>
+                @error('template_surat_id') <span class="text-sm text-red-600 mt-1">{{ $message }}</span> @enderror
+            </div>
+
+            <div x-show="create_sk" x-transition class="mt-4">
+                <label for="klasifikasi_id" class="block font-semibold text-sm text-gray-700 mb-1">Pilih Klasifikasi Surat <span class="text-red-600">*</span></label>
+                <select name="klasifikasi_id" id="klasifikasi_id" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150 @error('klasifikasi_id') border-red-500 @enderror">
+                    <option value="">-- Pilih Klasifikasi --</option>
+                    @isset($klasifikasiSurat)
+                        @foreach($klasifikasiSurat as $klasifikasi)
+                            <option value="{{ $klasifikasi->id }}" @selected(old('klasifikasi_id') == $klasifikasi->id)>
+                                {{ $klasifikasi->kode }} - {{ $klasifikasi->nama }}
+                            </option>
+                        @endforeach
+                    @endisset
+                </select>
+                @error('klasifikasi_id') <span class="text-sm text-red-600 mt-1">{{ $message }}</span> @enderror
+            </div>
+        </div>
+
+        <!-- Input Nomor SK manual, ditampilkan jika checkbox tidak dicentang -->
+        <div x-show="!create_sk" x-transition>
             <label for="sk_number" class="block font-semibold text-sm text-gray-700 mb-1">Nomor SK (Opsional)</label>
             <input type="text" name="sk_number" id="sk_number" value="{{ old('sk_number', $assignment->sk_number ?? '') }}" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150 @error('sk_number') border-red-500 @enderror">
             @error('sk_number') <span class="text-sm text-red-600 mt-1">{{ $message }}</span> @enderror

--- a/resources/views/special-assignments/index.blade.php
+++ b/resources/views/special-assignments/index.blade.php
@@ -59,7 +59,15 @@
                                 <div>
                                     <h4 class="font-bold text-xl text-indigo-700 mb-1">{{ $sk->title }}</h4>
                                     <div class="text-sm text-gray-600 mt-1 flex items-center space-x-3">
-                                        <span class="inline-flex items-center"><i class="fas fa-hashtag text-gray-400 mr-1"></i> No. SK: {{ $sk->sk_number ?? '-' }}</span>
+                                        <span class="inline-flex items-center"><i class="fas fa-hashtag text-gray-400 mr-1"></i>
+                                            @if($sk->surat)
+                                                <a href="{{ route('surat-keluar.show', $sk->surat) }}" class="text-blue-600 hover:underline" title="Lihat Dokumen Surat">
+                                                    No. SK: {{ $sk->sk_number }}
+                                                </a>
+                                            @else
+                                                No. SK: {{ $sk->sk_number ?? '-' }}
+                                            @endif
+                                        </span>
                                         <span class="inline-flex items-center"><i class="fas fa-user-edit text-gray-400 mr-1"></i> Dibuat oleh: {{ $sk->creator->name ?? 'N/A' }}</span>
                                         @if ($sk->file_path)
                                             <a href="{{ asset('storage/' . $sk->file_path) }}" target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline flex items-center font-medium">


### PR DESCRIPTION
This commit implements the automatic generation of official Surat Keputusan (SK) documents when creating a Special Assignment. It closes the integration gap identified in the initial analysis.

Key changes:
- Adds a `surat()` polymorphic relationship to the `SpecialAssignment` model.
- Modifies the `SpecialAssignmentController` to handle the new workflow:
    - Fetches `TemplateSurat` and `KlasifikasiSurat` for the creation form.
    - Updates the `store` method with validation and logic to create a `Surat` record using the `NomorSuratService`.
    - Associates the new `Surat` with the `SpecialAssignment`.
    - Updates the `SpecialAssignment`'s `sk_number` with the generated number.
- Updates the `special-assignments.create` form with a checkbox and conditional dropdowns to manage the new feature.
- Updates the `special-assignments.index` view to display a clickable link to the generated `Surat` document, eager-loading the relationship for performance.