### PR TITLE
refactor(project): Improve project progress calculation

### DIFF
--- a/app/Http/Controllers/GlobalDashboardController.php
+++ b/app/Http/Controllers/GlobalDashboardController.php
@@ -69,8 +69,10 @@ class GlobalDashboardController extends Controller
             $projectQuery->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($search) . '%']);
         }
 
-        // Eager load relationships for performance. `tasks` is needed for the status accessor.
-        $projectQuery->with(['leader', 'tasks'])->withSum('budgetItems', 'total_cost');
+        // REFACTOR: Eager load counts for performance. This is crucial for the new progress accessor.
+        $projectQuery->with(['leader'])
+                     ->withCount(['tasks', 'completedTasks'])
+                     ->withSum('budgetItems', 'total_cost');
 
         // Get all projects matching the search criteria first.
         $projects = $projectQuery->latest()->get();

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -22,7 +22,8 @@ class ProjectController extends Controller
     
     public function index(Request $request)
     {
-        $query = Project::with(['owner', 'leader', 'members', 'tasks'])
+        $query = Project::with(['owner', 'leader', 'members'])
+            ->withCount(['tasks', 'completedTasks'])
             ->withSum('budgetItems', 'total_cost');
 
         if ($request->filled('search')) {


### PR DESCRIPTION
This commit addresses an issue where the project progress bar was not updating correctly and remained at 0%. The previous implementation relied on filtering a loaded collection of tasks within the `getProgressAttribute` accessor, which was inefficient and prone to errors if the tasks were not eager-loaded correctly.

The fix refactors the progress calculation to be more robust and performant:
1.  A new `completedTasks` relationship has been added to the `Project` model to specifically query for completed tasks.
2.  The `getProgressAttribute` accessor in the `Project` model has been updated to use eager-loaded counts via `withCount(['tasks', 'completedTasks'])`, which is significantly more performant. A fallback to direct counting remains for single model instances.
3.  The `GlobalDashboardController` and `ProjectController` have been updated to use the new `withCount` method, ensuring the optimized query is used on the project list pages.

This change ensures the project progress is calculated accurately and efficiently, resolving the user-reported bug.