### PR TITLE
This commit fixes a critical bug on the global dashboard where the "M…

### DIFF
--- a/resources/views/global-dashboard.blade.php
+++ b/resources/views/global-dashboard.blade.php
@@ -150,7 +150,9 @@
                     <!-- Task Status Chart -->
                     <div class="bg-white p-4 rounded-lg shadow">
                         <h4 class="font-semibold text-lg mb-4">Status Tugas Saya</h4>
-                        <canvas id="myTasksChart"></canvas>
+                        <div class="relative h-72">
+                            <canvas id="myTasksChart"></canvas>
+                        </div>
                     </div>
 
                     <x-card>


### PR DESCRIPTION
…y Task Status" chart would cause an infinite rendering loop for some users.

- **Layout Fix:** The chart's canvas element is now wrapped in a `div` with a fixed height (`h-72`). This provides a constrained container for Chart.js to render in, preventing the infinite growth feedback loop that was causing the page to expand indefinitely.

- **Performance:** The controller query that aggregates task statuses has been optimized. It now performs the counting directly in the database using a `GROUP BY` clause, rather than fetching all task models into memory. This significantly improves performance for users with a large number of assigned or subordinate tasks.