### PR TITLE
Refactor: Jabatan CRUD and Fix Role Assignment Logic

### DIFF
--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -104,16 +104,9 @@ function form_textarea($label, $name, $user, $is_required = false) {
 
         @if($user->jabatan)
         <div class="p-4 mt-4 bg-indigo-50 border border-indigo-200 rounded-lg">
-            <h4 class="font-semibold text-gray-800">Jabatan Saat Ini</h4>
-            <p class="text-sm text-gray-600">
-                <span class="font-medium">{{ $user->jabatan->name }}</span>
-            </p>
-            <p class="text-sm text-gray-500">
-                Peran: <span class="font-semibold">{{ $user->jabatan->role ?? 'Belum Diatur' }}</span>
-            </p>
             <div class="mt-3">
-                <a href="{{ url('/admin/jabatans/' . $user->jabatan->id . '/edit') }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150">
-                    <i class="fas fa-pencil-alt mr-2"></i> Edit Jabatan & Peran
+                <a href="{{ route('admin.jabatans.edit', $user->jabatan) }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150">
+                    <i class="fas fa-pencil-alt mr-2"></i> Edit Jabatan
                 </a>
             </div>
         </div>


### PR DESCRIPTION
This commit addresses several issues related to Jabatan (position) management and role assignment.

1.  **Refactor Jabatan CRUD to dedicated controller:** The logic for managing Jabatans was previously located in the `UnitController`, which was unconventional and caused routing issues. This has been refactored into a new, dedicated `JabatanController` at `app/Http/Controllers/Admin/JabatanController.php`. The `routes/web.php` file has been updated to use `Route::resource` for this new controller, following Laravel best practices. All related logic and views have been created or updated accordingly. This fixes the original bug where the "Save Changes" button on the edit page was not working.

2.  **Fix Role Assignment in Data Importer:** A bug was identified where user roles were being assigned incorrectly because the data importer did not account for a new top-level 'Menteri' unit. The `OrganizationalDataImporterService` has been updated to create a root 'Kementerian Ketenagakerjaan' unit, which corrects the hierarchy depth calculation and ensures roles are assigned correctly based on the new structure.

3.  **Clean up User Edit UI:** The user profile edit page has been cleaned up to remove redundant text displaying the current Jabatan and Role, as this information is now handled more automatically. The edit button has also been simplified.