### PR TITLE
feat: Implement Jabatan role management with debug changes

### DIFF
--- a/resources/views/admin/jabatans/edit.blade.php
+++ b/resources/views/admin/jabatans/edit.blade.php
@@ -16,13 +16,13 @@
                         <!-- Nama Jabatan -->
                         <div class="mb-4">
                             <label for="name" class="block text-sm font-medium text-gray-700">Nama Jabatan</label>
-                            <input type="text" name="name" id="name" value="{{ old('name', $jabatan->name) }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                            <input type="text" name="name" id="name" value="{{ old('name', $jabatan->name) }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
                         </div>
 
                         <!-- Role Jabatan -->
                         <div class="mb-4">
                             <label for="role" class="block text-sm font-medium text-gray-700">Peran (Role)</label>
-                            <select name="role" id="role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                            <select name="role" id="role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
                                 @foreach($availableRoles as $role)
                                     <option value="{{ $role }}" @selected(old('role', $jabatan->role) == $role)>
                                         {{ $role }}


### PR DESCRIPTION
This commit implements a comprehensive feature to manage user roles by associating them directly with their 'Jabatan' (Position).

The key changes are:
- Added a 'role' column to the 'jabatans' table.
- Consolidated all Jabatan CRUD logic into the `UnitController`.
- Created views for creating and editing Jabatan roles.
- Implemented a workaround for a persistent 'Route not defined' error by generating URLs directly via the `url()` helper.
- Removed `required` attributes from the `jabatans` edit form to debug a client-side issue where the form was not being sent.