### PR TITLE
Feat: Implement Intelligent Delegation, Fix Roles, and Refactor

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -207,25 +207,18 @@ class Unit extends Model
      */
     public function getExpectedHeadRole(): ?string
     {
-        // Mapping from hierarchy level (depth) to the expected role name.
-        // Level 0 = Top level (no parent)
+        // The depth is the number of ancestors, which is 1-based (root is 1).
+        $depth = $this->ancestors()->count();
+
+        // Mapping from hierarchy depth to the expected role name for the HEAD of that unit.
         $roleMap = [
-            0 => 'Eselon I',
-            1 => 'Eselon II',
-            2 => 'Koordinator',
-            3 => 'Sub Koordinator',
+            1 => 'Menteri',          // A unit with depth 1 (root) is headed by a Menteri.
+            2 => 'Eselon I',        // A unit with depth 2 is headed by an Eselon I.
+            3 => 'Eselon II',       // A unit with depth 3 is headed by an Eselon II.
+            4 => 'Koordinator',     // A unit with depth 4 is headed by a Koordinator.
+            5 => 'Sub Koordinator', // A unit with depth 5 is headed by a Sub Koordinator.
         ];
 
-        $level = 0;
-        $current = $this;
-
-        // Traverse up the hierarchy to determine the level.
-        // This is efficient if 'parentUnitRecursive' has been eager-loaded.
-        while ($current && $current->parentUnit) {
-            $level++;
-            $current = $current->parentUnit;
-        }
-
-        return $roleMap[$level] ?? null;
+        return $roleMap[$depth] ?? null;
     }
 }


### PR DESCRIPTION
This commit delivers a comprehensive update that addresses several issues and adds new functionality related to delegations (Plt/Plh), role assignments, and Jabatan (position) management.

Key changes:

1.  **New Feature: Intelligent Delegation for Vacant Units**
    - Implements a feature to assign a temporary head (Plt/Plh) to a Unit with a vacant head position, managed directly from the 'Edit Unit' page.
    - The list of eligible users for delegation is now correctly filtered to show only users from any unit who have the exact same role level as the vacant position (e.g., an Eselon II vacancy can only be filled by another Eselon II user).
    - The dropdown for selecting a definitive 'Kepala Unit' is also now intelligently filtered to only show users within that unit who have the appropriate role for that unit's level in the hierarchy.

2.  **Bug Fix: Role Assignment Logic**
    - Corrects a bug in the `OrganizationalDataImporterService` that caused incorrect role assignments.
    - The importer now creates a root 'Kementerian Ketenagakerjaan' unit, ensuring the organizational hierarchy depth is calculated correctly, which in turn assigns the proper roles to all users during data seeding.

3.  **Refactoring and Cleanup**
    - To fix an initial bug with a non-functional save button, the Jabatan management logic was refactored out of `UnitController` and into its own dedicated `JabatanController`.
    - As requested, the ability to edit a Jabatan after creation has been removed. All related UI, controller methods, routes, and view files have been deleted or updated to reflect this.
    - Corrected a `RouteNotFoundException` that occurred post-refactoring by updating the relevant form action.