### PR TITLE
feat: Add back links and enhance report filters

### DIFF
--- a/resources/views/adhoc-tasks/create.blade.php
+++ b/resources/views/adhoc-tasks/create.blade.php
@@ -7,6 +7,14 @@
 
     <div class="py-12 bg-gray-50"> {{-- Menyesuaikan latar belakang dengan Executive Summary dan Adhoc Tasks Index --}}
         <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg"> {{-- Mengubah shadow-sm menjadi shadow-xl --}}
                 <div class="p-6 text-gray-900">
                     {{-- MODIFIKASI: Tambahkan enctype untuk upload file --}}

--- a/resources/views/adhoc-tasks/workflow.blade.php
+++ b/resources/views/adhoc-tasks/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <!-- Intro Card -->
             <x-card>

--- a/resources/views/admin/klasifikasi/create.blade.php
+++ b/resources/views/admin/klasifikasi/create.blade.php
@@ -7,6 +7,14 @@
 
     <div class="py-12">
         <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
                     <form action="{{ route('admin.klasifikasi.store') }}" method="POST">
@@ -39,7 +47,6 @@
                         </div>
 
                         <div class="flex items-center justify-end mt-8 pt-6 border-t border-gray-200">
-                            <a href="{{ route('admin.klasifikasi.index') }}" class="text-sm font-medium text-gray-600 hover:text-gray-900 mr-4">Batal</a>
                             <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md">
                                 Simpan
                             </button>

--- a/resources/views/admin/klasifikasi/workflow.blade.php
+++ b/resources/views/admin/klasifikasi/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <x-card>
                 <div class="p-6">

--- a/resources/views/arsip/workflow.blade.php
+++ b/resources/views/arsip/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <x-card>
                 <div class="p-6">

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -102,6 +102,14 @@
     <div x-data="projectDetail()">
         <div class="py-12 bg-gray-50"> {{-- Pastikan latar belakang halaman konsisten --}}
             <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8 space-y-8">
+                <div class="mb-4">
+                    <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                        </svg>
+                        Kembali
+                    </a>
+                </div>
                 <div>
                     <h2 class="text-2xl font-semibold text-gray-700 mb-4">Ringkasan Kegiatan</h2>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6"> {{-- Gap lebih besar --}}

--- a/resources/views/projects/workflow.blade.php
+++ b/resources/views/projects/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <!-- Intro Card -->
             <x-card>

--- a/resources/views/special-assignments/create.blade.php
+++ b/resources/views/special-assignments/create.blade.php
@@ -9,6 +9,14 @@
     {{-- Mengubah py-12 menjadi py-8 untuk konsistensi padding vertikal --}}
     <div class="py-8"> 
         <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             {{-- Mengubah shadow-sm menjadi shadow-xl dan memastikan rounded-lg --}}
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 text-gray-900">

--- a/resources/views/special-assignments/edit.blade.php
+++ b/resources/views/special-assignments/edit.blade.php
@@ -8,6 +8,14 @@
     {{-- Latar belakang dan padding konsisten dengan halaman lain --}}
     <div class="py-8"> 
         <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             {{-- Bayangan dan sudut membulat konsisten --}}
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 text-gray-900">

--- a/resources/views/special-assignments/workflow.blade.php
+++ b/resources/views/special-assignments/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <!-- Intro Card -->
             <x-card>

--- a/resources/views/suratkeluar/create-step1.blade.php
+++ b/resources/views/suratkeluar/create-step1.blade.php
@@ -7,6 +7,14 @@
 
     <div class="py-12 bg-gray-50">
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 sm:p-8 text-gray-900">
                     <h3 class="text-xl font-bold text-gray-800 mb-4">Pilih Template Surat</h3>

--- a/resources/views/suratkeluar/create-upload.blade.php
+++ b/resources/views/suratkeluar/create-upload.blade.php
@@ -7,6 +7,14 @@
 
     <div class="py-12 bg-gray-50">
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 sm:p-8 text-gray-900">
                     <form action="{{ route('surat-keluar.store') }}" method="POST" enctype="multipart/form-data">
@@ -55,7 +63,6 @@
                         </div>
 
                         <div class="flex items-center justify-end mt-8 pt-6 border-t border-gray-200">
-                            <a href="{{ route('surat-keluar.create') }}" class="text-sm font-medium text-gray-600 hover:text-gray-900 mr-4">Kembali</a>
                             <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg">
                                 <i class="fas fa-archive mr-2"></i> Simpan & Arsipkan
                             </button>

--- a/resources/views/suratkeluar/pilih-metode.blade.php
+++ b/resources/views/suratkeluar/pilih-metode.blade.php
@@ -7,6 +7,14 @@
 
     <div class="py-12 bg-gray-50">
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 sm:p-8 text-gray-900 text-center">
                     <h3 class="text-2xl font-bold text-gray-800 mb-2">Pilih Metode Pembuatan Surat</h3>

--- a/resources/views/suratkeluar/workflow.blade.php
+++ b/resources/views/suratkeluar/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <x-card>
                 <div class="p-6">

--- a/resources/views/suratmasuk/create.blade.php
+++ b/resources/views/suratmasuk/create.blade.php
@@ -7,6 +7,14 @@
 
     <div class="py-12 bg-gray-50">
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 sm:p-8 text-gray-900">
                     <form action="{{ route('surat-masuk.store') }}" method="POST" enctype="multipart/form-data">

--- a/resources/views/suratmasuk/workflow.blade.php
+++ b/resources/views/suratmasuk/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <!-- Intro Card -->
             <x-card>

--- a/resources/views/templatesurat/create.blade.php
+++ b/resources/views/templatesurat/create.blade.php
@@ -7,6 +7,14 @@
 
     <div class="py-12 bg-gray-50">
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 sm:p-8 text-gray-900">
                     <form action="{{ route('templatesurat.store') }}" method="POST">
@@ -58,7 +66,6 @@
                         </div>
 
                         <div class="flex items-center justify-end mt-8 pt-6 border-t border-gray-200">
-                            <a href="{{ route('templatesurat.index') }}" class="text-sm font-medium text-gray-600 hover:text-gray-900 mr-4">Batal</a>
                             <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg">
                                 <i class="fas fa-save mr-2"></i> Simpan Template
                             </button>

--- a/resources/views/templatesurat/workflow.blade.php
+++ b/resources/views/templatesurat/workflow.blade.php
@@ -8,6 +8,14 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="mb-4">
+                <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali
+                </a>
+            </div>
 
             <!-- Intro Card -->
             <x-card>


### PR DESCRIPTION
This commit addresses several user requests:
1.  **Adds 'Kembali' (Back) Links:**
    - A consistent 'Kembali' link using `javascript:history.back()` has been added to 18 pages across various modules to improve navigation.
    - Redundant 'Batal' or 'Kembali' links were removed from some forms.

2.  **Enhances Ad-hoc Task Report Filters:**
    - A new date filter with presets (Weekly, Monthly, etc.) and a manual date range picker has been added to the Ad-hoc Tasks filter form.
    - The filter now auto-submits when a date preset is chosen.
    - The main list view now correctly filters by the selected date range.

3.  **Fixes Print Report Functionality:**
    - The 'Cetak Laporan' (Print Report) functionality for Ad-hoc Tasks has been refactored to use the exact same filters as the main view, ensuring the printed report is consistent with the on-screen data.
    - The print template has been improved to display the active filters.

4.  **Fixes Priority Dropdown:**
    - A bug was fixed where the priority filter dropdown was empty on the Ad-hoc tasks page.