### PR TITLE
fix: Correct logic for saving temporary delegations

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -207,16 +207,18 @@ class Unit extends Model
      */
     public function getExpectedHeadRole(): ?string
     {
-        // The depth is the number of ancestors, which is 1-based (root is 1).
+        // The depth is the number of ancestors. This is 0-indexed.
+        // Root (Kementerian) has depth 0. Its children have depth 1, and so on.
         $depth = $this->ancestors()->count();
 
-        // Mapping from hierarchy depth to the expected role name for the HEAD of that unit.
+        // A unit at a given depth is headed by an official of the corresponding role level.
+        // e.g., A unit at depth 1 (Eselon I unit) is headed by an 'Eselon I' official.
         $roleMap = [
-            1 => 'Menteri',          // A unit with depth 1 (root) is headed by a Menteri.
-            2 => 'Eselon I',        // A unit with depth 2 is headed by an Eselon I.
-            3 => 'Eselon II',       // A unit with depth 3 is headed by an Eselon II.
-            4 => 'Koordinator',     // A unit with depth 4 is headed by a Koordinator.
-            5 => 'Sub Koordinator', // A unit with depth 5 is headed by a Sub Koordinator.
+            0 => 'Menteri',          // Depth 0 (Root) is headed by a Menteri.
+            1 => 'Eselon I',        // Depth 1 (Child of Root) is headed by an Eselon I.
+            2 => 'Eselon II',       // Depth 2 is headed by an Eselon II.
+            3 => 'Koordinator',     // Depth 3 is headed by a Koordinator.
+            4 => 'Sub Koordinator', // Depth 4 is headed by a Sub Koordinator.
         ];
 
         return $roleMap[$depth] ?? null;

--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -64,14 +64,17 @@
                             {{-- User Selection --}}
                             <div>
                                 <label for="delegation_user_id" class="block text-sm font-medium text-gray-700">Pilih Pengguna <span class="text-red-500">*</span></label>
-                                <select name="user_id" id="delegation_user_id" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                <select name="user_id" id="delegation_user_id" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 @error('user_id') border-red-500 @enderror focus:border-indigo-500 focus:ring-indigo-500" required>
                                     <option value="">-- Pilih Pengguna --</option>
                                     @forelse($eligibleDelegates as $user)
-                                        <option value="{{ $user->id }}">{{ $user->name }}</option>
+                                        <option value="{{ $user->id }}" {{ old('user_id') == $user->id ? 'selected' : '' }}>{{ $user->name }}</option>
                                     @empty
-                                        <option value="" disabled>Tidak ada pengguna dengan level yang sama ditemukan.</option>
+                                        <option value="" disabled>Tidak ada pengguna dengan level peran yang sama ditemukan.</option>
                                     @endforelse
                                 </select>
+                                @error('user_id')
+                                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
                             </div>
                              {{-- Type Selection --}}
                             <div>


### PR DESCRIPTION
This commit fixes a critical bug that prevented the assignment of temporary officials (Plt./Plh.) from being saved. The failure was caused by an off-by-one error in the role validation logic.

The `getExpectedHeadRole()` method in the `Unit` model was incorrectly mapping a unit's hierarchy depth to the role of its head. For example, it expected an Eselon I unit (depth 1) to be headed by a 'Menteri', leading to a validation failure. This has been corrected to map the depth to the appropriate role (e.g., depth 1 is now correctly mapped to 'Eselon I').

Additionally, to prevent future "silent failures", specific validation error display has been added to the delegation form in `resources/views/admin/units/edit.blade.php`. If a validation error occurs, the message will now be clearly displayed below the user selection field.