### PR TITLE
Refactor adhoc-task form to align with standard task edit form

### DIFF
--- a/resources/views/adhoc-tasks/_form.blade.php
+++ b/resources/views/adhoc-tasks/_form.blade.php
@@ -16,15 +16,13 @@
     </div>
 
     @if (Auth::user()->canManageUsers())
-        <div>
-            <label for="assignees" class="block font-semibold text-sm text-gray-700 mb-1">Tugaskan Kepada <span class="text-red-500">*</span></label>
-            {{-- MODIFIKASI: Ganti kelas menjadi tom-select-multiple --}}
-            <select name="assignees[]" id="assignees" class="tom-select-multiple" multiple required placeholder="Pilih anggota tim...">
-                @php
-                    $assignedUserIds = old('assignees', isset($task) ? $task->assignees->pluck('id')->all() : []);
-                @endphp
+        <div class="relative z-20">
+            <label for="assignees" class="block font-semibold text-sm text-gray-700 mb-1">
+                <i class="fas fa-users-line mr-2 text-gray-500"></i> Ditugaskan Kepada <span class="text-red-500">*</span>
+            </label>
+            <select name="assignees[]" id="assignees" class="block mt-1 w-full tom-select-multiple" multiple required placeholder="Pilih Anggota Tim...">
                 @foreach ($assignableUsers as $member)
-                    <option value="{{ $member->id }}" @selected(in_array($member->id, $assignedUserIds))>
+                    <option value="{{ $member->id }}" @selected(in_array($member->id, old('assignees', (isset($task) && $task->assignees) ? $task->assignees->pluck('id')->all() : [])))>
                         {{ $member->name }}
                     </option>
                 @endforeach


### PR DESCRIPTION
The 'Ditugaskan Kepada' (Assign To) field in the ad-hoc task creation form (`adhoc-tasks/_form.blade.php`) has been updated to match the structure and styling of the main task edit form (`tasks/edit.blade.php`).

This change addresses an inconsistency where the Tom Select multiple-choice input was not rendering or behaving correctly on the create form.

The key changes include:
- Updating the HTML structure and adding appropriate CSS classes (`block`, `w-full`) to the `<select>` element.
- Adopting the more robust Font Awesome icon in the label for better UI consistency.
- Ensuring the Blade logic for `@selected` options is safe for both create (new task) and edit (validation failure) contexts.