### PR TITLE
Feat: Overhaul 'Surat' module and remove related features.

### DIFF
--- a/database/migrations/2025_08_30_004700_create_surat_table.php
+++ b/database/migrations/2025_08_30_004700_create_surat_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('perihal');
             $table->date('tanggal_surat');
             $table->enum('jenis', ['masuk', 'keluar']);
-            $table->enum('status', ['draft', 'dikirim', 'diarsipkan', 'disetujui', 'ditolak', 'perlu_revisi']);
+            $table->string('status')->default('draft');
             $table->foreignId('pembuat_id')->constrained('users');
             $table->foreignId('penyetuju_id')->nullable()->constrained('users');
             $table->longText('konten')->nullable();

--- a/database/migrations/2025_09_09_230800_refactor_surat_table_for_unified_concept.php
+++ b/database/migrations/2025_09_09_230800_refactor_surat_table_for_unified_concept.php
@@ -15,9 +15,8 @@ return new class extends Migration
             // 1. Add file_path column
             $table->string('file_path')->nullable()->after('konten');
 
-            // 2. Modify status enum
-            $table->enum('status', ['Baru', 'Didisposisikan', 'Ditugaskan', 'Diarsipkan'])
-                  ->default('Baru')->change();
+            // 2. Modify status column
+            $table->string('status')->default('Baru')->change();
 
             // 3. Drop unnecessary columns
             $table->dropColumn('jenis');
@@ -47,8 +46,7 @@ return new class extends Migration
 
         // 3. Change the status column back to its original state in a separate call for safety.
         Schema::table('surat', function (Blueprint $table) {
-            $table->enum('status', ['draft', 'dikirim', 'diarsipkan', 'disetujui', 'ditolak', 'perlu_revisi'])
-                  ->default('draft')->change();
+            $table->string('status')->default('draft')->change();
         });
     }
 };


### PR DESCRIPTION
This commit completes a major refactoring of the application's document management functionality.

1.  **Unified 'Surat' Concept:**
    *   Replaced the separate 'Surat Masuk' and 'Surat Keluar' modules with a single, unified 'Surat' module.
    *   The new workflow is based on uploading a finished document, which can then be used to create dispositions or tasks.
    *   Removed all controllers, models, routes, and views related to the old concept, including letter templates.

2.  **Removed TTE (Electronic Signature) Feature:**
    *   Deleted all services, providers, and configuration files associated with the TTE feature.
    *   Created new database migrations to remove TTE-related columns (`signature_image_path` from `users`, `final_pdf_path` from `surat`).

3.  **Cleaned Up Settings and Navigation:**
    *   Removed the 'Kop Surat' (Letterhead) and 'Blok Penandatangan' (Signer Block) forms from the General Settings page as they are obsolete.
    *   Restructured the main navigation menu to place 'Manajemen Klasifikasi' and 'Arsip Digital' under a new 'Surat' dropdown menu, as requested.

4.  **Database Migration Fix:**
    *   Modified the `surat` table's `status` column from `enum` to `string` to ensure compatibility with PostgreSQL and prevent migration errors.

This set of changes brings the application in line with the new, simplified concept for handling documents and removes unnecessary features and settings.