### PR TITLE
Fix foreign key violation on project deletion and include prior UI work.

### DIFF
--- a/app/Models/Traits/RecordsActivity.php
+++ b/app/Models/Traits/RecordsActivity.php
@@ -34,7 +34,7 @@ trait RecordsActivity
         if (isset(static::$recordableEvents)) {
             return static::$recordableEvents;
         }
-        return ['created', 'updated', 'deleted'];
+        return ['created', 'updated', 'deleting'];
     }
 
     public function recordActivity($description)


### PR DESCRIPTION
This commit resolves a critical bug that caused a foreign key violation when deleting a project. The activity log for the deletion was being created after the project was already deleted from the database.

The fix involves changing the model event listener in the `RecordsActivity` trait from `deleted` to `deleting`. This ensures the activity log is written while the project record still exists, satisfying the database constraint.

This submission also includes the comprehensive UI and UX modernization from the previous session, as the environment accumulates all changes.