### PR TITLE
feat: Handle missing user unit code gracefully

### DIFF
--- a/app/Exceptions/UnitCodeNotFoundException.php
+++ b/app/Exceptions/UnitCodeNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class UnitCodeNotFoundException extends Exception
+{
+    //
+}

--- a/app/Http/Controllers/SuratKeluarController.php
+++ b/app/Http/Controllers/SuratKeluarController.php
@@ -7,6 +7,7 @@ use App\Models\Surat;
 use App\Models\TemplateSurat;
 use App\Models\User;
 use App\Models\LampiranSurat;
+use App\Exceptions\UnitCodeNotFoundException;
 use App\Models\Setting;
 use App\Services\NomorSuratService;
 use App\Services\Tte\TteManager;
@@ -80,8 +81,12 @@ class SuratKeluarController extends Controller
         $validated = $request->validate(array_merge($baseRules, $specificRules));
 
         // --- Automatic Numbering ---
-        $klasifikasi = KlasifikasiSurat::find($validated['klasifikasi_id']);
-        $nomorSurat = $nomorSuratService->generate($klasifikasi, Auth::user());
+        try {
+            $klasifikasi = KlasifikasiSurat::find($validated['klasifikasi_id']);
+            $nomorSurat = $nomorSuratService->generate($klasifikasi, Auth::user());
+        } catch (UnitCodeNotFoundException $e) {
+            return back()->withInput()->with('error', $e->getMessage());
+        }
         // --- End Automatic Numbering ---
 
         $suratData = [

--- a/app/Services/NomorSuratService.php
+++ b/app/Services/NomorSuratService.php
@@ -6,6 +6,7 @@ use App\Models\KlasifikasiSurat;
 use App\Models\Surat;
 use App\Models\User;
 use Carbon\Carbon;
+use App\Exceptions\UnitCodeNotFoundException;
 use Illuminate\Support\Facades\DB;
 
 class NomorSuratService
@@ -19,7 +20,7 @@ class NomorSuratService
      * @param KlasifikasiSurat $klasifikasi The classification chosen for the letter.
      * @param User $pembuat The user creating the letter, used to find the work unit.
      * @return string The generated letter number.
-     * @throws \Exception If the user does not have a unit with a code.
+     * @throws UnitCodeNotFoundException If the user does not have a unit with a code.
      */
     public function generate(KlasifikasiSurat $klasifikasi, User $pembuat): string
     {
@@ -33,7 +34,10 @@ class NomorSuratService
             $unitCode = $pembuat->unit->kode ?? null;
 
             if (!$unitCode) {
-                throw new \Exception("User's unit or unit code not found.");
+                if (!$pembuat->unit) {
+                    throw new UnitCodeNotFoundException("Profil Anda tidak terasosiasi dengan unit kerja manapun. Silakan hubungi administrator.");
+                }
+                throw new UnitCodeNotFoundException("Kode untuk unit kerja Anda ({$pembuat->unit->name}) tidak ditemukan. Silakan hubungi administrator.");
             }
 
             $romanMonth = $this->toRoman($month);


### PR DESCRIPTION
Instead of throwing a generic exception when a user's unit or unit code is not found during letter number generation, catch the error and redirect the user with a friendly error message.

- Created a new `UnitCodeNotFoundException` for more specific error handling.
- Modified `NomorSuratService` to throw this custom exception with a detailed message, distinguishing between a missing unit and a missing unit code.
- Updated `SuratKeluarController` to wrap the number generation in a try-catch block. If the exception occurs, the user is redirected back to the form with an actionable error message.