### PR TITLE
Feat: Add Plt/Plh for vacant units and fix role logic

### DIFF
--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -48,6 +48,58 @@
                 </div>
             </div>
 
+            {{-- Card for Temporary Head (Plt./Plh.) Assignment --}}
+            @if(!$unit->kepala_unit_id)
+            <div class="mt-8 bg-yellow-50 border-2 border-yellow-200 overflow-hidden shadow-xl sm:rounded-lg">
+                <div class="p-6">
+                    <h3 class="text-lg font-semibold text-yellow-800 mb-2">
+                        <i class="fas fa-user-clock mr-2"></i>Jabatan Kepala Unit Kosong
+                    </h3>
+                    <p class="text-sm text-yellow-700 mb-4">
+                        Unit ini tidak memiliki kepala definitif. Anda dapat menunjuk Pelaksana Tugas (Plt.) atau Pelaksana Harian (Plh.) untuk mengisi posisi ini sementara.
+                    </p>
+                    <form action="{{ route('admin.units.delegation.store', $unit) }}" method="POST">
+                        @csrf
+                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                            {{-- User Selection --}}
+                            <div>
+                                <label for="delegation_user_id" class="block text-sm font-medium text-gray-700">Pilih Pengguna <span class="text-red-500">*</span></label>
+                                <select name="user_id" id="delegation_user_id" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                    <option value="">-- Pilih Pengguna --</option>
+                                    @foreach($usersInUnit as $user)
+                                        <option value="{{ $user->id }}">{{ $user->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                             {{-- Type Selection --}}
+                            <div>
+                                <label for="delegation_type" class="block text-sm font-medium text-gray-700">Tipe <span class="text-red-500">*</span></label>
+                                <select name="type" id="delegation_type" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                    <option value="Plt">Plt (Pelaksana Tugas)</option>
+                                    <option value="Plh">Plh (Pelaksana Harian)</option>
+                                </select>
+                            </div>
+                            {{-- Start Date --}}
+                            <div>
+                                <label for="delegation_start_date" class="block text-sm font-medium text-gray-700">Tanggal Mulai <span class="text-red-500">*</span></label>
+                                <input type="date" name="start_date" id="delegation_start_date" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                            </div>
+                            {{-- End Date --}}
+                            <div>
+                                <label for="delegation_end_date" class="block text-sm font-medium text-gray-700">Tanggal Selesai <span class="text-red-500">*</span></label>
+                                <input type="date" name="end_date" id="delegation_end_date" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                            </div>
+                        </div>
+                        <div class="flex justify-end mt-6">
+                            <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-yellow-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md">
+                                <i class="fas fa-user-plus mr-2"></i> Tetapkan Pejabat Sementara
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            @endif
+
             {{-- Card for Jabatan Management --}}
             <div class="mt-8 bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">

--- a/routes/web.php
+++ b/routes/web.php
@@ -252,6 +252,7 @@ Route::get('/api/units/{parentUnit}/children', [UnitApiController::class, 'getCh
 
 Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('units/workflow', [UnitController::class, 'showWorkflow'])->name('units.workflow');
+    Route::post('units/{unit}/delegation', [UnitController::class, 'storeUnitDelegation'])->name('units.delegation.store');
     Route::resource('units', UnitController::class);
     Route::post('units/{unit}/jabatans', [UnitController::class, 'storeJabatan'])->name('units.jabatans.store');
 


### PR DESCRIPTION
This commit includes several major fixes and features related to Jabatan (position) management, role assignment, and delegations.

1.  **Refactor Jabatan CRUD**: Moved all Jabatan management logic from the `UnitController` to a new, dedicated `JabatanController`, following standard Laravel conventions. This fixed the original bug where the 'Save Changes' button was non-functional.

2.  **Fix Role Assignment Logic**: Modified the `OrganizationalDataImporterService` to correctly handle a top-level 'Menteri' unit. This ensures the organizational hierarchy depth is calculated correctly, which in turn assigns the proper roles to all users during data seeding.

3.  **Remove Jabatan Edit Functionality**: As requested, the ability to edit a Jabatan after creation has been removed. This includes removing the UI, controller methods, routes, and view files related to editing a Jabatan.

4.  **Implement Plt/Plh for Vacant Units**: Added a new feature to allow the assignment of a temporary head (Plt/Plh) to a Unit with a vacant head position. This functionality is integrated directly into the 'Edit Unit' page for a better user workflow.

5.  **Add Delegation Validation**: Implemented a new validation rule to ensure that a user being delegated as a Plt/Plh has a role level equal to or higher than the position they are temporarily filling.