### PR TITLE
feat: Add two-way relationship for Task-Surat integration

### DIFF
--- a/app/Http/Controllers/AdHocTaskController.php
+++ b/app/Http/Controllers/AdHocTaskController.php
@@ -19,7 +19,7 @@ class AdHocTaskController extends Controller
     public function index(Request $request)
     {
         $user = Auth::user();
-        $query = Task::whereNull('project_id')->with(['assignees', 'status', 'priorityLevel'])->latest();
+        $query = Task::whereNull('project_id')->with(['assignees', 'status', 'priorityLevel', 'asalSurat'])->latest();
         $subordinates = collect();
 
         if ($user->canManageUsers()) {

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -127,7 +127,7 @@ class ProjectController extends Controller
 
         $project->load(['owner', 'leader', 'members', 'activities.user', 'surat']);
 
-        $taskQuery = $project->tasks()->with(['assignees', 'comments.user', 'attachments', 'subTasks', 'status', 'priorityLevel']);
+        $taskQuery = $project->tasks()->with(['assignees', 'comments.user', 'attachments', 'subTasks', 'status', 'priorityLevel', 'asalSurat']);
 
         if ($user->isStaff()) {
             $taskQuery->whereHas('assignees', fn($q) => $q->where('user_id', $user->id));

--- a/app/Http/Controllers/SuratTaskController.php
+++ b/app/Http/Controllers/SuratTaskController.php
@@ -37,6 +37,9 @@ class SuratTaskController extends Controller
             $task->project_id = null;
         }
 
+        // Link the task back to the source letter
+        $task->surat_id = $surat->id;
+
         // Set an initial status and priority
         $task->status = 'pending';
         $task->priority = 'medium';

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -19,6 +19,8 @@ class Task extends Model
         'deadline',
         'progress',
         'project_id',
+        'surat_id',
+        'creator_id',
         'estimated_hours',
         'task_status_id',
         'priority_level_id',
@@ -35,6 +37,14 @@ class Task extends Model
     public function project()
     {
         return $this->belongsTo(Project::class);
+    }
+
+    /**
+     * Get the source letter (surat) for this task, if any.
+     */
+    public function asalSurat()
+    {
+        return $this->belongsTo(Surat::class, 'surat_id');
     }
 
     /**

--- a/database/migrations/2025_09_03_003500_add_surat_id_to_tasks_table.php
+++ b/database/migrations/2025_09_03_003500_add_surat_id_to_tasks_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->foreignId('surat_id')->nullable()->after('project_id')->constrained('surat')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropForeign(['surat_id']);
+            $table->dropColumn('surat_id');
+        });
+    }
+};

--- a/resources/views/components/task-card.blade.php
+++ b/resources/views/components/task-card.blade.php
@@ -16,6 +16,15 @@
                     {{ $task->deadline ? \Carbon\Carbon::parse($task->deadline)->format('d M Y') : 'N/A' }}
                 </span>
             </p>
+            @if($task->asalSurat)
+                <p class="text-xs text-gray-500 mt-1">
+                    <i class="fas fa-file-import mr-1 text-gray-400"></i>
+                    Berasal dari Surat:
+                    <a href="{{ route('surat-masuk.show', $task->asalSurat) }}" class="text-blue-600 hover:underline" title="{{ $task->asalSurat->perihal }}">
+                        {{ $task->asalSurat->nomor_surat ?? 'Lihat Surat' }}
+                    </a>
+                </p>
+            @endif
         </div>
         <div class="flex items-center space-x-2 flex-shrink-0">
             <span class="badge-status text-xs font-semibold px-3 py-1 rounded-full {{ $task->status->color_class ?? 'bg-gray-100 text-gray-800' }}">{{ $task->status->label ?? 'N/A' }}</span>


### PR DESCRIPTION
This commit completes the planned integration work by creating a two-way relationship between a Task and its source Surat (letter).

Key changes:
- Adds a new migration to create the `surat_id` foreign key on the `tasks` table.
- Updates the `Task` model with the `asalSurat()` relationship and adds `surat_id` to the fillable array.
- Modifies `SuratTaskController` to save the `surat_id` when a new task is created from a letter.
- Updates the `task-card` component to display a link back to the source letter.
- Updates `ProjectController` and `AdHocTaskController` to eager-load the new relationship, preventing N+1 query issues.