### PR TITLE
fix: Add missing AuthorizesRequests trait to DisposisiController

### DIFF
--- a/app/Http/Controllers/DisposisiController.php
+++ b/app/Http/Controllers/DisposisiController.php
@@ -9,9 +9,12 @@ use App\Notifications\SuratDisposisiNotification;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class DisposisiController extends Controller
 {
+    use AuthorizesRequests;
+
     public function store(Request $request, Surat $surat)
     {
         $validated = $request->validate([


### PR DESCRIPTION
This commit fixes a fatal error (`Call to undefined method authorize()`) that occurred when accessing the 'lacak disposisi' (track disposition) page.

The error was caused by a missing `AuthorizesRequests` trait in the `DisposisiController`. The `lacak` method was attempting to call `$this->authorize()` without the controller using the necessary trait that provides this method.

This commit adds the trait to the controller, resolving the fatal error and allowing the authorization check to function correctly.