### PR TITLE
feat: Implement Plt/Plh delegation and refactor Jabatan management

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -25,15 +25,13 @@ class UnitController extends Controller
     {
         $this->authorize('viewAny', Unit::class);
         
-        // PENTING: Perbaiki eager loading di sini.
-        // Kita perlu secara eksplisit memuat relasi yang akan digunakan di view
-        // untuk setiap level hierarki.
+        // Eager load relationships for efficiency
         $units = Unit::with([
-            'kepalaUnit',
+            'kepalaUnit', // Definitive head
+            'jabatans.delegations.user', // Delegated head
             'parentUnit',
             'childrenRecursive' => function ($query) {
-                // Muat relasi-relasi yang dibutuhkan untuk anak-anak
-                $query->with('kepalaUnit', 'parentUnit');
+                $query->with('kepalaUnit', 'jabatans.delegations.user', 'parentUnit');
             }
         ])
         ->whereNull('parent_unit_id')

--- a/app/Models/Jabatan.php
+++ b/app/Models/Jabatan.php
@@ -42,4 +42,9 @@ class Jabatan extends Model
     {
         return $this->hasMany(Jabatan::class, 'parent_id');
     }
+
+    public function delegations(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(Delegation::class);
+    }
 }

--- a/resources/views/admin/units/partials/_unit-tree-item.blade.php
+++ b/resources/views/admin/units/partials/_unit-tree-item.blade.php
@@ -18,7 +18,17 @@
 
         {{-- Kepala Unit --}}
         <div class="w-1/4 text-sm text-gray-600">
-            {{ $unit->kepalaUnit->name ?? '---' }}
+            @php $displayableHead = $unit->displayable_head; @endphp
+            @if($displayableHead)
+                {{ $displayableHead->name }}
+                @if($displayableHead->is_delegate)
+                    <span class="ml-2 px-2 py-0.5 bg-yellow-200 text-yellow-800 text-xs font-bold rounded-full">
+                        {{ $displayableHead->delegation_type }}
+                    </span>
+                @endif
+            @else
+                <span class="text-gray-400 italic">--- Kosong ---</span>
+            @endif
         </div>
 
         {{-- Unit Atasan --}}


### PR DESCRIPTION
This commit introduces several major features and improvements to the organizational management module:

1.  **Plt/Plh Delegation for Vacant Positions:**
    - Adds a form to the "Edit Unit" page that allows assigning a temporary (Plt. or Plh.) head to a unit where the head position is vacant.
    - Implements strict validation to ensure that only users with the exact same role as the vacant position can be appointed as Plt/Plh.
    - Updates the main unit list to display a "(Plt.)" or "(Plh.)" badge next to the names of temporary heads.
    - A new `getDisplayableHeadAttribute` accessor on the `Unit` model simplifies the logic for finding and displaying the definitive or delegated head.

2.  **Refactor Jabatan Management:**
    - Creates a new dedicated `JabatanController` to handle all CRUD operations for `Jabatan` (positions), following Laravel best practices.
    - Moves all relevant logic from `UnitController` to the new `JabatanController`.
    - Updates `routes/web.php` to use `Route::resource` for the new controller.

3.  **Remove Jabatan Editing:**
    - As roles are now fully automated based on the hierarchy, the ability to manually edit a `Jabatan` has been removed.
    - The "Edit Jabatan" button and related sections have been removed from the user profile view.
    - The `edit` and `update` methods and routes for `JabatanController` have been removed.

4.  **Bug Fixes:**
    - Corrects a bug in the `OrganizationalDataImporterService` where role assignments were incorrect due to a miscalculation of hierarchy depth. The importer now correctly handles the top-level "Kementerian" unit.
    - Fixes the original bug where the "Simpan" (Save) button on the user profile page was not correctly creating a new `Jabatan` due to a routing issue.