### PR TITLE
feat: Add holiday import feature and unify calendars

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -530,8 +530,31 @@ class ProjectController extends Controller
             ];
         });
 
+        // Get National Holidays and Collective Leaves as background events
+        $nationalHolidays = \App\Models\NationalHoliday::whereYear('date', now()->year)
+            ->get()
+            ->map(fn($holiday) => [
+                'title' => $holiday->name,
+                'start' => $holiday->date->format('Y-m-d'),
+                'allDay' => true,
+                'color' => '#EF4444', // Red
+                'display' => 'background',
+            ]);
+
+        $collectiveLeaves = \App\Models\CutiBersama::whereYear('date', now()->year)
+            ->get()
+            ->map(fn($leave) => [
+                'title' => $leave->name,
+                'start' => $leave->date->format('Y-m-d'),
+                'allDay' => true,
+                'color' => '#10B981', // Green
+                'display' => 'background',
+            ]);
+
+        $finalEvents = $events->concat($nationalHolidays)->concat($collectiveLeaves);
+
         if ($project->start_date && $project->end_date) {
-            $events->prepend([
+            $finalEvents->prepend([
                 'id' => 'project_duration',
                 'title' => 'Durasi Proyek',
                 'start' => $project->start_date->format('Y-m-d'),
@@ -541,7 +564,7 @@ class ProjectController extends Controller
             ]);
         }
 
-        return response()->json($events);
+        return response()->json($finalEvents);
     }
 
     public function showWorkflow(PageTitleService $pageTitleService, BreadcrumbService $breadcrumbService)

--- a/resources/views/admin/cuti_bersama/index.blade.php
+++ b/resources/views/admin/cuti_bersama/index.blade.php
@@ -17,6 +17,12 @@
                             <a href="{{ route('admin.cuti-bersama.workflow') }}" class="inline-flex items-center px-4 py-2 bg-blue-500 border border-transparent rounded-lg font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-600">
                                 <i class="fas fa-project-diagram mr-2"></i> Alur Kerja
                             </a>
+                            <form action="{{ route('admin.cuti-bersama.import') }}" method="POST" class="inline-block">
+                                @csrf
+                                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-500 border border-transparent rounded-lg font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-600" onclick="return confirm('Apakah Anda yakin ingin mengimpor hari libur dari API? Ini akan menambahkan data baru ke database.');">
+                                    <i class="fas fa-cloud-download-alt mr-2"></i> Import dari API
+                                </button>
+                            </form>
                             <a href="{{ route('admin.cuti-bersama.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-lg font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700">
                                 <i class="fas fa-plus-circle mr-2"></i> Tambah Tanggal
                             </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -301,6 +301,7 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
 Route::middleware(['auth', 'can.manage.leave.settings'])->prefix('admin')->name('admin.')->group(function () {
     // Cuti Bersama Management
     Route::get('cuti-bersama/workflow', [CutiBersamaController::class, 'showWorkflow'])->name('cuti-bersama.workflow');
+    Route::post('cuti-bersama/import', [CutiBersamaController::class, 'import'])->name('cuti-bersama.import');
     Route::resource('cuti-bersama', CutiBersamaController::class)->parameters(['cuti-bersama' => 'cutiBersama']);
     // Approval Workflow Management
     Route::get('approval-workflows/workflow', [ApprovalWorkflowController::class, 'showWorkflow'])->name('approval-workflows.workflow');


### PR DESCRIPTION
This commit introduces a new feature to import national holidays and collective leaves from an external API.

- Adds an 'Import from API' button to the Collective Leave management page.
- Implements the logic to fetch data from `https://libur.deno.dev/api` and store it in the `cuti_bersamas` and `national_holidays` tables.
- Unifies the calendar configurations in the Leaves and Projects modules to display the imported holiday data.

This also includes two previous bug fixes:
- Fixes a TypeError in the status-badge component when the status is an enum.
- Fixes a QueryException in the LeaveController calendar method by using the correct column names.