### PR TITLE
refactor: Make back button conditional

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -24,6 +24,7 @@ class ProjectController extends Controller
     public function index(Request $request, BreadcrumbService $breadcrumbService)
     {
         $breadcrumbService->add('Dashboard', route('dashboard'));
+        $breadcrumbService->hideBackButton();
         $query = Project::with(['owner', 'leader', 'members'])
             ->withCount(['tasks', 'completedTasks'])
             ->withSum('budgetItems', 'total_cost');

--- a/app/Http/View/Composers/BreadcrumbComposer.php
+++ b/app/Http/View/Composers/BreadcrumbComposer.php
@@ -17,5 +17,6 @@ class BreadcrumbComposer
     public function compose(View $view)
     {
         $view->with('breadcrumbs', $this->breadcrumbService->get());
+        $view->with('showBackButton', $this->breadcrumbService->getShowBackButton());
     }
 }

--- a/app/Services/BreadcrumbService.php
+++ b/app/Services/BreadcrumbService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 class BreadcrumbService
 {
     protected array $breadcrumbs = [];
+    protected bool $showBackButton = true;
 
     public function add(string $title, ?string $url = null): void
     {
@@ -14,5 +15,15 @@ class BreadcrumbService
     public function get(): array
     {
         return $this->breadcrumbs;
+    }
+
+    public function hideBackButton(): void
+    {
+        $this->showBackButton = false;
+    }
+
+    public function getShowBackButton(): bool
+    {
+        return $this->showBackButton;
     }
 }

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,4 +1,4 @@
-@props(['breadcrumbs' => []])
+@props(['breadcrumbs' => [], 'showBackButton' => true])
 
 <div class="flex justify-between items-center mb-4">
     @if (count($breadcrumbs) > 0)
@@ -29,7 +29,9 @@
         </nav>
     @endif
 
+    @if($showBackButton)
     <button onclick="history.back()" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
         Kembali
     </button>
+    @endif
 </div>


### PR DESCRIPTION
This commit refactors the breadcrumb system to allow the back button to be conditionally displayed.

- The `BreadcrumbService` now has a `hideBackButton()` method.
- The `breadcrumbs` component now conditionally renders the back button based on a `showBackButton` flag.
- The back button is now hidden on the main dashboard page.

This addresses the user's feedback that the back button was not needed on all pages.