### PR TITLE
Fix: Correct redirect after updating Jabatan

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -223,6 +223,7 @@ class UnitController extends Controller
 
     public function updateJabatan(Request $request, \App\Models\Jabatan $jabatan)
     {
+        // Mendapatkan unit dari relasi jabatan
         $unit = $jabatan->unit;
         $this->authorize('update', $unit);
 
@@ -242,7 +243,8 @@ class UnitController extends Controller
             \App\Models\User::recalculateAndSaveRole($jabatan->user);
         }
 
-        return back()->with('success', 'Jabatan berhasil diperbarui.');
+        // Menggunakan variabel $unit yang sudah didapatkan
+        return redirect()->route('admin.units.edit', $unit)->with('success', 'Jabatan berhasil diperbarui.');
     }
 
     public function destroyJabatan(\App\Models\Jabatan $jabatan)

--- a/resources/views/admin/jabatans/edit.blade.php
+++ b/resources/views/admin/jabatans/edit.blade.php
@@ -9,7 +9,7 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
-                    <form action="{{ url('/admin/jabatans/' . $jabatan->id) }}" method="POST">
+                    <form action="{{ route('admin.jabatans.update', $jabatan) }}" method="POST">
                         @csrf
                         @method('PUT')
 


### PR DESCRIPTION
The 'Simpan Perubahan' button on the 'edit jabatan' page was not working as expected. This was due to two issues:

1. The form action was using a hardcoded URL instead of the `route()` helper.
2. The redirect logic in the `updateJabatan` method in `UnitController` was not redirecting to the correct page.

This commit fixes these issues by:

- Updating the form action in `resources/views/admin/jabatans/edit.blade.php` to use the `route()` helper.
- Modifying the `updateJabatan` method in `app/Http/Controllers/UnitController.php` to redirect to the `admin.units.edit` route after a successful update.