### PR TITLE
feat: Display detailed performance calculation formulas and logic

### DIFF
--- a/app/Http/Controllers/WorkloadAnalysisController.php
+++ b/app/Http/Controllers/WorkloadAnalysisController.php
@@ -165,12 +165,16 @@ class WorkloadAnalysisController extends Controller
         $adhocTasks = $user->tasks()->whereNull('project_id')->get();
         $projectTasks = $user->tasks()->whereNotNull('project_id')->get()->groupBy('project.name');
 
+        $calculator = app(\App\Services\PerformanceCalculatorService::class);
+        $performanceDetails = $calculator->getPerformanceCalculationDetails($user);
+
         return view('workload-analysis.show', [
             'user' => $user,
             'adhocTasks' => $adhocTasks,
             'projectTasks' => $projectTasks,
             'specialAssignments' => $user->specialAssignments,
             'settings' => $settings,
+            'performanceDetails' => $performanceDetails,
         ]);
     }
 

--- a/resources/views/workload-analysis/show.blade.php
+++ b/resources/views/workload-analysis/show.blade.php
@@ -31,36 +31,47 @@
                     <div class="bg-yellow-50 p-4 rounded-lg shadow lg:col-span-4">
                         <h3 class="text-lg font-semibold text-yellow-800 mb-2">Rincian Perhitungan Predikat Kinerja (SKP): <span class="text-yellow-900 font-bold">{{ $user->performance_predicate }}</span></h3>
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                            <!-- Kolom Rating Hasil Kerja -->
+
+                            <!-- Kolom Rating Hasil Kerja & IKI -->
                             <div class="p-4 bg-white rounded-lg border">
-                                <h4 class="font-bold text-gray-800 mb-2">1. Rating Hasil Kerja: <span class="text-blue-600">{{ $user->work_result_rating }}</span></h4>
-                                <p class="text-xs text-gray-600 mb-2">
-                                    Rating ini didasarkan pada <strong class="text-gray-900">Nilai Kinerja Final (NKF)</strong> pegawai, yang saat ini adalah <strong class="text-gray-900">{{ number_format($user->final_performance_value, 3) }}</strong>.
-                                    Nilai ini sendiri dihitung dari akumulasi progres tugas, efisiensi waktu, dan kinerja tim (jika seorang manajer).
-                                </p>
+                                <h4 class="font-bold text-gray-800 mb-2">1. Perhitungan Indeks Kinerja Individu (IKI)</h4>
+                                <p class="text-xs text-gray-600 mb-2">IKI mengukur kinerja individu berdasarkan progres tugas dan efisiensi waktu.</p>
+                                <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
+                                    <p class="font-semibold">Rumus: <code class="text-red-600">{{ $performanceDetails['iki_formula'] }}</code></p>
+                                    <p>Hasil: {{ str_replace(array_keys($performanceDetails['iki_components']), array_values($performanceDetails['iki_components']), $performanceDetails['iki_formula']) }} = <strong class="text-red-600">{{ $performanceDetails['iki_result'] }}</strong></p>
+                                </div>
                                 <ul class="text-xs space-y-1">
-                                    <li class="p-1 rounded {{ $user->work_result_rating == 'Diatas Ekspektasi' ? 'bg-green-100 font-bold' : '' }}">Jika NKF &ge; {{ $settings['rating_threshold_high'] ?? '1.15' }}  &rarr; Diatas Ekspektasi</li>
-                                    <li class="p-1 rounded {{ $user->work_result_rating == 'Sesuai Ekspektasi' ? 'bg-green-100 font-bold' : '' }}">Jika NKF &ge; {{ $settings['rating_threshold_medium'] ?? '0.90' }} &rarr; Sesuai Ekspektasi</li>
-                                    <li class="p-1 rounded {{ $user->work_result_rating == 'Dibawah Ekspektasi' ? 'bg-red-100 font-bold' : '' }}">Jika NKF &lt; {{ $settings['rating_threshold_medium'] ?? '0.90' }}  &rarr; Dibawah Ekspektasi</li>
+                                    @foreach($performanceDetails['iki_components'] as $key => $value)
+                                    <li><span class="font-semibold">{{ ucfirst(str_replace('_', ' ', $key)) }}:</span> {{ $value }}</li>
+                                    @endforeach
                                 </ul>
                             </div>
-                            <!-- Kolom Predikat Kinerja -->
+
+                            <!-- Kolom NKF & Predikat -->
                             <div class="p-4 bg-white rounded-lg border">
-                                <h4 class="font-bold text-gray-800 mb-2">2. Penentuan Predikat SKP</h4>
-                                <p class="text-xs text-gray-600 mb-2">
-                                    Predikat final adalah hasil dari matriks kuadran antara <strong>Rating Hasil Kerja</strong> dan <strong>Penilaian Perilaku Kerja</strong> (yang diinput oleh atasan).
-                                </p>
-                                <div class="text-xs">
-                                    <p class="mb-2">Kombinasi saat ini:</p>
-                                    <div class="p-2 rounded bg-gray-100 border text-center">
-                                        <span class="font-semibold">{{ $user->work_result_rating }}</span>
-                                        <span class="mx-2">+</span>
-                                        <span class="font-semibold">{{ $user->work_behavior_rating ?? 'Sesuai Ekspektasi' }}</span>
-                                        <span class="mx-2">&darr;</span>
-                                        <strong class="text-blue-600">{{ $user->performance_predicate }}</strong>
-                                    </div>
+                                <h4 class="font-bold text-gray-800 mb-2">2. Perhitungan Nilai Kinerja Final (NKF)</h4>
+                                <p class="text-xs text-gray-600 mb-2">NKF adalah skor akhir yang menjadi dasar rating hasil kerja. Untuk pimpinan, nilai ini juga dipengaruhi oleh kinerja timnya.</p>
+                                <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
+                                    <p class="font-semibold">Rumus: <code class="text-blue-600">{{ $performanceDetails['nkf_formula'] }}</code></p>
+                                    <p>Hasil: {{ str_replace(array_keys($performanceDetails['nkf_components']), array_values($performanceDetails['nkf_components']), $performanceDetails['nkf_formula']) }} = <strong class="text-blue-600">{{ $performanceDetails['nkf_result'] }}</strong></p>
+                                </div>
+                                <ul class="text-xs space-y-1 mb-3">
+                                     @foreach($performanceDetails['nkf_components'] as $key => $value)
+                                    <li><span class="font-semibold">{{ ucfirst(str_replace('_', ' ', $key)) }}:</span> {{ $value }}</li>
+                                    @endforeach
+                                </ul>
+
+                                <h4 class="font-bold text-gray-800 mb-2 pt-3 border-t">3. Penentuan Predikat</h4>
+                                <p class="text-xs text-gray-600 mb-2">Predikat final adalah gabungan dari <strong>Rating Hasil Kerja</strong> (berdasarkan NKF) dan <strong>Penilaian Perilaku Kerja</strong> (dari atasan).</p>
+                                <div class="text-xs p-2 rounded bg-gray-100 border text-center">
+                                    <span class="font-semibold">{{ $user->work_result_rating }}</span>
+                                    <span class="mx-2">+</span>
+                                    <span class="font-semibold">{{ $user->work_behavior_rating ?? 'Sesuai Ekspektasi' }}</span>
+                                    <span class="mx-2">&darr;</span>
+                                    <strong class="text-green-600">{{ $user->performance_predicate }}</strong>
                                 </div>
                             </div>
+
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This commit enhances the 'Detail Beban Kerja' page (`workload-analysis.show`) to provide full transparency into how a user's performance ratings are calculated, based on user feedback.

Key Changes:
- A new public method, `getPerformanceCalculationDetails(User $user)`, has been added to `PerformanceCalculatorService`. This method encapsulates the calculation logic and returns a detailed array of all formula components (e.g., `base_score`, `efficiency_factor`) and results for a single user.
- The `WorkloadAnalysisController@show` method now calls this new service method and passes the detailed data to the view.
- The `workload-analysis.show.blade.php` view has been significantly updated. It now features a "Rincian Perhitungan Kinerja" (Performance Calculation Details) card that:
  - Displays the actual IKI (Indeks Kinerja Individu) and NKF (Nilai Kinerja Final) formulas being used from the application settings.
  - Shows the user's specific values (e.g., base_score = 0.95) being plugged into the formula.
  - Displays the final calculated result for each step.
  - Explains the matrix logic used to determine the final SKP Predicate from the work result and behavior ratings.

This change directly addresses the user's request for a more detailed and intuitive explanation of the performance calculation system.