### PR TITLE
feat: Integrate Employee Loan requests with official letters

### DIFF
--- a/app/Models/PeminjamanRequest.php
+++ b/app/Models/PeminjamanRequest.php
@@ -3,13 +3,14 @@
 namespace App\Models;
 
 use App\Enums\RequestStatus;
+use App\Models\Traits\RecordsActivity;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PeminjamanRequest extends Model
 {
-    use HasFactory;
+    use HasFactory, RecordsActivity;
 
     protected $fillable = [
         'project_id',
@@ -50,5 +51,12 @@ class PeminjamanRequest extends Model
         // User yang harus menyetujui, melalui kolom 'approver_id'.
         return $this->belongsTo(User::class, 'approver_id', 'id');
     }
-    // --- AKHIR PERBAIKAN FINAL ---
+
+    /**
+     * Get the official letter associated with this loan request.
+     */
+    public function surat()
+    {
+        return $this->morphOne(Surat::class, 'suratable');
+    }
 }

--- a/app/Services/SuratPeminjamanGenerator.php
+++ b/app/Services/SuratPeminjamanGenerator.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\KlasifikasiSurat;
+use App\Models\PeminjamanRequest;
+use App\Models\Surat;
+use App\Models\TemplateSurat;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+class SuratPeminjamanGenerator
+{
+    /**
+     * Generate a draft official letter for a given employee loan request.
+     *
+     * @param PeminjamanRequest $peminjamanRequest The loan request.
+     * @return Surat|null The generated letter, or null on failure.
+     * @throws \Exception If a suitable template or classification is not found.
+     */
+    public function generate(PeminjamanRequest $peminjamanRequest): ?Surat
+    {
+        // 1. Find a suitable template for this type of letter.
+        $template = TemplateSurat::where('judul', 'LIKE', '%Peminjaman Pegawai%')
+            ->orWhere('judul', 'LIKE', '%Nota Dinas Permohonan%')
+            ->first();
+
+        if (!$template) {
+            Log::error('Template Surat Peminjaman Pegawai tidak ditemukan.');
+            throw new \Exception('Template Surat Peminjaman Pegawai tidak ditemukan.');
+        }
+
+        // 2. Find a suitable classification (e.g., Kepegawaian).
+        $klasifikasi = KlasifikasiSurat::where('kode', 'LIKE', 'KP%') // KP for Kepegawaian
+            ->orWhere('nama', 'LIKE', '%Kepegawaian%')
+            ->first();
+
+        if (!$klasifikasi) {
+            Log::error('Klasifikasi surat untuk Kepegawaian (KP) tidak ditemukan.');
+            throw new \Exception('Klasifikasi surat untuk Kepegawaian (KP) tidak ditemukan.');
+        }
+
+        // 3. Create the Surat record as a draft.
+        $surat = new Surat([
+            'perihal' => 'Permohonan Peminjaman Pegawai a.n. ' . $peminjamanRequest->requestedUser->name,
+            'tanggal_surat' => now(),
+            'jenis' => 'KELUAR',
+            'status' => 'draft', // Created as a draft, to be finalized upon approval.
+            'pembuat_id' => $peminjamanRequest->requester_id,
+            'penyetuju_id' => $peminjamanRequest->approver_id, // The approver is pre-determined
+            'konten' => $this->replacePlaceholders($template->konten, $peminjamanRequest),
+            'klasifikasi_id' => $klasifikasi->id,
+        ]);
+
+        // 4. Associate with the PeminjamanRequest and save.
+        $surat->suratable()->associate($peminjamanRequest);
+        $surat->save();
+
+        Log::info("Generated draft Surat Peminjaman #{$surat->id} for PeminjamanRequest #{$peminjamanRequest->id}");
+
+        return $surat;
+    }
+
+    /**
+     * Replace placeholders in the letter template with actual data.
+     */
+    private function replacePlaceholders(string $content, PeminjamanRequest $peminjamanRequest): string
+    {
+        $replacements = [
+            '{{nama_pemohon}}' => $peminjamanRequest->requester->name,
+            '{{jabatan_pemohon}}' => $peminjamanRequest->requester->jabatan->name ?? 'N/A',
+            '{{unit_pemohon}}' => $peminjamanRequest->requester->unit->name ?? 'N/A',
+            '{{nama_pegawai_dipinjam}}' => $peminjamanRequest->requestedUser->name,
+            '{{jabatan_pegawai_dipinjam}}' => $peminjamanRequest->requestedUser->jabatan->name ?? 'N/A',
+            '{{unit_pegawai_dipinjam}}' => $peminjamanRequest->requestedUser->unit->name ?? 'N/A',
+            '{{nama_proyek}}' => $peminjamanRequest->project->name,
+            '{{tanggal_surat}}' => now()->isoFormat('D MMMM Y'),
+        ];
+
+        return str_replace(array_keys($replacements), array_values($replacements), $content);
+    }
+}

--- a/resources/views/peminjaman_requests/my_requests.blade.php
+++ b/resources/views/peminjaman_requests/my_requests.blade.php
@@ -102,6 +102,7 @@
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Peminta</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Anggota Diminta</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Kegiatan</th>
+                                    <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Dokumen</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Status & Alasan</th>
                                     <th class="px-6 py-3 text-center text-xs font-semibold text-gray-600 uppercase">Aksi</th>
                                 </tr>
@@ -117,6 +118,16 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 flex items-center">
                                             <i class="fas fa-folder mr-2 text-gray-400"></i> {{ $request->project?->name ?? '[Kegiatan Dihapus]' }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                            @if($request->surat)
+                                                <a href="{{ route('surat-keluar.show', $request->surat) }}" class="text-indigo-600 hover:underline" title="Lihat Surat Permohonan">
+                                                    <i class="fas fa-file-alt mr-1"></i>
+                                                    {{ $request->surat->status == 'draft' ? 'Draf' : 'Final' }}
+                                                </a>
+                                            @else
+                                                -
+                                            @endif
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap">
                                             @if ($request->status == 'approved')
@@ -164,6 +175,7 @@
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Anggota Diminta</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Kegiatan</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Approver</th>
+                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Dokumen</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase">Status & Alasan</th>
                                     <th class="px-6 py-3 text-center text-xs font-semibold text-gray-600 uppercase">Aksi</th>
                                 </tr>
@@ -179,6 +191,16 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 flex items-center">
                                             <i class="fas fa-user-shield mr-2 text-gray-400"></i> {{ $request->approver?->name }}
+                                        </td>
+                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                            @if($request->surat)
+                                                <a href="{{ route('surat-keluar.show', $request->surat) }}" class="text-indigo-600 hover:underline" title="Lihat Surat Permohonan">
+                                                    <i class="fas fa-file-alt mr-1"></i>
+                                                    {{ $request->surat->status == 'draft' ? 'Draf' : 'Final' }}
+                                                </a>
+                                            @else
+                                                -
+                                            @endif
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap">
                                              @if ($request->status == 'pending')


### PR DESCRIPTION
This commit formalizes the Employee Loan Request process by generating an official letter (Nota Dinas) for each request.

Key changes:
- Adds a `morphOne` relationship from `PeminjamanRequest` to `Surat`.
- Creates a new `SuratPeminjamanGenerator` service to handle the creation of the draft letter upon request submission.
- Modifies `PeminjamanRequestController` to call this service on `store` and to finalize the letter (approve, add number) on `approve`.
- Updates the `my_requests` view to display a link to the associated letter.