### PR TITLE
feat(adhoc-tasks): Implement Tom Select for assignees

### DIFF
--- a/resources/views/adhoc-tasks/create.blade.php
+++ b/resources/views/adhoc-tasks/create.blade.php
@@ -29,4 +29,21 @@
             </div>
         </div>
     </div>
+
+    @push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Initialize TomSelect on the assignees field with specific options
+            const assigneeSelect = document.getElementById('assignees');
+            if (assigneeSelect) {
+                new TomSelect(assigneeSelect, {
+                    plugins: ['remove_button'],
+                    create: false,
+                    maxItems: null,
+                    placeholder: 'Pilih Anggota Tim...'
+                });
+            }
+        });
+    </script>
+    @endpush
 </x-app-layout>


### PR DESCRIPTION
This commit implements the Tom Select component for the 'Tugaskan Kepada' (Assign To) field on the 'Add Daily Task' form. This enhances the user experience by providing a searchable and more user-friendly dropdown for selecting assignees.

The implementation relies on the globally available `TomSelect` object imported in `app.js`. A page-specific script has been added to the `adhoc-tasks/create.blade.php` view to initialize the component on the `#assignees` dropdown with the correct plugins (`remove_button`) and options for a multi-select field.

This approach avoids script conflicts that were discovered in previous attempts, ensuring that other form elements are not affected, and correctly implements the requested feature.