### PR TITLE
hotfix: Correct nonexistent Carbon method call

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -247,8 +247,8 @@ class Unit extends Model
         // If we found the correct Jabatan, check for an active delegation.
         if ($kepalaJabatan) {
             $activeDelegation = $kepalaJabatan->delegations->first(function ($delegation) {
-                $today = now();
-                return $delegation->start_date->isSameDayOrBefore($today) && $delegation->end_date->isSameDayOrAfter($today);
+                $today = now()->startOfDay();
+                return $delegation->start_date <= $today && $delegation->end_date >= $today;
             });
 
             if ($activeDelegation && $activeDelegation->user) {


### PR DESCRIPTION
This commit fixes a fatal error (`Carbon\Exceptions\UnknownMethodException`) that occurred because of a call to a non-existent Carbon method (`isSameDayOrBefore`).

The error was in the `getDisplayableHeadAttribute` accessor in the `Unit` model. The logic for checking if a delegation is active has been corrected to use standard date comparison operators (`<=`, `>=`) instead of the incorrect method names.

This resolves the fatal error and restores application functionality.