### PR TITLE
Feat: Implement enhanced delegation and fix role/jabatan logic

### DIFF
--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -66,9 +66,11 @@
                                 <label for="delegation_user_id" class="block text-sm font-medium text-gray-700">Pilih Pengguna <span class="text-red-500">*</span></label>
                                 <select name="user_id" id="delegation_user_id" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
                                     <option value="">-- Pilih Pengguna --</option>
-                                    @foreach($allUsers as $user)
+                                    @forelse($eligibleDelegates as $user)
                                         <option value="{{ $user->id }}">{{ $user->name }}</option>
-                                    @endforeach
+                                    @empty
+                                        <option value="" disabled>Tidak ada pengguna dengan level yang sama ditemukan.</option>
+                                    @endforelse
                                 </select>
                             </div>
                              {{-- Type Selection --}}


### PR DESCRIPTION
This commit delivers a comprehensive update that addresses several issues and adds new functionality related to delegations (Plt/Plh), role assignments, and Jabatan (position) management.

Key changes:

1.  **New Feature: Plt/Plh for Vacant Units**
    - Implements a feature to allow assigning a temporary head (Plt/Plh) to a Unit with a vacant head position.
    - This functionality is integrated directly into the 'Edit Unit' page for a better user workflow.
    - Adds strict validation to ensure the delegated user has the exact same role level as the position they are filling.
    - The dropdown list of users for delegation is now correctly filtered to show only eligible candidates from all units.

2.  **Bug Fix: Role Assignment Logic**
    - Corrects a bug in the `OrganizationalDataImporterService` that caused incorrect role assignments.
    - The importer now creates a root 'Kementerian Ketenagakerjaan' unit, ensuring the organizational hierarchy depth is calculated correctly and roles are assigned based on the proper depth.

3.  **Refactor: Jabatan CRUD**
    - To fix an initial bug with a non-functional save button, the Jabatan management logic was refactored out of `UnitController` and into its own dedicated `JabatanController`, following Laravel best practices.

4.  **Feature Removal: Edit Jabatan**
    - As requested, the ability to edit a Jabatan after creation has been removed. The UI, controller methods, routes, and view files related to editing a Jabatan have been deleted.