### PR TITLE
feat: Add workflow documentation for Leave Management

### DIFF
--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -22,6 +22,8 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use App\Models\CutiBersama;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use App\Services\PageTitleService;
+use App\Services\BreadcrumbService;
 
 class LeaveController extends Controller
 {
@@ -342,5 +344,13 @@ class LeaveController extends Controller
         $leaveRequest->recordActivity('rejected_leaverequest');
 
         return back()->with('success', 'Permintaan cuti telah ditolak.');
+    }
+
+    public function showWorkflow(PageTitleService $pageTitleService, BreadcrumbService $breadcrumbService)
+    {
+        $pageTitleService->setTitle('Alur Kerja Manajemen Cuti');
+        $breadcrumbService->add('Manajemen Cuti', route('leaves.index'));
+        $breadcrumbService->add('Alur Kerja');
+        return view('leaves.workflow');
     }
 }

--- a/resources/views/leaves/index.blade.php
+++ b/resources/views/leaves/index.blade.php
@@ -5,6 +5,10 @@
                 {{ __('Manajemen Cuti') }}
             </h2>
             <div class="flex items-center space-x-2">
+                <x-secondary-button :href="route('leaves.workflow')">
+                    <i class="fas fa-sitemap mr-2"></i>
+                    Lihat Alur Kerja
+                </x-secondary-button>
                 <a href="{{ route('leaves.calendar') }}" class="inline-flex items-center px-4 py-2 bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700">
                     <i class="fas fa-calendar-alt mr-2"></i> {{ __('Lihat Kalender') }}
                 </a>

--- a/resources/views/leaves/workflow.blade.php
+++ b/resources/views/leaves/workflow.blade.php
@@ -1,0 +1,127 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            <i class="fas fa-calendar-check mr-2"></i>
+            {{ __('Alur Kerja Modul Manajemen Cuti') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+
+            <!-- Intro Card -->
+            <x-card>
+                <div class="p-6">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Dokumentasi Alur Kerja Cuti</h3>
+                    <p class="text-gray-600">Halaman ini berisi dokumentasi lengkap mengenai alur kerja Modul Manajemen Cuti, mulai dari pengajuan oleh pegawai, proses persetujuan berjenjang, hingga penerbitan SK Cuti otomatis.</p>
+                </div>
+            </x-card>
+
+            <!-- Flowchart Umum -->
+            <x-card>
+                <div class="p-6">
+                    <h3 class="text-xl font-bold text-gray-800 mb-4 border-b pb-2">Flowchart Alur Kerja</h3>
+                    <p class="text-gray-600 mb-6">Flowchart ini merinci keseluruhan alur kerja standar untuk modul Manajemen Cuti.</p>
+                    <div class="p-4 bg-gray-50 rounded-lg text-center">
+                        <pre class="mermaid">
+graph TD
+    classDef page fill:#EBF5FB,stroke:#3498DB,color:#2874A6,stroke-width:1px;
+    classDef action fill:#FEF9E7,stroke:#F1C40F,color:#B7950B,stroke-width:1px;
+    classDef process fill:#E8F8F5,stroke:#1ABC9C,color:#148F77,stroke-width:1px;
+    classDef decision fill:#FDEDEC,stroke:#C0392B,color:#A93226,stroke-width:1px;
+    classDef io fill:#F4ECF7,stroke:#8E44AD,color:#6C3483,stroke-width:1px;
+
+    subgraph "A. Alur Pengajuan"
+        A1["<i class='fa fa-user'></i> Pegawai"]:::action -->|Klik 'Ajukan Cuti'| A2["<i class='fa fa-keyboard'></i> Form Pengajuan Cuti"]:::page;
+        A2 -- Isi Form & Submit --> A3{<i class='fa fa-check-double'></i> Validasi & Cek Saldo}:::decision;
+        A3 -- Gagal --> A2;
+        A3 -- Sukses --> A4["<i class='fa fa-save'></i> Simpan Permintaan Cuti<br>(Status: PENDING)"]:::process;
+        A4 --> A5["<i class='fa fa-bell'></i> Notifikasi ke Atasan Langsung"]:::process;
+        A5 --> B1;
+    end
+
+    subgraph "B. Alur Persetujuan Berjenjang"
+        B1["<i class='fa fa-user-tie'></i> Atasan"]:::action -->|Buka Notifikasi/Detail| B2["<i class='fa fa-file-alt'></i> Halaman Detail Cuti"]:::page;
+        B2 -->|Klik 'Setujui'| B3["<i class='fa fa-cogs'></i> LeaveApprovalService.processApproval"]:::process;
+        B3 --> B4{<i class='fa fa-question-circle'></i> Ada Jenjang Berikutnya? (berdasarkan Workflow & Role)}:::decision;
+
+        B4 -- Ya --> B5["Ubah Status: 'APPROVED_BY_SUPERVISOR'<br>Update Penyetuju Berikutnya"]:::process;
+        B5 --> B6["<i class='fa fa-bell'></i> Notifikasi ke Atasan Berikutnya"]:::process;
+        B6 --> B1;
+
+        B4 -- Tidak (Final) --> B7["Ubah Status: 'APPROVED'"]:::process;
+        B7 --> C_Flow["<i class='fa fa-file-signature'></i> Alur Penerbitan SK"];
+
+        B2 -->|Klik 'Tolak'| B8["<i class='fa fa-gavel'></i> Form Alasan Penolakan"]:::page;
+        B8 -- Submit --> B9["Ubah Status: 'REJECTED'"]:::process;
+        B9 --> B10["<i class='fa fa-bell'></i> Notifikasi ke Pegawai"]:::process;
+    end
+
+    subgraph "C. Alur Penerbitan SK Otomatis"
+        C1["<i class='fa fa-cogs'></i> SuratCutiGenerator.generate"]:::process --> C2["<i class='fa fa-file-word'></i> Buat Dokumen Surat<br>dari Template"]:::process;
+        C2 --> C3["<i class='fa fa-save'></i> Simpan Surat di Database<br>& Tautkan ke Permintaan Cuti"]:::process;
+        C3 --> C4["<i class='fa fa-check-circle'></i> Selesai"];
+    end
+                        </pre>
+                    </div>
+                </div>
+            </x-card>
+
+            <!-- Penjelasan Detail -->
+            <x-card>
+                <div class="p-6">
+                    <h3 class="text-xl font-bold text-gray-800 mb-4 border-b pb-2">Penjelasan Detail Alur Kerja</h3>
+                    <div class="prose max-w-none text-gray-700 space-y-4">
+                        <div>
+                            <h4 class="font-semibold text-gray-800">1. Alur Pengajuan (A)</h4>
+                            <p>Proses dimulai ketika seorang pegawai mengajukan cuti.</p>
+                            <ul class="list-disc list-inside ml-4 space-y-2">
+                                <li><strong>Pengisian Form</strong>: Pegawai mengisi jenis cuti, rentang tanggal, alasan, dan lampiran jika diperlukan.</li>
+                                <li><strong>Validasi Saldo</strong>: Jika jenis cuti adalah cuti tahunan, sistem akan otomatis memeriksa sisa saldo cuti yang tersedia. Jika tidak cukup, pengajuan akan ditolak.</li>
+                                <li><strong>Notifikasi Awal</strong>: Setelah berhasil diajukan, sistem secara otomatis mengirimkan notifikasi ke atasan langsung dari pegawai tersebut untuk memulai proses persetujuan.</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 class="font-semibold text-gray-800">2. Alur Persetujuan Berjenjang (B)</h4>
+                            <p>Ini adalah inti dari modul Cuti. Proses persetujuan tidak statis, melainkan dinamis berdasarkan workflow yang telah diatur untuk unit kerja pegawai.</p>
+                            <ul class="list-disc list-inside ml-4 space-y-2">
+                                <li><strong>Persetujuan Bertingkat</strong>: Seorang atasan yang menyetujui permintaan akan memicu `LeaveApprovalService`. Service ini akan memeriksa apakah ada tingkat persetujuan selanjutnya berdasarkan `ApprovalWorkflow` yang berlaku.</li>
+                                <li><strong>Penerusan (Forward)</strong>: Jika ada tingkat selanjutnya, status permintaan diubah menjadi 'Disetujui oleh Atasan' dan notifikasi dikirim ke atasan berikutnya dalam hierarki yang memiliki peran (role) yang sesuai.</li>
+                                <li><strong>Persetujuan Final</strong>: Jika tidak ada lagi tingkat persetujuan, permintaan dianggap disetujui sepenuhnya.</li>
+                                <li><strong>Penolakan</strong>: Atasan di tingkat manapun dapat menolak permintaan dengan memberikan alasan. Proses akan berhenti dan notifikasi penolakan dikirim ke pegawai.</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 class="font-semibold text-gray-800">3. Penerbitan SK Otomatis (C)</h4>
+                            <p>Setelah persetujuan final, sistem secara otomatis melakukan proses administrasi akhir.</p>
+                             <ul class="list-disc list-inside ml-4 space-y-2">
+                                <li><strong>Generate Surat</strong>: `SuratCutiGenerator` service akan dipanggil untuk membuat dokumen SK Cuti dari template yang sudah ada.</li>
+                                <li><strong>Integrasi</strong>: Dokumen surat yang baru dibuat akan otomatis tersimpan di modul Persuratan dan ditautkan ke permintaan cuti yang bersangkutan, memastikan semua data terhubung.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </x-card>
+
+        </div>
+    </div>
+
+    @push('scripts')
+        <script type="module">
+            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+            mermaid.initialize({
+                startOnLoad: true,
+                fontFamily: 'inherit',
+                theme: 'base',
+                themeVariables: {
+                    primaryColor: '#ffffff',
+                    primaryTextColor: '#333',
+                    primaryBorderColor: '#e5e7eb',
+                    lineColor: '#6b7280',
+                    textColor: '#374151',
+                    fontSize: '14px',
+                }
+            });
+        </script>
+    @endpush
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -177,6 +177,7 @@ Route::middleware(['auth'])->group(function () {
     // Leave Management Module Routes
     Route::group(['prefix' => 'leaves', 'as' => 'leaves.'], function () {
         Route::get('/', [\App\Http\Controllers\LeaveController::class, 'index'])->name('index');
+        Route::get('/workflow', [\App\Http\Controllers\LeaveController::class, 'showWorkflow'])->name('workflow');
         Route::get('/calendar', [\App\Http\Controllers\LeaveController::class, 'calendar'])->name('calendar');
         Route::get('/create', [\App\Http\Controllers\LeaveController::class, 'create'])->name('create');
         Route::post('/', [\App\Http\Controllers\LeaveController::class, 'store'])->name('store');


### PR DESCRIPTION
Adds a new documentation page with a detailed flowchart for the "Manajemen Cuti" (Leave Management) module.

This page details the process of submission, the dynamic multi-step approval workflow, and automatic letter generation. It is accessible via a new button on the Leave Management index page.