### PR TITLE
feat: Implement Jabatan role management

### DIFF
--- a/resources/views/admin/jabatans/edit.blade.php
+++ b/resources/views/admin/jabatans/edit.blade.php
@@ -9,7 +9,7 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
-                    <form action="{{ route('admin.jabatans.update', $jabatan) }}" method="POST">
+                    <form action="{{ url('/admin/jabatans/' . $jabatan->id) }}" method="POST">
                         @csrf
                         @method('PUT')
 


### PR DESCRIPTION
This commit introduces a comprehensive feature to manage user roles by associating them directly with their 'Jabatan' (Position).

The key changes are:
- Added a 'role' column to the 'jabatans' table via a new migration.
- Implemented helper methods on the User model to get available roles and to recalculate a user's role based on their assigned Jabatan.
- Consolidated all Jabatan CRUD logic into the `UnitController`.
- Created a new view for editing a Jabatan's properties, including its role, accessible from the User Edit page.
- Updated the "Add Jabatan" form to include a role selection dropdown.
- Added routes for the new functionality.
- Implemented a workaround for a persistent 'Route not defined' error by generating the edit link and form action URLs directly via the `url()` helper instead of the `route()` name helper.