### PR TITLE
feat: Add 'outside office hours' flag to tasks

### DIFF
--- a/app/Http/Controllers/AdHocTaskController.php
+++ b/app/Http/Controllers/AdHocTaskController.php
@@ -195,6 +195,7 @@ class AdHocTaskController extends Controller
             'estimated_hours' => 'required|numeric|min:0.1',
             'priority_level_id' => 'required|exists:priority_levels,id',
             'file_upload' => 'nullable|file|mimes:pdf,jpg,jpeg,png,doc,docx,xls,xlsx|max:2048',
+            'is_outside_office_hours' => 'nullable|boolean',
         ]);
         
         $assigneeIds = [];
@@ -209,6 +210,7 @@ class AdHocTaskController extends Controller
 
         $task = new Task();
         $task->fill($validated);
+        $task->is_outside_office_hours = $request->has('is_outside_office_hours');
         $task->task_status_id = $defaultStatus->id;
         $task->progress = 0;
         $task->project_id = null; // Menandakan ini tugas ad-hoc

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -118,9 +118,11 @@ class TaskController extends Controller
             'assignees' => 'nullable|array',
             'assignees.*' => 'exists:users,id',
             'file_upload' => 'nullable|' . config('tasmen.file_uploads.tasks.rules'),
+            'is_outside_office_hours' => 'nullable|boolean',
         ]);
 
         $task->fill($validated);
+        $task->is_outside_office_hours = $request->has('is_outside_office_hours');
 
         // --- LOGIKA ALUR PERSETUJUAN (jika tugas proyek) ---
         // Eager load status to check its key

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -24,6 +24,7 @@ class Task extends Model
         'estimated_hours',
         'task_status_id',
         'priority_level_id',
+        'is_outside_office_hours',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_09_10_013530_add_is_outside_office_hours_to_tasks_table.php
+++ b/database/migrations/2025_09_10_013530_add_is_outside_office_hours_to_tasks_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->boolean('is_outside_office_hours')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('is_outside_office_hours');
+        });
+    }
+};

--- a/resources/views/adhoc-tasks/_form.blade.php
+++ b/resources/views/adhoc-tasks/_form.blade.php
@@ -47,6 +47,13 @@
             <input type="number" step="0.5" name="estimated_hours" id="estimated_hours" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" value="{{ old('estimated_hours', $task->estimated_hours ?? '') }}" placeholder="Contoh: 2.5" required>
         </div>
     </div>
+
+    <div>
+        <label for="is_outside_office_hours" class="flex items-center">
+            <input type="checkbox" name="is_outside_office_hours" id="is_outside_office_hours" value="1" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" @checked(old('is_outside_office_hours', $task->is_outside_office_hours ?? false))>
+            <span class="ml-2 text-sm text-gray-600">Tugas ini dikerjakan di luar jam kerja</span>
+        </label>
+    </div>
     
     <div>
         <label for="priority_level_id" class="block font-semibold text-sm text-gray-700 mb-1">Prioritas</label>

--- a/resources/views/adhoc-tasks/index.blade.php
+++ b/resources/views/adhoc-tasks/index.blade.php
@@ -112,8 +112,15 @@
                         @forelse ($assignedTasks as $task)
                             <div class="block p-6 border border-gray-200 rounded-xl bg-white shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-300 ease-in-out">
                                 <div class="flex justify-between items-start">
-                                    <div>
-                                        <p class="font-bold text-xl text-indigo-700 mb-2">{{ $task->title }}</p>
+                                    <div class="flex-grow">
+                                        <div class="flex items-center mb-2">
+                                            <p class="font-bold text-xl text-indigo-700">{{ $task->title }}</p>
+                                            @if($task->is_outside_office_hours)
+                                                <span class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800" title="Tugas ini ditandai sebagai pekerjaan di luar jam kerja normal.">
+                                                    <i class="fas fa-moon mr-1.5"></i> Luar Jam Kerja
+                                                </span>
+                                            @endif
+                                        </div>
                                         <div class="text-sm text-gray-600 space-x-3">
                                             <span class="inline-flex items-center"><i class="far fa-calendar-alt text-gray-400 mr-1"></i> Deadline: {{ \Carbon\Carbon::parse($task->deadline)->format('d M Y') }}</span>
                                             <span class="inline-flex items-center"><i class="far fa-clock text-gray-400 mr-1"></i> Estimasi: {{ $task->estimated_hours }} jam</span>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -45,9 +45,16 @@
     </x-slot>
 
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Edit Tugas: ') }} <span class="font-bold text-indigo-600">{{ $task->title }}</span>
-        </h2>
+        <div class="flex items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Edit Tugas: ') }} <span class="font-bold text-indigo-600">{{ $task->title }}</span>
+            </h2>
+            @if($task->is_outside_office_hours)
+                <span class="ml-4 inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800" title="Tugas ini ditandai sebagai pekerjaan di luar jam kerja normal.">
+                    <i class="fas fa-moon mr-1.5"></i> Luar Jam Kerja
+                </span>
+            @endif
+        </div>
     </x-slot>
 
     <div class="py-12 bg-gray-50"> {{-- Latar belakang konsisten --}}
@@ -159,6 +166,13 @@
                                     </label>
                                     <input type="number" step="0.5" name="estimated_hours" id="estimated_hours" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" value="{{ old('estimated_hours', $task->estimated_hours) }}" placeholder="Contoh: 2.5">
                                 </div>
+                            </div>
+
+                            <div class="mb-6">
+                                <label for="is_outside_office_hours" class="flex items-center">
+                                    <input type="checkbox" name="is_outside_office_hours" id="is_outside_office_hours" value="1" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" @checked(old('is_outside_office_hours', $task->is_outside_office_hours))>
+                                    <span class="ml-2 text-sm text-gray-600">Tugas ini dikerjakan di luar jam kerja</span>
+                                </label>
                             </div>
                             
                             <div class="mb-6">


### PR DESCRIPTION
This commit introduces a new feature that allows users to flag tasks as being completed outside of normal office hours.

- Adds an `is_outside_office_hours` boolean column to the `tasks` table.
- Updates the `Task` model to include the new field.
- Modifies the `AdHocTaskController` and `TaskController` to handle the new flag during task creation and updates.
- Adds a checkbox to the task forms for setting the flag.
- Displays a badge on the task list and task detail page for tasks that have been flagged.