### PR TITLE
feat: Add detailed formula explanations and fix edge case

### DIFF
--- a/app/Services/PerformanceCalculatorService.php
+++ b/app/Services/PerformanceCalculatorService.php
@@ -212,10 +212,12 @@ class PerformanceCalculatorService
         if ($allTasks->isEmpty()) {
             return [
                 'iki_formula' => $settings['iki_formula'] ?? 'N/A',
-                'iki_calculation' => 'Tidak ada tugas untuk dinilai.',
+                'iki_components' => [],
+                'iki_calculation_error' => 'Tidak ada tugas untuk dinilai.',
                 'iki_result' => 0,
-                'nkf_formula' => 'N/A',
-                'nkf_calculation' => 'Tidak ada IKI untuk dinilai.',
+                'nkf_formula' => $settings['nkf_formula_staf'] ?? 'N/A',
+                'nkf_components' => [],
+                'nkf_calculation_error' => 'Tidak ada IKI untuk dinilai.',
                 'nkf_result' => 0,
             ];
         }

--- a/resources/views/workload-analysis/show.blade.php
+++ b/resources/views/workload-analysis/show.blade.php
@@ -36,15 +36,21 @@
                             <div class="p-4 bg-white rounded-lg border">
                                 <h4 class="font-bold text-gray-800 mb-2">1. Perhitungan Indeks Kinerja Individu (IKI)</h4>
                                 <p class="text-xs text-gray-600 mb-2">IKI mengukur kinerja individu berdasarkan progres tugas dan efisiensi waktu.</p>
-                                <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
-                                    <p class="font-semibold">Rumus: <code class="text-red-600">{{ $performanceDetails['iki_formula'] }}</code></p>
-                                    <p>Hasil: {{ str_replace(array_keys($performanceDetails['iki_components']), array_values($performanceDetails['iki_components']), $performanceDetails['iki_formula']) }} = <strong class="text-red-600">{{ $performanceDetails['iki_result'] }}</strong></p>
-                                </div>
-                                <ul class="text-xs space-y-1">
-                                    @foreach($performanceDetails['iki_components'] as $key => $value)
-                                    <li><span class="font-semibold">{{ ucfirst(str_replace('_', ' ', $key)) }}:</span> {{ $value }}</li>
-                                    @endforeach
-                                </ul>
+                                @if(empty($performanceDetails['iki_components']))
+                                    <div class="text-xs p-2 rounded bg-yellow-100 border border-yellow-300 text-yellow-800">
+                                        <p><i class="fas fa-info-circle mr-1"></i> {{ $performanceDetails['iki_calculation_error'] }}</p>
+                                    </div>
+                                @else
+                                    <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
+                                        <p class="font-semibold">Rumus: <code class="text-red-600">{{ $performanceDetails['iki_formula'] }}</code></p>
+                                        <p>Hasil: {{ str_replace(array_keys($performanceDetails['iki_components']), array_values($performanceDetails['iki_components']), $performanceDetails['iki_formula']) }} = <strong class="text-red-600">{{ $performanceDetails['iki_result'] }}</strong></p>
+                                    </div>
+                                    <ul class="text-xs space-y-1">
+                                        @foreach($performanceDetails['iki_components'] as $key => $value)
+                                        <li><span class="font-semibold">{{ ucfirst(str_replace('_', ' ', $key)) }}:</span> {{ $value }}</li>
+                                        @endforeach
+                                    </ul>
+                                @endif
                                 <div class="mt-3 pt-3 border-t text-xs text-gray-600">
                                     <p class="font-bold mb-1">Interpretasi IKI:</p>
                                     <ul class="list-disc list-inside">
@@ -59,15 +65,21 @@
                             <div class="p-4 bg-white rounded-lg border">
                                 <h4 class="font-bold text-gray-800 mb-2">2. Perhitungan Nilai Kinerja Final (NKF)</h4>
                                 <p class="text-xs text-gray-600 mb-2">NKF adalah skor akhir yang menjadi dasar rating hasil kerja. Untuk pimpinan, nilai ini juga dipengaruhi oleh kinerja timnya.</p>
-                                <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
-                                    <p class="font-semibold">Rumus: <code class="text-blue-600">{{ $performanceDetails['nkf_formula'] }}</code></p>
-                                    <p>Hasil: {{ str_replace(array_keys($performanceDetails['nkf_components']), array_values($performanceDetails['nkf_components']), $performanceDetails['nkf_formula']) }} = <strong class="text-blue-600">{{ $performanceDetails['nkf_result'] }}</strong></p>
-                                </div>
-                                <ul class="text-xs space-y-1 mb-3">
-                                     @foreach($performanceDetails['nkf_components'] as $key => $value)
-                                    <li><span class="font-semibold">{{ ucfirst(str_replace('_', ' ', $key)) }}:</span> {{ $value }}</li>
-                                    @endforeach
-                                </ul>
+                                @if(empty($performanceDetails['nkf_components']))
+                                    <div class="text-xs p-2 rounded bg-yellow-100 border border-yellow-300 text-yellow-800">
+                                        <p><i class="fas fa-info-circle mr-1"></i> {{ $performanceDetails['nkf_calculation_error'] }}</p>
+                                    </div>
+                                @else
+                                    <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
+                                        <p class="font-semibold">Rumus: <code class="text-blue-600">{{ $performanceDetails['nkf_formula'] }}</code></p>
+                                        <p>Hasil: {{ str_replace(array_keys($performanceDetails['nkf_components']), array_values($performanceDetails['nkf_components']), $performanceDetails['nkf_formula']) }} = <strong class="text-blue-600">{{ $performanceDetails['nkf_result'] }}</strong></p>
+                                    </div>
+                                    <ul class="text-xs space-y-1 mb-3">
+                                        @foreach($performanceDetails['nkf_components'] as $key => $value)
+                                        <li><span class="font-semibold">{{ ucfirst(str_replace('_', ' ', $key)) }}:</span> {{ $value }}</li>
+                                        @endforeach
+                                    </ul>
+                                @endif
                                 <div class="mt-3 pt-3 border-t text-xs text-gray-600">
                                      <p class="font-bold mb-1">Interpretasi Rating Hasil Kerja (berdasarkan NKF):</p>
                                     <ul class="list-disc list-inside">


### PR DESCRIPTION
This commit enhances the 'Detail Beban Kerja' page (`workload-analysis.show`) to provide full transparency into how a user's performance ratings are calculated. It also fixes a fatal error for users with no assigned tasks.

Feature Enhancement:
- A new public method, `getPerformanceCalculationDetails(User $user)`, has been added to `PerformanceCalculatorService` to return a detailed array of all formula components and results for a single user.
- The `WorkloadAnalysisController@show` method now uses this service to pass the detailed calculation data to the view.
- The `workload-analysis.show` view is enhanced to display the actual IKI and NKF formulas, the user's specific values plugged into them, and narrative explanations for each component.

Bug Fix:
- The `getPerformanceCalculationDetails` method in the service now returns a consistent array structure, even for users with no tasks, to prevent 'Undefined array key' errors.
- The `workload-analysis.show` view now conditionally checks if calculation components exist before attempting to render them, displaying an informational message for users with no tasks instead of crashing.