### PR TITLE
fix(adhoc-tasks): Align Tom Select styling with main task editor

### DIFF
--- a/resources/views/adhoc-tasks/_form.blade.php
+++ b/resources/views/adhoc-tasks/_form.blade.php
@@ -18,8 +18,8 @@
     @if (Auth::user()->canManageUsers())
         <div>
             <label for="assignees" class="block font-semibold text-sm text-gray-700 mb-1">Tugaskan Kepada <span class="text-red-500">*</span></label>
-            {{-- MODIFIKASI: Tambahkan kelas tom-select dan placeholder --}}
-            <select name="assignees[]" id="assignees" class="tom-select" multiple required placeholder="Pilih anggota tim...">
+            {{-- MODIFIKASI: Ganti kelas menjadi tom-select-multiple --}}
+            <select name="assignees[]" id="assignees" class="tom-select-multiple" multiple required placeholder="Pilih anggota tim...">
                 @php
                     $assignedUserIds = old('assignees', isset($task) ? $task->assignees->pluck('id')->all() : []);
                 @endphp

--- a/resources/views/adhoc-tasks/create.blade.php
+++ b/resources/views/adhoc-tasks/create.blade.php
@@ -31,18 +31,63 @@
     </div>
 
     @push('styles')
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.bootstrap5.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.min.css">
+    <style>
+        .ts-control {
+            border-radius: 0.5rem; /* rounded-lg */
+            border-color: #d1d5db; /* gray-300 */
+            padding: 0.5rem 0.75rem;
+            box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05); /* shadow-sm */
+            transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+        .ts-control.focus {
+            border-color: #6366f1; /* indigo-500 */
+            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2); /* ring-indigo-500 */
+        }
+        .ts-control .item {
+            background-color: #4f46e5; /* indigo-600 */
+            color: white;
+            border-radius: 0.25rem;
+            font-weight: 500;
+            padding: 0.25rem 0.5rem;
+            margin: 0.125rem;
+        }
+        .ts-control .item.active {
+            background-color: #4338ca; /* indigo-700 */
+        }
+        .ts-control .remove {
+            color: white;
+            opacity: 0.8;
+        }
+        .ts-control .remove:hover {
+            color: white;
+            opacity: 1;
+        }
+        .ts-dropdown {
+            border-radius: 0.5rem; /* rounded-lg */
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); /* shadow-lg */
+        }
+        .ts-dropdown .option.active {
+            background-color: #e0e7ff; /* indigo-100 */
+            color: #1e3a8a; /* indigo-900 */
+        }
+    </style>
     @endpush
+
     @push('scripts')
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            var tomSelect = new TomSelect('#assignees', {
-                plugins: ['remove_button'],
-                create: false,
-                maxItems: null, // Set to null to allow multiple selections
-                placeholder: 'Pilih Anggota Tim'
-            });
+            const selectElement = document.getElementById('assignees');
+            if (selectElement) {
+                new TomSelect(selectElement, {
+                    plugins: ['remove_button'],
+                    create: false,
+                    maxItems: null,
+                    placeholder: 'Pilih Anggota Tim',
+                    items: @json(old('assignees', []))
+                });
+            }
         });
     </script>
     @endpush

--- a/resources/views/adhoc-tasks/edit.blade.php
+++ b/resources/views/adhoc-tasks/edit.blade.php
@@ -33,18 +33,63 @@
     </div>
 
     @push('styles')
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.bootstrap5.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.min.css">
+    <style>
+        .ts-control {
+            border-radius: 0.5rem; /* rounded-lg */
+            border-color: #d1d5db; /* gray-300 */
+            padding: 0.5rem 0.75rem;
+            box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05); /* shadow-sm */
+            transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+        .ts-control.focus {
+            border-color: #6366f1; /* indigo-500 */
+            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2); /* ring-indigo-500 */
+        }
+        .ts-control .item {
+            background-color: #4f46e5; /* indigo-600 */
+            color: white;
+            border-radius: 0.25rem;
+            font-weight: 500;
+            padding: 0.25rem 0.5rem;
+            margin: 0.125rem;
+        }
+        .ts-control .item.active {
+            background-color: #4338ca; /* indigo-700 */
+        }
+        .ts-control .remove {
+            color: white;
+            opacity: 0.8;
+        }
+        .ts-control .remove:hover {
+            color: white;
+            opacity: 1;
+        }
+        .ts-dropdown {
+            border-radius: 0.5rem; /* rounded-lg */
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); /* shadow-lg */
+        }
+        .ts-dropdown .option.active {
+            background-color: #e0e7ff; /* indigo-100 */
+            color: #1e3a8a; /* indigo-900 */
+        }
+    </style>
     @endpush
+
     @push('scripts')
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            new TomSelect('#assignees', {
-                plugins: ['remove_button'],
-                create: false,
-                maxItems: null,
-                placeholder: 'Pilih Anggota Tim'
-            });
+            const selectElement = document.getElementById('assignees');
+            if (selectElement) {
+                new TomSelect(selectElement, {
+                    plugins: ['remove_button'],
+                    create: false,
+                    maxItems: null,
+                    placeholder: 'Pilih Anggota Tim',
+                    items: @json(old('assignees', $task->assignees->pluck('id')->toArray()))
+                });
+            }
         });
     </script>
     @endpush


### PR DESCRIPTION
This commit refines the Tom Select implementation on the ad-hoc task forms to match the styling and behavior of the main task editor, as per user feedback.

- Replaced the generic Tom Select stylesheet with a custom-styled version to ensure visual consistency with the application's theme.
- Updated the JavaScript initialization to be more robust, using the `items` property to handle pre-selected values on both create (from `old()`) and edit (from `old()` or the model).
- Changed the selector class to `tom-select-multiple` for consistency.