### PR TITLE
feat: Implement role management for Jabatan

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -455,6 +455,49 @@ class User extends Authenticatable
         return $validParentRolesMap[$subordinateRole] ?? null;
     }
 
+    /**
+     * Get the list of available roles for assignment.
+     *
+     * @return array
+     */
+    public static function getAvailableRoles(): array
+    {
+        // This could also query the roles table, but a static list is fine for now.
+        return ['Staf', 'Sub Koordinator', 'Koordinator', 'Eselon IV', 'Eselon III', 'Eselon II', 'Eselon I', 'Menteri', 'Superadmin'];
+    }
+
+    /**
+     * Recalculate and save the user's role based on their current Jabatan.
+     *
+     * @param User $user
+     * @return void
+     */
+    public static function recalculateAndSaveRole(User $user): void
+    {
+        $user->load('jabatan');
+
+        $newRoleName = 'Staf'; // Default to 'Staf' if no specific role is found
+
+        if ($user->jabatan && $user->jabatan->role) {
+            $newRoleName = $user->jabatan->role;
+        }
+
+        // Find the role model by name
+        $newRole = Role::where('name', $newRoleName)->first();
+
+        if ($newRole) {
+            // Sync the new role, replacing any old ones.
+            $user->roles()->sync([$newRole->id]);
+        } else {
+            // If the role from Jabatan is not found in the roles table,
+            // default to Staf as a fallback.
+            $stafRole = Role::where('name', 'Staf')->first();
+            if ($stafRole) {
+                $user->roles()->sync([$stafRole->id]);
+            }
+        }
+    }
+
     public function leaveRequests() { return $this->hasMany(LeaveRequest::class); }
     public function leaveBalances() { return $this->hasMany(LeaveBalance::class); }
 

--- a/database/migrations/2025_09_08_031200_add_role_and_permissions_to_jabatans_table.php
+++ b/database/migrations/2025_09_08_031200_add_role_and_permissions_to_jabatans_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('jabatans', function (Blueprint $table) {
+            $table->string('role')->nullable()->after('name');
+            $table->boolean('can_manage_users')->default(false)->after('role');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('jabatans', function (Blueprint $table) {
+            $table->dropColumn('role');
+            $table->dropColumn('can_manage_users');
+        });
+    }
+};

--- a/resources/views/admin/jabatans/edit.blade.php
+++ b/resources/views/admin/jabatans/edit.blade.php
@@ -1,0 +1,51 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Edit Jabatan: {{ $jabatan->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <form action="{{ route('admin.jabatans.update', $jabatan) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+
+                        <!-- Nama Jabatan -->
+                        <div class="mb-4">
+                            <label for="name" class="block text-sm font-medium text-gray-700">Nama Jabatan</label>
+                            <input type="text" name="name" id="name" value="{{ old('name', $jabatan->name) }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                        </div>
+
+                        <!-- Role Jabatan -->
+                        <div class="mb-4">
+                            <label for="role" class="block text-sm font-medium text-gray-700">Peran (Role)</label>
+                            <select name="role" id="role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                                @foreach($availableRoles as $role)
+                                    <option value="{{ $role }}" @selected(old('role', $jabatan->role) == $role)>
+                                        {{ $role }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <!-- Can Manage Users -->
+                        <div class="mb-4">
+                            <label class="flex items-center">
+                                <input type="checkbox" name="can_manage_users" value="1" @checked(old('can_manage_users', $jabatan->can_manage_users))>
+                                <span class="ml-2 text-sm text-gray-600">Dapat Mengelola Pengguna di Bawahnya</span>
+                            </label>
+                        </div>
+
+                        <div class="flex justify-end">
+                            <a href="{{ route('admin.units.edit', $unit) }}" class="mr-4 inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-800 uppercase tracking-widest hover:bg-gray-300">Batal</a>
+                            <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700">Simpan Perubahan</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -66,13 +66,16 @@
                                         @endif
                                     </p>
                                 </div>
-                                @if(!$jabatan->user_id)
-                                    <form action="{{ route('admin.jabatans.destroy', $jabatan) }}" method="POST" onsubmit="return confirm('Yakin ingin menghapus jabatan ini?');">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="text-red-500 hover:text-red-700 text-sm font-medium">Hapus</button>
-                                    </form>
-                                @endif
+                                <div class="flex items-center space-x-4">
+                                    <a href="{{ route('admin.jabatans.edit', $jabatan) }}" class="text-indigo-600 hover:text-indigo-900 text-sm font-medium">Edit</a>
+                                    @if(!$jabatan->user_id)
+                                        <form action="{{ route('admin.jabatans.destroy', $jabatan) }}" method="POST" onsubmit="return confirm('Yakin ingin menghapus jabatan ini?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-500 hover:text-red-700 text-sm font-medium">Hapus</button>
+                                        </form>
+                                    @endif
+                                </div>
                             </li>
                         @empty
                             <li class="text-center text-gray-500 py-4">Belum ada jabatan yang didefinisikan untuk unit ini.</li>
@@ -82,12 +85,25 @@
                     <form action="{{ route('admin.units.jabatans.store', $unit) }}" method="POST" class="border-t border-gray-200 pt-6">
                         @csrf
                         <h4 class="font-semibold text-lg text-gray-800 mb-4">Tambah Jabatan Baru</h4>
-                        <div class="grid grid-cols-1 gap-6">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                             {{-- Nama Jabatan --}}
                             <div>
-                                <label for="jabatan_name" class="block text-sm font-medium text-gray-700">Nama Jabatan Fungsional <span class="text-red-500 font-bold">*</span></label>
+                                <label for="jabatan_name" class="block text-sm font-medium text-gray-700">Nama Jabatan <span class="text-red-500 font-bold">*</span></label>
                                 <input type="text" name="name" id="jabatan_name" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" placeholder="e.g., Pranata Komputer Muda" required>
-                                <p class="mt-1 text-xs text-gray-500">Ini adalah titel fungsional yang melekat pada pegawai, bukan peran struktural.</p>
+                            </div>
+                            {{-- Role Jabatan --}}
+                            <div>
+                                <label for="jabatan_role" class="block text-sm font-medium text-gray-700">Peran (Role) <span class="text-red-500 font-bold">*</span></label>
+                                <select name="role" id="jabatan_role" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" required>
+                                    @php
+                                        // We need the list of roles here. We can get it from the User model.
+                                        $availableRoles = \App\Models\User::getAvailableRoles();
+                                    @endphp
+                                    <option value="">-- Pilih Peran --</option>
+                                    @foreach($availableRoles as $role)
+                                        <option value="{{ $role }}">{{ $role }}</option>
+                                    @endforeach
+                                </select>
                             </div>
                         </div>
                         <div class="mt-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -253,6 +253,8 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     Route::get('units/workflow', [UnitController::class, 'showWorkflow'])->name('units.workflow');
     Route::resource('units', UnitController::class);
     Route::post('units/{unit}/jabatans', [UnitController::class, 'storeJabatan'])->name('units.jabatans.store');
+    Route::get('jabatans/{jabatan}/edit', [UnitController::class, 'editJabatan'])->name('jabatans.edit');
+    Route::put('jabatans/{jabatan}', [UnitController::class, 'updateJabatan'])->name('jabatans.update');
     Route::delete('jabatans/{jabatan}', [UnitController::class, 'destroyJabatan'])->name('jabatans.destroy');
 
     // User Import Routes


### PR DESCRIPTION
This commit introduces a comprehensive feature to manage user roles by associating them directly with their 'Jabatan' (Position). This addresses the issue where unit heads were not automatically receiving the correct role.

The key changes are:
- Added a 'role' column to the 'jabatans' table via a new migration.
- Implemented helper methods on the User model to get available roles and to recalculate a user's role based on their assigned Jabatan.
- Added `editJabatan` and `updateJabatan` methods to `UnitController` to handle the new functionality.
- Created a new view for editing a Jabatan's properties, including its role.
- Updated the "Add Jabatan" form to include a role selection dropdown.
- Added routes for the new functionality.

This provides administrators with explicit control over user roles, making the system more transparent and manageable.