### PR TITLE
Refactor: Create JabatanController for CRUD operations

### DIFF
--- a/app/Http/Controllers/Admin/JabatanController.php
+++ b/app/Http/Controllers/Admin/JabatanController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Jabatan;
+use App\Models\Unit;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+class JabatanController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        // Simple index method to list all jabatans.
+        // In a real app, this would be paginated.
+        $jabatans = Jabatan::with('unit', 'user')->latest()->get();
+        return view('admin.jabatans.index', compact('jabatans'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        $this->authorize('create', Unit::class);
+        $units = Unit::orderBy('name')->get();
+        $availableRoles = User::getAvailableRoles();
+        return view('admin.jabatans.create', compact('units', 'availableRoles'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $this->authorize('create', Jabatan::class);
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'unit_id' => 'required|exists:units,id',
+            'can_manage_users' => ['nullable', 'boolean'],
+            'role' => ['required', 'string', Rule::in(User::getAvailableRoles())],
+        ]);
+
+        $unit = Unit::find($validated['unit_id']);
+        $this->authorize('update', $unit);
+
+        $dataToCreate = [
+            'name' => $validated['name'],
+            'can_manage_users' => $request->has('can_manage_users'),
+            'role' => $validated['role'],
+        ];
+
+        $unit->jabatans()->create($dataToCreate);
+
+        return redirect()->route('admin.units.edit', $unit)->with('success', 'Jabatan berhasil ditambahkan.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Jabatan $jabatan)
+    {
+        $unit = $jabatan->unit;
+        // The authorization might need to be adapted depending on the policy.
+        // Assuming authorization is based on the unit.
+        $this->authorize('update', $unit);
+
+        $availableRoles = User::getAvailableRoles();
+        $user = $jabatan->user;
+
+        return view('admin.jabatans.edit', compact('jabatan', 'unit', 'user', 'availableRoles'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Jabatan $jabatan)
+    {
+        $unit = $jabatan->unit;
+        $this->authorize('update', $unit);
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255', Rule::unique('jabatans')->ignore($jabatan->id)],
+            'can_manage_users' => ['nullable', 'boolean'],
+            'role' => ['required', 'string', Rule::in(User::getAvailableRoles())],
+        ]);
+
+        $oldRole = $jabatan->role;
+        $jabatan->name = $validated['name'];
+        $jabatan->can_manage_users = $request->has('can_manage_users');
+        $jabatan->role = $validated['role'];
+        $jabatan->save();
+
+        if ($oldRole !== $validated['role'] && $jabatan->user) {
+            User::recalculateAndSaveRole($jabatan->user);
+        }
+
+        // Redirect back to the unit's edit page for a consistent user experience.
+        return redirect()->route('admin.units.edit', $unit)->with('success', 'Jabatan berhasil diperbarui.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Jabatan $jabatan)
+    {
+        $unit = $jabatan->unit;
+        $this->authorize('update', $unit);
+
+        if ($jabatan->user_id) {
+            return back()->with('error', 'Tidak dapat menghapus jabatan yang masih diisi oleh pengguna.');
+        }
+
+        $jabatan->delete();
+
+        return back()->with('success', 'Jabatan berhasil dihapus.');
+    }
+}

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -190,77 +190,7 @@ class UnitController extends Controller
         $user->delete();
     }
 
-    public function storeJabatan(Request $request, Unit $unit)
-    {
-        $this->authorize('update', $unit);
 
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
-            'can_manage_users' => ['nullable', 'boolean'],
-            'role' => ['required', 'string', Rule::in(\App\Models\User::getAvailableRoles())],
-        ]);
-
-        $dataToCreate = [
-            'name' => $validated['name'],
-            'can_manage_users' => $request->has('can_manage_users'),
-            'role' => $validated['role'],
-        ];
-
-        $unit->jabatans()->create($dataToCreate);
-
-        return back()->with('success', 'Jabatan berhasil ditambahkan.');
-    }
-
-    public function editJabatan(\App\Models\Jabatan $jabatan)
-    {
-        $unit = $jabatan->unit;
-        $this->authorize('update', $unit);
-        $availableRoles = \App\Models\User::getAvailableRoles();
-        $user = $jabatan->user; // Pass user to view if it exists
-
-        return view('admin.jabatans.edit', compact('jabatan', 'unit', 'user', 'availableRoles'));
-    }
-
-    public function updateJabatan(Request $request, \App\Models\Jabatan $jabatan)
-    {
-        $unit = $jabatan->unit;
-        $this->authorize('update', $unit);
-
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255', Rule::unique('jabatans')->ignore($jabatan->id)],
-            'can_manage_users' => ['nullable', 'boolean'],
-            'role' => ['required', 'string', Rule::in(\App\Models\User::getAvailableRoles())],
-        ]);
-
-        $oldRole = $jabatan->role;
-        $jabatan->name = $validated['name'];
-        $jabatan->can_manage_users = $request->has('can_manage_users');
-        $jabatan->role = $validated['role'];
-        $jabatan->save();
-
-        if ($oldRole !== $validated['role'] && $jabatan->user) {
-            \App\Models\User::recalculateAndSaveRole($jabatan->user);
-        }
-
-        // Get the unit from the jabatan relationship before redirecting
-        $unit = $jabatan->unit;
-
-        return redirect()->route('admin.units.edit', $unit)->with('success', 'Jabatan berhasil diperbarui.');
-    }
-
-    public function destroyJabatan(\App\Models\Jabatan $jabatan)
-    {
-        $unit = $jabatan->unit;
-        $this->authorize('update', $unit);
-
-        if ($jabatan->user_id) {
-            return back()->with('error', 'Tidak dapat menghapus jabatan yang masih diisi oleh pengguna.');
-        }
-
-        $jabatan->delete();
-
-        return back()->with('success', 'Jabatan berhasil dihapus.');
-    }
 
     public function getChildren(Unit $unit)
     {

--- a/resources/views/admin/jabatans/create.blade.php
+++ b/resources/views/admin/jabatans/create.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            Edit Jabatan: {{ $jabatan->name }}
+            Buat Jabatan Baru
         </h2>
     </x-slot>
 
@@ -9,14 +9,26 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
-                    <form action="{{ route('admin.jabatans.update', $jabatan) }}" method="POST">
+                    <form action="{{ route('admin.jabatans.store') }}" method="POST">
                         @csrf
-                        @method('PUT')
 
                         <!-- Nama Jabatan -->
                         <div class="mb-4">
                             <label for="name" class="block text-sm font-medium text-gray-700">Nama Jabatan</label>
-                            <input type="text" name="name" id="name" value="{{ old('name', $jabatan->name) }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                            <input type="text" name="name" id="name" value="{{ old('name') }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                        </div>
+
+                        <!-- Unit -->
+                        <div class="mb-4">
+                            <label for="unit_id" class="block text-sm font-medium text-gray-700">Unit</label>
+                            <select name="unit_id" id="unit_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                                <option value="">Pilih Unit</option>
+                                @foreach($units as $unit)
+                                    <option value="{{ $unit->id }}" @selected(old('unit_id') == $unit->id)>
+                                        {{ $unit->name }}
+                                    </option>
+                                @endforeach
+                            </select>
                         </div>
 
                         <!-- Role Jabatan -->
@@ -24,7 +36,7 @@
                             <label for="role" class="block text-sm font-medium text-gray-700">Peran (Role)</label>
                             <select name="role" id="role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
                                 @foreach($availableRoles as $role)
-                                    <option value="{{ $role }}" @selected(old('role', $jabatan->role) == $role)>
+                                    <option value="{{ $role }}" @selected(old('role') == $role)>
                                         {{ $role }}
                                     </option>
                                 @endforeach
@@ -34,18 +46,14 @@
                         <!-- Can Manage Users -->
                         <div class="mb-4">
                             <label class="flex items-center">
-                                <input type="checkbox" name="can_manage_users" value="1" @checked(old('can_manage_users', $jabatan->can_manage_users))>
+                                <input type="checkbox" name="can_manage_users" value="1" @checked(old('can_manage_users'))>
                                 <span class="ml-2 text-sm text-gray-600">Dapat Mengelola Pengguna di Bawahnya</span>
                             </label>
                         </div>
 
                         <div class="flex justify-end">
-                            @if(isset($user) && $user)
-                                <a href="{{ route('users.edit', $user) }}" class="mr-4 inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-800 uppercase tracking-widest hover:bg-gray-300">Batal</a>
-                            @else
-                                <a href="{{ route('admin.units.edit', $unit) }}" class="mr-4 inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-800 uppercase tracking-widest hover:bg-gray-300">Batal</a>
-                            @endif
-                            <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700">Simpan Perubahan</button>
+                            <a href="{{ url()->previous() }}" class="mr-4 inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-800 uppercase tracking-widest hover:bg-gray-300">Batal</a>
+                            <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700">Simpan</button>
                         </div>
                     </form>
                 </div>

--- a/resources/views/admin/jabatans/index.blade.php
+++ b/resources/views/admin/jabatans/index.blade.php
@@ -1,0 +1,52 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Daftar Jabatan
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Nama Jabatan
+                                </th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Unit
+                                </th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Pengguna
+                                </th>
+                                <th scope="col" class="relative px-6 py-3">
+                                    <span class="sr-only">Edit</span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach ($jabatans as $jabatan)
+                                <tr>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                        {{ $jabatan->name }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {{ $jabatan->unit->name ?? 'N/A' }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {{ $jabatan->user->name ?? 'Kosong' }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                        <a href="{{ route('admin.jabatans.edit', $jabatan) }}" class="text-indigo-600 hover:text-indigo-900">Edit</a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -230,6 +230,7 @@ use App\Http\Controllers\Admin\ApprovalWorkflowController;
 use App\Http\Controllers\Admin\DelegationController;
 use App\Http\Controllers\Api\UnitApiController;
 use App\Http\Controllers\UnitController;
+use App\Http\Controllers\Admin\JabatanController;
 
 require __DIR__.'/auth.php';
 
@@ -253,9 +254,9 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     Route::get('units/workflow', [UnitController::class, 'showWorkflow'])->name('units.workflow');
     Route::resource('units', UnitController::class);
     Route::post('units/{unit}/jabatans', [UnitController::class, 'storeJabatan'])->name('units.jabatans.store');
-    Route::get('jabatans/{jabatan}/edit', [UnitController::class, 'editJabatan'])->name('admin.jabatans.edit');
-    Route::put('jabatans/{jabatan}', [UnitController::class, 'updateJabatan'])->name('admin.jabatans.update');
-    Route::delete('jabatans/{jabatan}', [UnitController::class, 'destroyJabatan'])->name('jabatans.destroy');
+
+    // Refactored to use JabatanController
+    Route::resource('jabatans', JabatanController::class)->except(['show']);
 
     // User Import Routes
     Route::get('/users/import', [UserController::class, 'showImportForm'])->name('users.import.show');


### PR DESCRIPTION
The previous implementation for managing 'Jabatans' (positions) had its logic incorrectly placed within the `UnitController`. This unconventional structure led to persistent routing issues and made the 'Save Changes' button on the edit page non-functional.

This commit refactors the entire feature to follow standard Laravel conventions:

1.  A new `JabatanController` has been created at `app/Http/Controllers/Admin/JabatanController.php` to encapsulate all CRUD logic for jabatans.
2.  The `edit`, `update`, `create`, `store`, and `destroy` methods have been moved from `UnitController` to `JabatanController`.
3.  The `routes/web.php` file has been updated to use `Route::resource` for `jabatans`, pointing to the new controller. This cleans up the route definitions and ensures they work as expected.
4.  The now-obsolete `jabatan`-related methods have been removed from `UnitController`.
5.  New views for creating and listing jabatans have been added to support the full resourceful controller.

This refactoring resolves the original bug in a robust and maintainable way.