### PR TITLE
Fix: Use 'draft' as initial status for Surat

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -48,7 +48,7 @@ class SuratController extends Controller
             'perihal' => $validated['perihal'],
             'tanggal_surat' => $validated['tanggal_surat'],
             'file_path' => $path,
-            'status' => 'Baru',
+            'status' => 'draft',
             'pembuat_id' => Auth::id(),
         ]);
 


### PR DESCRIPTION
The status 'Baru' was being used when creating a new Surat, but this violated the 'surat_status_check' constraint in the database.

This change updates the status to 'draft', which is an allowed value in the database schema, resolving the QueryException.