### PR TITLE
feat: Implement role management for Jabatan

### DIFF
--- a/database/migrations/2025_09_08_031200_add_role_to_jabatans_table.php
+++ b/database/migrations/2025_09_08_031200_add_role_to_jabatans_table.php
@@ -13,7 +13,6 @@ return new class extends Migration
     {
         Schema::table('jabatans', function (Blueprint $table) {
             $table->string('role')->nullable()->after('name');
-            $table->boolean('can_manage_users')->default(false)->after('role');
         });
     }
 
@@ -24,7 +23,6 @@ return new class extends Migration
     {
         Schema::table('jabatans', function (Blueprint $table) {
             $table->dropColumn('role');
-            $table->dropColumn('can_manage_users');
         });
     }
 };


### PR DESCRIPTION
This commit introduces a comprehensive feature to manage user roles by associating them directly with their 'Jabatan' (Position). This addresses the issue where unit heads were not automatically receiving the correct role.

The key changes are:
- Added a 'role' column to the 'jabatans' table via a new migration.
- Implemented helper methods on the User model to get available roles and to recalculate a user's role based on their assigned Jabatan.
- Added `editJabatan` and `updateJabatan` methods to `UnitController` to handle the new functionality.
- Created a new view for editing a Jabatan's properties, including its role.
- Updated the "Add Jabatan" form to include a role selection dropdown.
- Added routes for the new functionality.

This provides administrators with explicit control over user roles, making the system more transparent and manageable.