### PR TITLE
feat: Implement and refactor Jabatan role management

### DIFF
--- a/resources/views/admin/jabatans/edit.blade.php
+++ b/resources/views/admin/jabatans/edit.blade.php
@@ -16,13 +16,13 @@
                         <!-- Nama Jabatan -->
                         <div class="mb-4">
                             <label for="name" class="block text-sm font-medium text-gray-700">Nama Jabatan</label>
-                            <input type="text" name="name" id="name" value="{{ old('name', $jabatan->name) }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                            <input type="text" name="name" id="name" value="{{ old('name', $jabatan->name) }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
                         </div>
 
                         <!-- Role Jabatan -->
                         <div class="mb-4">
                             <label for="role" class="block text-sm font-medium text-gray-700">Peran (Role)</label>
-                            <select name="role" id="role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                            <select name="role" id="role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
                                 @foreach($availableRoles as $role)
                                     <option value="{{ $role }}" @selected(old('role', $jabatan->role) == $role)>
                                         {{ $role }}


### PR DESCRIPTION
This commit introduces a comprehensive feature to manage user roles by associating them directly with their 'Jabatan' (Position).

The key changes are:
- Added a 'role' column to the 'jabatans' table via a new migration.
- Implemented helper methods on the User model to get available roles and to recalculate a user's role based on their assigned Jabatan.
- Consolidated all Jabatan CRUD logic into the `UnitController`.
- Created a new view for editing a Jabatan's properties, including its role, accessible from the User Edit page.
- Updated the "Add Jabatan" form to include a role selection dropdown.
- Added routes for the new functionality.
- Implemented a workaround for a persistent 'Route not defined' error by generating URLs directly via the `url()` helper.
- Ensured the `updateJabatan` method correctly returns a redirect response.