### PR TITLE
feat: Implement Plt./Plh. authority and fix display logic

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -75,7 +75,7 @@ class UnitController extends Controller
         $this->authorize('update', $unit);
 
         // Eager load relationships for efficiency
-        $unit->load('jabatans.user', 'users', 'approvalWorkflow', 'parentUnitRecursive');
+        $unit->load('jabatans.user', 'jabatans.delegations.user', 'users', 'approvalWorkflow', 'parentUnitRecursive');
 
         $units = Unit::where('id', '!=', $unit->id)->orderBy('name')->get();
         $workflows = ApprovalWorkflow::orderBy('name')->get();

--- a/app/Observers/UnitObserver.php
+++ b/app/Observers/UnitObserver.php
@@ -114,8 +114,9 @@ class UnitObserver
         $affectedUnits = $ancestors->push($unit);
 
         foreach ($affectedUnits as $affectedUnit) {
-            if ($affectedUnit->kepalaUnit) {
-                Cache::forget('subordinate_unit_ids_for_user_' . $affectedUnit->kepalaUnit->id);
+            $actingHead = $affectedUnit->getActingHead();
+            if ($actingHead) {
+                Cache::forget('subordinate_unit_ids_for_user_' . $actingHead->id);
             }
         }
     }


### PR DESCRIPTION
This commit delivers a comprehensive solution for managing temporary (Plt./Plh.) heads of unit. It fixes a persistent display bug and implements the user's requirement for temporary heads to have the same authority as definitive ones.

Key Changes:

1.  **Fixed Delegation Display:**
    - Corrected the eager-loading of relationships in `UnitController@edit` to include `jabatans.delegations.user`, which was preventing the temporary head's name from being displayed on the edit page.
    - Rewrote the `getDisplayableHeadAttribute` accessor in the `Unit` model to be more explicit and robust. It now correctly finds the 'Kepala' `Jabatan` by its consistent name and checks for active delegations, ensuring the correct acting head is always displayed.

2.  **Implemented Plt./Plh. Authority:**
    - Created a new `getActingHead()` method in the `Unit` model. This method serves as the single source of truth for identifying the person in charge of a unit, whether definitive or temporary.
    - Refactored `SuratMasukController` to use `getActingHead()`. This ensures that automatic dispositions and notifications for incoming mail are sent to the Plt./Plh. if one is active.
    - Refactored `UnitObserver` to use `getActingHead()` when clearing caches, ensuring system maintenance tasks are performed correctly for units managed by a temporary head.

3.  **Regression Fix:**
    - Reverted a previous, incorrect change to the `getExpectedHeadRole()` method, which had caused a regression in the dropdown list of eligible users for delegation. The logic is now restored to its previously working state.