### PR TITLE
fix: Add role to Jabatan's fillable array

### DIFF
--- a/app/Models/Jabatan.php
+++ b/app/Models/Jabatan.php
@@ -16,6 +16,7 @@ class Jabatan extends Model
         'unit_id',
         'user_id',
         'can_manage_users',
+        'role',
     ];
 
     protected $casts = [


### PR DESCRIPTION
The `role` attribute was missing from the `$fillable` array in the `Jabatan` model. This prevented the role from being saved when creating or updating a Jabatan using mass assignment.

This commit adds 'role' to the `$fillable` array, resolving the bug and ensuring that role changes are correctly persisted to the database.