### PR TITLE
fix: Ensure workflow button is visible on all dashboards

### DIFF
--- a/resources/views/global-dashboard.blade.php
+++ b/resources/views/global-dashboard.blade.php
@@ -4,6 +4,11 @@
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
                 <i class="fas fa-briefcase mr-2"></i> {{ __('Daftar Kegiatan') }}
             </h2>
+        <div class="flex items-center space-x-2">
+            <x-secondary-button :href="route('projects.workflow')">
+                <i class="fas fa-sitemap mr-2"></i>
+                Lihat Alur Kerja
+            </x-secondary-button>
             @can('create', App\Models\Project::class)
                 <a href="{{ route('projects.create.step1') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-lg font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg">
                     <i class="fas fa-plus-circle mr-2"></i> Tambah Kegiatan


### PR DESCRIPTION
Fixes an issue where the "Lihat Alur Kerja" (View Workflow) button was not appearing on the main user dashboards (`/dashboard` and `/global-dashboard`).

The button was previously only added to the project list page (`/projects`). This commit adds the button to the header of the global dashboard view, ensuring it is visible to users in all expected locations.