### PR TITLE
Fix: Corrected undefined method call in UnitController

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -117,13 +117,13 @@ class UnitController extends Controller
             if ($oldKepalaUnitId) {
                 $oldKepala = \App\Models\User::find($oldKepalaUnitId);
                 if ($oldKepala) {
-                    \App\Models\User::recalculateAndSaveRole($oldKepala);
+                    \App\Models\User::syncRoleFromUnit($oldKepala);
                 }
             }
             if ($newKepalaUnitId) {
                 $newKepala = \App\Models\User::find($newKepalaUnitId);
                 if ($newKepala) {
-                    \App\Models\User::recalculateAndSaveRole($newKepala);
+                    \App\Models\User::syncRoleFromUnit($newKepala);
                 }
             }
         }


### PR DESCRIPTION
In the `UnitController@update` method, a `BadMethodCallException` was being thrown due to a call to a non-existent method `recalculateAndSaveRole` on the `User` model.

This was likely a typo or a remnant of a previous refactoring. The correct method to call is `syncRoleFromUnit`, which exists on the `User` model and performs the intended action of updating a user's role based on their position as head of a unit.

This commit replaces the two incorrect calls to `recalculateAndSaveRole` with the correct calls to `syncRoleFromUnit`, resolving the exception.