### PR TITLE
Fix: Resolve Multiple Issues on Ad-Hoc Tasks Page

### DIFF
--- a/resources/views/adhoc-tasks/index.blade.php
+++ b/resources/views/adhoc-tasks/index.blade.php
@@ -226,9 +226,54 @@
                     });
                 }
 
+                function syncDatePreset() {
+                    const startDateValue = startDateInput.value;
+                    const endDateValue = endDateInput.value;
+                    if (!startDateValue || !endDateValue) return;
+
+                    const presets = ['weekly', 'monthly', 'quarterly', 'semesterly', 'yearly'];
+
+                    for (const preset of presets) {
+                        const now = new Date(); // Re-initialize 'now' each loop to prevent mutation
+                        let expectedStartDate, expectedEndDate;
+
+                        switch (preset) {
+                            case 'weekly':
+                                const firstDay = new Date(now.setDate(now.getDate() - now.getDay()));
+                                expectedStartDate = firstDay.toISOString().split('T')[0];
+                                expectedEndDate = new Date(firstDay.setDate(firstDay.getDate() + 6)).toISOString().split('T')[0];
+                                break;
+                            case 'monthly':
+                                expectedStartDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0];
+                                expectedEndDate = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split('T')[0];
+                                break;
+                            case 'quarterly':
+                                const quarter = Math.floor(now.getMonth() / 3);
+                                expectedStartDate = new Date(now.getFullYear(), quarter * 3, 1).toISOString().split('T')[0];
+                                expectedEndDate = new Date(now.getFullYear(), quarter * 3 + 3, 0).toISOString().split('T')[0];
+                                break;
+                            case 'semesterly':
+                                const semester = now.getMonth() < 6 ? 0 : 6;
+                                expectedStartDate = new Date(now.getFullYear(), semester, 1).toISOString().split('T')[0];
+                                expectedEndDate = new Date(now.getFullYear(), semester + 6, 0).toISOString().split('T')[0];
+                                break;
+                            case 'yearly':
+                                expectedStartDate = new Date(now.getFullYear(), 0, 1).toISOString().split('T')[0];
+                                expectedEndDate = new Date(now.getFullYear(), 11, 31).toISOString().split('T')[0];
+                                break;
+                        }
+
+                        if (startDateValue === expectedStartDate && endDateValue === expectedEndDate) {
+                            datePreset.value = preset;
+                            break;
+                        }
+                    }
+                }
+
                 form.addEventListener('input', updatePrintLink);
                 form.addEventListener('change', updatePrintLink);
                 updatePrintLink();
+                syncDatePreset();
             });
         </script>
     @endpush


### PR DESCRIPTION
This commit addresses three interconnected issues on the 'Tugas Harian' (Ad-Hoc Tasks) page:

1.  **Fix Logout on 'Rentang Waktu' Filter:**
    - The original problem was a logout when selecting a time preset. This was caused by `form.submit()` triggering an unexpected session issue.
    - The fix is to change the JavaScript event listener to manually construct the filter URL and navigate using `window.location.href`, ensuring a clean GET request.

2.  **Fix Print Report Ignoring Filters:**
    - The 'Cetak Laporan' (Print Report) button was not including active filters.
    - The JavaScript for the print button has been simplified to use `window.location.search`, which takes the current page's query string. This ensures the print URL always mirrors the active filters.

3.  **Fix Dropdown State Restoration (Regression):**
    - The fix for the logout issue introduced a regression where the 'Rentang Waktu' dropdown did not visually reflect the active filter after the page reloaded.
    - A new JavaScript function, `syncDatePreset`, has been added. It runs on page load, compares the active date filters in the URL to the presets, and sets the dropdown to the correct selection.