### PR TITLE
fix: Resolve 404 error on surat masuk detail page

### DIFF
--- a/app/Http/Controllers/SuratMasukController.php
+++ b/app/Http/Controllers/SuratMasukController.php
@@ -87,8 +87,9 @@ class SuratMasukController extends Controller
         return redirect()->route('surat-masuk.index')->with('success', 'Surat masuk berhasil diarsipkan dan disposisi otomatis telah dibuat.');
     }
 
-    public function show(Surat $surat)
+    public function show(Surat $surat_masuk)
     {
+        $surat = $surat_masuk;
         if ($surat->jenis !== 'masuk') {
             abort(404);
         }


### PR DESCRIPTION
This commit fixes a 404 Not Found error that occurred when clicking the "Detail & Disposisi" link on the incoming mail index page.

The error was caused by a mismatch in the parameter name for the route model binding. The resource route `surat-masuk` expects a parameter named `{surat_masuk}`, but the `show` method in `SuratMasukController` was type-hinting for a parameter named `$surat`.

This has been corrected by updating the method signature in the controller to `show(Surat $surat_masuk)`, which allows Laravel's route model binding to correctly resolve and inject the model.