### PR TITLE
Fix: Correct role calculation and data import logic

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -475,16 +475,19 @@ class User extends Authenticatable
         $newRoleName = 'Staf'; // Default role
 
         if ($isHeadOfUnit) {
+            // The `ancestors()` method includes the unit itself, so the depth count is off by 1.
+            // A top-level unit has 1 ancestor (itself). A child of it has 2, and so on.
+            // We adjust the depth check to match this 1-based index.
             $depth = $user->unit->ancestors()->count();
             $isStruktural = $user->unit->type === 'Struktural';
 
             $newRoleName = match (true) {
-                $depth === 1 => 'Eselon I',
-                $depth === 2 => 'Eselon II',
-                $depth === 3 && $isStruktural => 'Eselon III',
-                $depth === 3 && !$isStruktural => 'Koordinator',
-                $depth === 4 && $isStruktural => 'Eselon IV',
-                $depth === 4 && !$isStruktural => 'Sub Koordinator',
+                $depth === 2 => 'Eselon I', // Level 1 parent + self = 2
+                $depth === 3 => 'Eselon II', // Level 2 parents + self = 3
+                $depth === 4 && $isStruktural => 'Eselon III',
+                $depth === 4 && !$isStruktural => 'Koordinator',
+                $depth === 5 && $isStruktural => 'Eselon IV',
+                $depth === 5 && !$isStruktural => 'Sub Koordinator',
                 default => 'Staf',
             };
         }


### PR DESCRIPTION
This commit addresses several issues related to automatic user role assignment when a user is made the head of a unit.

The initial problem was a `BadMethodCallException` in `UnitController` due to a call to a non-existent method, `recalculateAndSaveRole`. This has been corrected to call the existing `syncRoleFromUnit` method.

A follow-up investigation revealed two deeper bugs:

1.  An off-by-one error in the role calculation logic within `User::syncRoleFromUnit`. The unit depth was calculated using `ancestors()->count()`, which includes the unit itself, but the role assignment logic expected a zero-indexed depth. The depth checks in the `match` statement have been adjusted to account for this.

2.  The `OrganizationalDataImporterService` was not setting the `type` ('Struktural' or 'Fungsional') for units during the data seeding process. This prevented the role logic from correctly differentiating between roles like 'Eselon III' and 'Koordinator'. The importer has been updated to derive the unit type from the user's "Jenis Jabatan" and save it.

These changes ensure that user roles are now calculated and assigned correctly based on their position in the organizational hierarchy.