### PR TITLE
fix: Revert role logic and fix delegation display

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -207,18 +207,16 @@ class Unit extends Model
      */
     public function getExpectedHeadRole(): ?string
     {
-        // The depth is the number of ancestors. This is 0-indexed.
-        // Root (Kementerian) has depth 0. Its children have depth 1, and so on.
+        // The depth is the number of ancestors, which is 1-based (root is 1).
         $depth = $this->ancestors()->count();
 
-        // A unit at a given depth is headed by an official of the corresponding role level.
-        // e.g., A unit at depth 1 (Eselon I unit) is headed by an 'Eselon I' official.
+        // Mapping from hierarchy depth to the expected role name for the HEAD of that unit.
         $roleMap = [
-            0 => 'Menteri',          // Depth 0 (Root) is headed by a Menteri.
-            1 => 'Eselon I',        // Depth 1 (Child of Root) is headed by an Eselon I.
-            2 => 'Eselon II',       // Depth 2 is headed by an Eselon II.
-            3 => 'Koordinator',     // Depth 3 is headed by a Koordinator.
-            4 => 'Sub Koordinator', // Depth 4 is headed by a Sub Koordinator.
+            1 => 'Menteri',          // A unit with depth 1 (root) is headed by a Menteri.
+            2 => 'Eselon I',        // A unit with depth 2 is headed by an Eselon I.
+            3 => 'Eselon II',       // A unit with depth 3 is headed by an Eselon II.
+            4 => 'Koordinator',     // A unit with depth 4 is headed by a Koordinator.
+            5 => 'Sub Koordinator', // A unit with depth 5 is headed by a Sub Koordinator.
         ];
 
         return $roleMap[$depth] ?? null;


### PR DESCRIPTION
This commit resolves a regression and fixes the underlying display issue for temporary (Plt./Plh.) officials.

A previous fix incorrectly modified the role-mapping logic in the `getExpectedHeadRole()` method. This caused a regression where the dropdown list of eligible users for delegation was populated with users of the wrong role. This change reverts `getExpectedHeadRole()` to its original, working state, fixing the dropdown.

This commit also retains two important fixes from previous attempts:
1.  The `getDisplayableHeadAttribute` accessor in the `Unit` model is now more resilient and can find the active delegated head even if there are data inconsistencies in the `Jabatan` name. This fixes the original issue where a temporary head's name would not display correctly.
2.  The delegation form in `edit.blade.php` now has explicit error handling to prevent any future 'silent failures' if validation does not pass.