### PR TITLE
fix(adhoc-tasks): Correct Tom Select implementation

### DIFF
--- a/resources/views/adhoc-tasks/_form.blade.php
+++ b/resources/views/adhoc-tasks/_form.blade.php
@@ -18,7 +18,7 @@
     @if (Auth::user()->canManageUsers())
         <div>
             <label for="assignees" class="block font-semibold text-sm text-gray-700 mb-1">Tugaskan Kepada <span class="text-red-500">*</span></label>
-            <select name="assignees[]" id="assignees" class="tom-select" multiple required>
+            <select name="assignees[]" id="assignees" class="select2-searchable block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" multiple required>
                 @php
                     $assignedUserIds = old('assignees', isset($task) ? $task->assignees->pluck('id')->all() : []);
                 @endphp

--- a/resources/views/adhoc-tasks/create.blade.php
+++ b/resources/views/adhoc-tasks/create.blade.php
@@ -1,21 +1,4 @@
 <x-app-layout>
-    <x-slot name="styles">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.min.css">
-        <style>
-            .ts-control {
-                border-radius: 0.5rem;
-                border-color: #d1d5db;
-                padding: 0.5rem 0.75rem;
-                box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-                transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-            }
-            .ts-control.focus {
-                border-color: #6366f1;
-                box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
-            }
-        </style>
-    </x-slot>
-
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Tambah Tugas Harian Baru') }}
@@ -46,20 +29,4 @@
             </div>
         </div>
     </div>
-
-    @push('scripts')
-    <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            document.querySelectorAll('.tom-select').forEach(element => {
-                new TomSelect(element, {
-                    plugins: ['remove_button'],
-                    create: false,
-                    maxItems: null,
-                    placeholder: 'Pilih Anggota Tim'
-                });
-            });
-        });
-    </script>
-    @endpush
 </x-app-layout>


### PR DESCRIPTION
This commit fixes a regression caused by the initial implementation of the Tom Select component on the 'Add Daily Task' form. The previous change incorrectly loaded Tom Select from a CDN, which conflicted with the version bundled in `app.js` and caused other form elements (like the priority dropdown) to break.

This fix reverts the changes to `create.blade.php` and correctly implements the searchable dropdown by:
1.  Removing the redundant CDN links for Tom Select CSS and JS from `adhoc-tasks/create.blade.php`.
2.  Changing the class on the `assignees` select element in `adhoc-tasks/_form.blade.php` to `select2-searchable`, which is the class the global `app.js` uses to initialize Tom Select.
3.  Restoring the standard form styling classes to the select element for visual consistency.

This resolves the regression and correctly implements the feature as intended.