### PR TITLE
feat(projects): Add search to leader dropdown on edit page

### DIFF
--- a/resources/views/projects/edit.blade.php
+++ b/resources/views/projects/edit.blade.php
@@ -105,12 +105,16 @@
         document.addEventListener('DOMContentLoaded', function() {
             // Inisialisasi TomSelect untuk semua elemen dengan kelas 'tom-select'
             document.querySelectorAll('.tom-select').forEach(element => {
-                new TomSelect(element, {
-                    plugins: ['remove_button'],
+                let config = {
                     create: false,
-                    maxItems: null,
-                    placeholder: 'Pilih Anggota Tim'
-                });
+                    placeholder: element.getAttribute('placeholder') || 'Pilih...'
+                };
+
+                if (element.multiple) {
+                    config.plugins = ['remove_button'];
+                }
+
+                new TomSelect(element, config);
             });
         });
     </script>

--- a/resources/views/projects/partials/form.blade.php
+++ b/resources/views/projects/partials/form.blade.php
@@ -79,8 +79,7 @@
                 <label for="leader_id" class="block font-semibold text-sm text-gray-700 mb-1">
                     <i class="fas fa-user-tie mr-2 text-gray-500"></i> Pimpinan Kegiatan <span class="text-red-500">*</span>
                 </label>
-                <select name="leader_id" id="leader_id" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" required>
-                    <option value="">-- Pilih Pimpinan Kegiatan --</option>
+                <select name="leader_id" id="leader_id" class="tom-select" required placeholder="Pilih Pimpinan Kegiatan...">
                     @foreach ($potentialMembers as $member)
                         <option value="{{ $member->id }}" @selected(old('leader_id', $project->leader_id ?? '') == $member->id)>
                             {{ $member->name }}{{ $member->roles->isNotEmpty() ? ' (' . $member->roles->first()->name . ')' : '' }}


### PR DESCRIPTION
This commit adds search functionality to the "Pimpinan Kegiatan" (Project Leader) dropdown on the project **edit** page.

This is achieved by applying the TomSelect JavaScript library to the leader selection dropdown, making it consistent with the team member selection and the project creation page. The TomSelect initialization script has also been made more robust to handle both single and multiple select elements.