### PR TITLE
Fix double submission on member loan request

### DIFF
--- a/resources/views/projects/create_step2.blade.php
+++ b/resources/views/projects/create_step2.blade.php
@@ -192,10 +192,17 @@
                     }, 500);
                 });
 
-                addBtn.addEventListener('click', () => {
+                addBtn.addEventListener('click', function() {
+                    const button = this;
+                    const originalBtnText = button.innerHTML;
+                    button.disabled = true;
+                    button.innerHTML = `<i class="fas fa-spinner fa-spin mr-2"></i> Memproses...`;
+
                     const selectedRadio = document.querySelector('.member-radio:checked');
                     if (!selectedRadio) {
                         alert('Silakan pilih satu anggota untuk ditambahkan.');
+                        button.disabled = false;
+                        button.innerHTML = originalBtnText;
                         return;
                     }
                     
@@ -203,32 +210,34 @@
                     const memberName = selectedRadio.getAttribute('data-name');
                     const type = selectedRadio.getAttribute('data-type');
                         
-                    // Get the TomSelect instance for 'members'
                     const tomSelectInstance = membersSelect.tomselect;
 
-                    if (tomSelectInstance.getValue().includes(memberId)) { // Check if already selected in TomSelect
+                    if (tomSelectInstance.getValue().includes(memberId)) {
                         alert(`${memberName} sudah ada di dalam tim.`);
+                        button.disabled = false;
+                        button.innerHTML = originalBtnText;
                         return;
                     }
 
                     if (type === 'pool') {
-                        // Add directly to TomSelect
                         tomSelectInstance.addOption({value: memberId, text: memberName});
                         tomSelectInstance.addItem(memberId);
+                        button.disabled = false;
+                        button.innerHTML = originalBtnText;
+                        closeModal();
                     } else {
-                        // Send borrow request, then add to TomSelect (or alert failure)
-                        sendBorrowRequest(memberId, memberName, tomSelectInstance); // Pass TomSelect instance
+                        sendBorrowRequest(memberId, memberName, tomSelectInstance, button, originalBtnText);
                     }
-                    
-                    closeModal();
                 });
 
-                function sendBorrowRequest(memberId, memberName, tomSelectInstance) {
-                    let projectId = '{{ $project->id }}'; // Project ID is available in this context
+                function sendBorrowRequest(memberId, memberName, tomSelectInstance, button, originalBtnText) {
+                    let projectId = '{{ $project->id }}';
 
                     let message = prompt(`Anda akan mengirim permintaan untuk menugaskan "${memberName}".\nTambahkan pesan untuk atasan mereka (opsional):`);
                     
                     if (message === null) {
+                        button.disabled = false;
+                        button.innerHTML = originalBtnText;
                         return;
                     }
 
@@ -246,9 +255,9 @@
                     .then(data => {
                         if (data.success) {
                             alert(`Permintaan untuk ${memberName} telah terkirim.`);
-                            // Add the member to TomSelect with a "Pending" indicator
                             tomSelectInstance.addOption({value: memberId, text: `${memberName} [Menunggu]`});
                             tomSelectInstance.addItem(memberId);
+                            closeModal();
                         } else {
                             alert(`Gagal mengirim permintaan: ${data.message || 'Terjadi kesalahan yang tidak diketahui.'}`);
                         }
@@ -256,6 +265,10 @@
                     .catch(error => {
                         console.error('Error sending borrow request:', error);
                         alert(`Gagal mengirim permintaan: ${error.message || 'Terjadi kesalahan koneksi.'}`);
+                    })
+                    .finally(() => {
+                        button.disabled = false;
+                        button.innerHTML = originalBtnText;
                     });
                 }
             } else {


### PR DESCRIPTION
The "Tambahkan Anggota Terpilih" button in the project creation flow could be clicked multiple times, sending duplicate AJAX requests to create a member loan (`PeminjamanRequest`).

This resulted in multiple loan requests being created for the same user in the same project.

The fix involves adding JavaScript to disable the button immediately on click and show a processing state. The button is re-enabled after the AJAX operation completes (on success, failure, or cancellation) to ensure the UI remains responsive. This prevents the double submission bug.