### PR TITLE
feat: Add automatic SK Cuti generation on leave approval

### DIFF
--- a/app/Models/LeaveRequest.php
+++ b/app/Models/LeaveRequest.php
@@ -34,4 +34,12 @@ class LeaveRequest extends Model
     public function user() { return $this->belongsTo(User::class); }
     public function leaveType() { return $this->belongsTo(LeaveType::class); }
     public function approver() { return $this->belongsTo(User::class, 'current_approver_id'); }
+
+    /**
+     * Get the official decision letter (SK) for this leave request.
+     */
+    public function surat()
+    {
+        return $this->morphOne(Surat::class, 'suratable');
+    }
 }

--- a/app/Services/SuratCutiGenerator.php
+++ b/app/Services/SuratCutiGenerator.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\KlasifikasiSurat;
+use App\Models\LeaveRequest;
+use App\Models\Surat;
+use App\Models\TemplateSurat;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+class SuratCutiGenerator
+{
+    protected NomorSuratService $nomorSuratService;
+
+    public function __construct(NomorSuratService $nomorSuratService)
+    {
+        $this->nomorSuratService = $nomorSuratService;
+    }
+
+    /**
+     * Generate an official SK Cuti for a given leave request.
+     *
+     * @param LeaveRequest $leaveRequest The approved leave request.
+     * @param User $approver The user who gave the final approval.
+     * @return Surat|null The generated letter, or null on failure.
+     * @throws \Exception If a suitable template or classification is not found.
+     */
+    public function generate(LeaveRequest $leaveRequest, User $approver): ?Surat
+    {
+        // 1. Find a suitable template for SK Cuti.
+        $template = TemplateSurat::where('judul', 'LIKE', '%SK Cuti%')
+            ->orWhere('judul', 'LIKE', '%Surat Cuti%')
+            ->first();
+
+        if (!$template) {
+            Log::error('Template SK Cuti tidak ditemukan.');
+            throw new \Exception('Template SK Cuti tidak ditemukan.');
+        }
+
+        // 2. Find a suitable classification (e.g., Kepegawaian).
+        $klasifikasi = KlasifikasiSurat::where('kode', 'LIKE', 'KP%') // KP for Kepegawaian
+            ->orWhere('nama', 'LIKE', '%Kepegawaian%')
+            ->first();
+
+        if (!$klasifikasi) {
+            Log::error('Klasifikasi surat untuk Kepegawaian (KP) tidak ditemukan.');
+            throw new \Exception('Klasifikasi surat untuk Kepegawaian (KP) tidak ditemukan.');
+        }
+
+        // 3. Generate the letter number.
+        // The letter is generated on behalf of the final approver.
+        $nomorSurat = $this->nomorSuratService->generate($klasifikasi, $approver);
+
+        // 4. Create the Surat record.
+        $surat = new Surat([
+            'nomor_surat' => $nomorSurat,
+            'perihal' => 'Surat Keputusan Izin Cuti - ' . $leaveRequest->user->name,
+            'tanggal_surat' => now(),
+            'jenis' => 'KELUAR',
+            'status' => 'TERVERIFIKASI', // Automatically verified as it's system-generated
+            'pembuat_id' => $approver->id,
+            'penyetuju_id' => $approver->id,
+            'konten' => $this->replacePlaceholders($template->konten, $leaveRequest, $approver),
+            'klasifikasi_id' => $klasifikasi->id,
+        ]);
+
+        // 5. Associate with the LeaveRequest and save.
+        $surat->suratable()->associate($leaveRequest);
+        $surat->save();
+
+        Log::info("Generated SK Cuti #{$nomorSurat} for Leave Request #{$leaveRequest->id}");
+
+        return $surat;
+    }
+
+    /**
+     * Replace placeholders in the letter template with actual data.
+     *
+     * @param string $content The template content.
+     * @param LeaveRequest $leaveRequest The leave request data.
+     * @param User $approver The approver data.
+     * @return string The content with placeholders replaced.
+     */
+    private function replacePlaceholders(string $content, LeaveRequest $leaveRequest, User $approver): string
+    {
+        $replacements = [
+            '{{nama_pegawai}}' => $leaveRequest->user->name,
+            '{{jabatan_pegawai}}' => $leaveRequest->user->jabatan->nama ?? 'N/A',
+            '{{unit_kerja_pegawai}}' => $leaveRequest->user->unit->nama ?? 'N/A',
+            '{{jenis_cuti}}' => $leaveRequest->leaveType->name,
+            '{{tanggal_mulai_cuti}}' => $leaveRequest->start_date->isoFormat('D MMMM Y'),
+            '{{tanggal_selesai_cuti}}' => $leaveRequest->end_date->isoFormat('D MMMM Y'),
+            '{{durasi_cuti}}' => $leaveRequest->duration_days . ' hari',
+            '{{alasan_cuti}}' => $leaveRequest->reason,
+            '{{nama_pejabat_penyetuju}}' => $approver->name,
+            '{{jabatan_pejabat_penyetuju}}' => $approver->jabatan->nama ?? 'N/A',
+            '{{tanggal_penetapan}}' => now()->isoFormat('D MMMM Y'),
+        ];
+
+        return str_replace(array_keys($replacements), array_values($replacements), $content);
+    }
+}

--- a/resources/views/leaves/show.blade.php
+++ b/resources/views/leaves/show.blade.php
@@ -9,6 +9,21 @@
         <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 sm:p-8 bg-white border-b border-gray-200">
+
+                    @if($leaveRequest->surat)
+                        <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                            <h4 class="font-bold text-md text-blue-800 flex items-center">
+                                <i class="fas fa-file-signature mr-2"></i>SK Cuti Telah Terbit
+                            </h4>
+                            <p class="text-sm text-gray-700 mt-1">
+                                Surat Keputusan (SK) untuk cuti ini telah di-generate oleh sistem.
+                                <a href="{{ route('surat-keluar.show', $leaveRequest->surat) }}" target="_blank" class="font-semibold text-blue-600 hover:underline">
+                                    Lihat Dokumen SK di sini.
+                                </a>
+                            </p>
+                        </div>
+                    @endif
+
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
                             <h3 class="text-lg font-bold text-gray-800">Data Pegawai</h3>


### PR DESCRIPTION
This commit implements the automatic generation of an official "Surat Keputusan Cuti" (Leave Approval Letter) when a leave request receives final approval.

This continues the work of integrating the "Persuratan" module with other parts of the application.

Key changes:
- Creates a new `SuratCutiGenerator` service to encapsulate the letter generation logic. This service finds the appropriate templates and classifications, generates a letter number, and replaces placeholders in the content.
- Adds a `surat()` polymorphic relationship to the `LeaveRequest` model.
- Modifies the `LeaveController@approve` method to inject and use the new service after a leave request is successfully approved.
- Implements robust error handling to ensure letter generation failures do not block the leave approval process.
- Updates the `leaves/show.blade.php` view to display a link to the generated SK document.