### PR TITLE
fix: Display uploaded PDF in surat keluar show page

### DIFF
--- a/resources/views/suratkeluar/show.blade.php
+++ b/resources/views/suratkeluar/show.blade.php
@@ -34,6 +34,9 @@
                             <div class="prose max-w-none">
                                 {!! $surat->konten !!}
                             </div>
+                        @elseif ($surat->final_pdf_path)
+                            <h3 class="text-lg font-bold text-gray-800 mb-4">Dokumen Surat</h3>
+                            <iframe src="{{ Illuminate\Support\Facades\Storage::url($surat->final_pdf_path) }}" class="w-full h-screen rounded-lg border"></iframe>
                         @elseif ($surat->lampiran->isNotEmpty())
                              @php $lampiran = $surat->lampiran->first(); @endphp
                             <h3 class="text-lg font-bold text-gray-800 mb-4">Lampiran Surat</h3>


### PR DESCRIPTION
The detail page for an uploaded 'surat keluar' was not displaying the document because the view was not checking for the `final_pdf_path` attribute.

This commit updates the `resources/views/suratkeluar/show.blade.php` file to add a condition that checks for `final_pdf_path`. If the path exists, it renders the PDF in an iframe.