### PR TITLE
feat: Prevent back history after logout

### DIFF
--- a/app/Http/Middleware/PreventBackHistory.php
+++ b/app/Http/Middleware/PreventBackHistory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class PreventBackHistory
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+        return $response->header('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+                        ->header('Pragma', 'no-cache')
+                        ->header('Expires', 'Fri, 01 Jan 1990 00:00:00 GMT');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             \App\Http\Middleware\MarkNotificationAsRead::class,
             \App\Http\Middleware\CheckProfileIsComplete::class,
+            \App\Http\Middleware\PreventBackHistory::class,
         ]);
 
         $middleware->alias([
@@ -24,6 +25,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'can.manage.leave.settings' => \App\Http\Middleware\CheckCanManageLeaveSettings::class,
             'auth.apikey' => \App\Http\Middleware\AuthenticateApiClient::class,
             'log.api' => \App\Http\Middleware\LogApiActivity::class,
+            'prevent-back-history' => \App\Http\Middleware\PreventBackHistory::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {


### PR DESCRIPTION
Adds a new middleware `PreventBackHistory` that sets the `Cache-Control` headers to prevent browser caching of authenticated pages.

This middleware is applied globally to all web routes, which resolves the issue where a user could use the browser's back button to view a cached version of a page after they have logged out.