### PR TITLE
fix: Correct type hint in TteManager

### DIFF
--- a/app/Services/Tte/TteManager.php
+++ b/app/Services/Tte/TteManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Tte;
 
+use App\Models\Surat;
 use Illuminate\Support\Manager;
 
 class TteManager extends Manager implements TteProvider


### PR DESCRIPTION
Resolves a fatal error caused by an incorrect type hint in the `sign` method of `App\Services\Tte\TteManager`.

The method was type-hinting `Surat` which resolved to the non-existent class `App\Services\Tte\Surat`.

This commit adds the correct `use App\Models\Surat;` statement, ensuring the type hint resolves to the correct Eloquent model, which matches the `TteProvider` interface.