### PR TITLE
fix: Make workflow button visible to all users

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -529,7 +529,6 @@ class ProjectController extends Controller
 
     public function showWorkflow(PageTitleService $pageTitleService, BreadcrumbService $breadcrumbService)
     {
-        $this->authorize('create', Project::class); // Only users who can create projects can see the workflow
         $pageTitleService->setTitle('Alur Kerja Kegiatan');
         $breadcrumbService->add('Dashboard', route('dashboard'));
         $breadcrumbService->add('Alur Kerja Kegiatan');

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,11 +11,11 @@
                 </p>
             </div>
         <div class="mt-4 sm:mt-0 sm:ml-4 flex items-center space-x-2">
-                 @can('create', App\Models\Project::class)
-                <x-secondary-button :href="route('projects.workflow')">
-                    <i class="fas fa-sitemap mr-2"></i>
-                    Lihat Alur Kerja
-                </x-secondary-button>
+            <x-secondary-button :href="route('projects.workflow')">
+                <i class="fas fa-sitemap mr-2"></i>
+                Lihat Alur Kerja
+            </x-secondary-button>
+            @can('create', App\Models\Project::class)
                     <x-primary-button :href="route('projects.create.step1')">
                         <i class="fas fa-plus mr-2"></i>
                         Inisiasi Kegiatan Baru


### PR DESCRIPTION
Fixes an issue where the "Lihat Alur Kerja" (View Workflow) button was not visible to all users. The button was incorrectly placed inside a permission check.

This commit moves the button outside the permission block in the view and removes the corresponding authorization from the controller method, making the workflow documentation accessible to all authenticated users.