### PR TITLE
fix: Prevent crash in PreventBackHistory middleware

### DIFF
--- a/app/Http/Middleware/PreventBackHistory.php
+++ b/app/Http/Middleware/PreventBackHistory.php
@@ -17,6 +17,13 @@ class PreventBackHistory
     public function handle(Request $request, Closure $next)
     {
         $response = $next($request);
+
+        // Check if the response is a StreamedResponse (e.g., a file download)
+        // StreamedResponse does not have a header() method, so we skip adding headers.
+        if ($response instanceof \Symfony\Component\HttpFoundation\StreamedResponse) {
+            return $response;
+        }
+
         return $response->header('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
                         ->header('Pragma', 'no-cache')
                         ->header('Expires', 'Fri, 01 Jan 1990 00:00:00 GMT');


### PR DESCRIPTION
This commit fixes a fatal error (`Call to undefined method header()`) that occurred when a user tried to download a file from the application.

The `PreventBackHistory` middleware was attempting to add cache-control headers to every response. However, it did not account for `StreamedResponse` objects, which are used for file downloads and do not have a `header()` method. This caused a crash during any file download operation.

The fix adds a check within the middleware to determine if the response is an instance of `StreamedResponse`. If it is, the middleware now returns the response immediately without attempting to modify its headers, resolving the crash.