### PR TITLE
fix: Correct outdated schema usage in SuratTaskController

### DIFF
--- a/app/Http/Controllers/SuratTaskController.php
+++ b/app/Http/Controllers/SuratTaskController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Surat;
 use App\Models\Task;
+use App\Models\TaskStatus;
+use App\Models\PriorityLevel;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -17,6 +19,10 @@ class SuratTaskController extends Controller
      */
     public function create(Surat $surat)
     {
+        // Find default status and priority
+        $defaultStatus = TaskStatus::where('key', 'pending')->first();
+        $defaultPriority = PriorityLevel::where('name', 'Medium')->first();
+
         // Create a new Task
         $task = new Task();
 
@@ -37,9 +43,13 @@ class SuratTaskController extends Controller
         // Link the task back to the source letter
         $task->surat_id = $surat->id;
 
-        // Set an initial status and priority
-        $task->status = 'pending';
-        $task->priority = 'medium';
+        // Set an initial status and priority using the new relational IDs
+        if ($defaultStatus) {
+            $task->task_status_id = $defaultStatus->id;
+        }
+        if ($defaultPriority) {
+            $task->priority_level_id = $defaultPriority->id;
+        }
 
         $task->save();
 


### PR DESCRIPTION
This commit fixes a fatal SQL error that occurred when using the "Jadikan Tugas" (Make Task) feature from an incoming letter.

The `SuratTaskController` was attempting to set `status` and `priority` as string values on a new Task object. However, later database migrations had replaced these columns with foreign key relationships (`task_status_id` and `priority_level_id`). This mismatch between the controller's code and the database schema caused an `Undefined column` SQL exception.

The fix updates the `create` method in `SuratTaskController` to:
1.  Look up the default 'pending' status from the `task_statuses` table.
2.  Look up the default 'Medium' priority from the `priority_levels` table.
3.  Assign the corresponding IDs to the `task_status_id` and `priority_level_id` fields of the new task.

This aligns the controller with the current database schema and resolves the crash.