### PR TITLE
feat: Enhance workload analysis views based on user feedback

### DIFF
--- a/app/Http/Controllers/WorkloadAnalysisController.php
+++ b/app/Http/Controllers/WorkloadAnalysisController.php
@@ -101,6 +101,9 @@ class WorkloadAnalysisController extends Controller
             } else {
                 $effectiveHours = null;
                 $workloadPercentage = null;
+                $internalHours = $user->internal_tasks_hours;
+                $externalHours = $user->external_tasks_hours;
+                $totalTaskHours = $internalHours + $externalHours; // Recalculate total for 'all'
             }
 
             $workloadData[$user->id] = [
@@ -108,6 +111,9 @@ class WorkloadAnalysisController extends Controller
                 'effective_hours' => $effectiveHours,
                 'percentage' => $workloadPercentage,
                 'active_sk_count' => $user->specialAssignments->count(),
+                // Add these for the 'all' view
+                'internal_hours' => $internalHours ?? 0,
+                'external_hours' => $externalHours ?? 0,
             ];
         }
 

--- a/resources/views/workload-analysis/index.blade.php
+++ b/resources/views/workload-analysis/index.blade.php
@@ -146,6 +146,37 @@
                                                     <span><i class="fas fa-file-signature mr-2 text-gray-500"></i>SK Aktif</span>
                                                     <strong>{{ $activeSkCount }}</strong>
                                                 </div>
+                                            @else
+                                                {{-- Tampilan "Semua" / Fallback --}}
+                                                @php
+                                                    $internalHours = $workloadData[$user->id]['internal_hours'];
+                                                    $externalHours = $workloadData[$user->id]['external_hours'];
+                                                    $totalAllTimeHours = $internalHours + $externalHours;
+                                                    $internalPercent = $totalAllTimeHours > 0 ? ($internalHours / $totalAllTimeHours) * 100 : 0;
+                                                    $externalPercent = $totalAllTimeHours > 0 ? ($externalHours / $totalAllTimeHours) * 100 : 0;
+                                                @endphp
+                                                <div class="flex items-center mb-2">
+                                                    <i class="fas fa-hourglass-start mr-2 text-blue-500"></i>
+                                                    <strong class="text-base">Total: {{ $totalAllTimeHours }} Jam</strong>
+                                                </div>
+                                                <div class="w-full bg-gray-200 rounded-full h-4 mb-2 overflow-hidden shadow-inner">
+                                                    <div class="bg-blue-600 h-4 text-xs font-medium text-blue-100 text-center p-0.5 leading-none" style="width: {{ $internalPercent }}%" title="Tugas Dalam Unit ({{ round($internalPercent) }}%)"></div>
+                                                    <div class="bg-yellow-500 h-4 text-xs font-medium text-yellow-100 text-center p-0.5 leading-none" style="width: {{ $externalPercent }}%" title="Tugas Luar Unit ({{ round($externalPercent) }}%)"></div>
+                                                </div>
+                                                <ul class="space-y-1 text-xs">
+                                                    <li class="flex items-center justify-between">
+                                                        <span><i class="fas fa-building-user mr-2 text-blue-600"></i>Tugas Dalam Unit</span>
+                                                        <strong>{{ $internalHours }} Jam ({{ round($internalPercent) }}%)</strong>
+                                                    </li>
+                                                    <li class="flex items-center justify-between">
+                                                        <span><i class="fas fa-people-arrows mr-2 text-yellow-500"></i>Tugas Luar Unit (Bantuan)</span>
+                                                        <strong>{{ $externalHours }} Jam ({{ round($externalPercent) }}%)</strong>
+                                                    </li>
+                                                    <li class="flex items-center justify-between pt-1 mt-1 border-t">
+                                                        <span><i class="fas fa-file-signature mr-2 text-gray-500"></i>SK Aktif</span>
+                                                        <strong>{{ $activeSkCount }}</strong>
+                                                    </li>
+                                                </ul>
                                             @endif
                                         </td>
                                         <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-700">

--- a/resources/views/workload-analysis/show.blade.php
+++ b/resources/views/workload-analysis/show.blade.php
@@ -14,7 +14,7 @@
     <div class="py-12 bg-gray-50">
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6">
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
                     <div class="bg-blue-50 p-4 rounded-lg shadow">
                         <h3 class="text-lg font-semibold text-blue-800">Total Jam Kegiatan</h3>
                         <p class="text-3xl font-bold text-blue-900">{{ $user->total_project_hours }} Jam</p>
@@ -26,6 +26,18 @@
                     <div class="bg-purple-50 p-4 rounded-lg shadow">
                         <h3 class="text-lg font-semibold text-purple-800">SK Aktif</h3>
                         <p class="text-3xl font-bold text-purple-900">{{ $user->active_sk_count }}</p>
+                    </div>
+                    <!-- Performance Predicate Explanation Card -->
+                    <div class="bg-yellow-50 p-4 rounded-lg shadow">
+                        <h3 class="text-lg font-semibold text-yellow-800">Predikat Kinerja (SKP)</h3>
+                        <p class="text-3xl font-bold text-yellow-900">{{ $user->performance_predicate }}</p>
+                        <div class="text-xs text-yellow-700 mt-2">
+                            <p>Berdasarkan matriks:</p>
+                            <ul class="list-disc list-inside ml-2">
+                                <li><strong>Hasil Kerja:</strong> {{ $user->work_result_rating }}</li>
+                                <li><strong>Perilaku Kerja:</strong> {{ $user->work_behavior_rating ?? 'Sesuai Ekspektasi' }}</li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
This commit implements two specific UI/UX improvements to the workload analysis feature based on direct user feedback.

1.  **Restore Internal/External Workload Breakdown for 'All' View:**
    - The main Workload Analysis dashboard (`workload-analysis.index`) now conditionally displays the workload breakdown.
    - When the 'All' period filter is active, it shows the detailed view of 'Internal Task Hours' vs. 'External Task Hours'.
    - When any other specific period (Weekly, Monthly, etc.) is selected, it shows the new percentage-based capacity view (`Task Hours / Effective Hours`).
    - The `WorkloadAnalysisController` has been updated to support this conditional logic by providing the necessary data for both views.

2.  **Add Performance Predicate Explanation:**
    - The user detail page (`workload-analysis.show`) now includes a new summary card that displays the final SKP Predicate (e.g., 'Baik', 'Sangat Baik').
    - This card also explicitly lists the two components that determine the predicate: the 'Rating Hasil Kerja' and the 'Penilaian Perilaku Kerja', providing transparency into how the final rating is achieved.