### PR TITLE
Fix: Implement Floating Dropdown to Prevent Clipping

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -1,37 +1,44 @@
 @props(['align' => 'right', 'width' => '48', 'contentClasses' => 'py-1 bg-white'])
 
 @php
-$alignmentClasses = match ($align) {
-    'left' => 'ltr:origin-top-left rtl:origin-top-right start-0',
-    'top' => 'origin-top',
-    default => 'ltr:origin-top-right rtl:origin-top-left end-0',
-};
-
 $width = match ($width) {
     '48' => 'w-48',
-    '60' => 'w-60', // Menambahkan opsi lebar 60 agar lebih fleksibel
+    '60' => 'w-60',
     default => $width,
 };
 @endphp
 
-<div class="relative" x-data="{ open: false }" @click.outside="open = false" @close.stop="open = false">
-    <div @click="open = ! open">
-        {{-- Ini adalah tombol pemicu dropdown (misal: "Kegiatan Saya") --}}
+<div x-data="{
+        open: false,
+        position() {
+            const trigger = this.$refs.trigger;
+            const content = this.$refs.content;
+            const rect = trigger.getBoundingClientRect();
+
+            content.style.top = `${rect.bottom + window.scrollY + 4}px`;
+
+            if ('{{ $align }}' === 'right') {
+                content.style.left = `${rect.right - content.offsetWidth}px`;
+            } else {
+                content.style.left = `${rect.left}px`;
+            }
+        }
+    }" @click.outside="open = false" @close.stop="open = false">
+    <div @click="open = ! open; if (open) { $nextTick(() => position()) }" x-ref="trigger">
         {{ $trigger }}
     </div>
 
-    {{-- PERBAIKAN: Menyesuaikan gaya kontainer dropdown --}}
     <div x-show="open"
+            x-ref="content"
             x-transition:enter="transition ease-out duration-200"
             x-transition:enter-start="opacity-0 scale-95"
             x-transition:enter-end="opacity-100 scale-100"
             x-transition:leave="transition ease-in duration-75"
             x-transition:leave-start="opacity-100 scale-100"
             x-transition:leave-end="opacity-0 scale-95"
-            class="absolute z-50 mt-2 {{ $width }} rounded-md shadow-lg {{ $alignmentClasses }}"
+            class="fixed z-50 {{ $width }} rounded-md shadow-lg"
             style="display: none;"
             @click="open = false">
-        {{-- Menghapus kelas dark mode dan menambahkan border yang lebih sesuai tema --}}
         <div class="rounded-md ring-1 ring-black ring-opacity-5 {{ $contentClasses }}">
             {{ $content }}
         </div>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -37,7 +37,7 @@
                 </form>
             </div>
 
-            <div class="overflow-x-auto bg-white shadow-md rounded-xl border border-gray-200">
+            <div class="overflow-x-auto bg-white overflow-hidden shadow-md rounded-xl border border-gray-200">
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>


### PR DESCRIPTION
Re-implements the dropdown component to use a floating approach, preventing it from being clipped by parent containers with `overflow: hidden`.

This addresses two issues:
1. The dropdown menu being cut off when inside a short, scrollable table.
2. A visual bug with broken rounded corners on the table container when `overflow-hidden` was previously removed.

Changes:
- The `div` wrapping the user table in `users/index.blade.php` now correctly uses `overflow-hidden` again to clip its children and maintain the rounded corner design.
- The `dropdown.blade.php` component has been updated to use `position: fixed`. It now leverages Alpine.js to dynamically calculate its position on the screen relative to the trigger button, making it "float" above all other content.