### PR TITLE
fix: Remove overflow-hidden from arsip page container

### DIFF
--- a/resources/views/arsip/index.blade.php
+++ b/resources/views/arsip/index.blade.php
@@ -53,7 +53,7 @@
                 </div>
 
                 {{-- Main Content for Surat List --}}
-                <div class="lg:col-span-3 bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="lg:col-span-3 bg-white shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">
                         {{-- Filter Form --}}
                         <form action="{{ route('arsip.index') }}" method="GET" class="mb-8 p-4 bg-gray-50 rounded-lg border">


### PR DESCRIPTION
This commit removes the `overflow-hidden` class from the main content container on the `/arsip` page. This class was causing the dropdowns from the filter's select boxes to be clipped, creating an overlay issue.