### PR TITLE
fix: Add kode to units table and seeder

### DIFF
--- a/database/migrations/2025_09_09_221900_add_kode_to_units_table.php
+++ b/database/migrations/2025_09_09_221900_add_kode_to_units_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->string('kode')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropColumn('kode');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             RoleSeeder::class,
             NationalHolidaySeeder::class,
             OrganizationalDataSeeder::class,
+            UpdateUnitKodeSeeder::class,
             LeaveTypesSeeder::class,
             TaskStatusSeeder::class,
             PriorityLevelSeeder::class,

--- a/database/seeders/UpdateUnitKodeSeeder.php
+++ b/database/seeders/UpdateUnitKodeSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class UpdateUnitKodeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        DB::table('units')
+            ->where('name', 'Pusat Data dan Teknologi Informasi Ketenagakerjaan')
+            ->update(['kode' => 'Pusdatin']);
+    }
+}


### PR DESCRIPTION
- Adds a new migration to create the `kode` column on the `units` table, which is required for generating letter numbers.
- Creates a new seeder (`UpdateUnitKodeSeeder`) to populate the `kode` for the 'Pusat Data dan Teknologi Informasi Ketenagakerjaan' unit.
- Updates the main `DatabaseSeeder` to call the new seeder.

This change fixes the underlying data issue that was causing the `UnitCodeNotFoundException`.