### PR TITLE
Fix: Align Surat status values and fix task creation bug

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -124,6 +124,8 @@ class SuratController extends Controller
 
         $task->assignees()->attach(Auth::id());
 
+    $task->load('status');
+
         $surat->status = 'disetujui';
         $surat->save();
 


### PR DESCRIPTION
This commit resolves a series of `QueryException` errors caused by a mismatch between the application's status values and the database's `surat_status_check` constraint.

The `Surat` status values have been aligned with the database schema:
- 'Baru' is now 'draft'
- 'Didisposisikan' is now 'dikirim'
- 'Ditugaskan' is now 'disetujui'

The `surat.show` view has been updated to correctly display and style all the valid statuses.

This commit also fixes a bug in the `makeTask` method where the `status` relationship was not loaded on the `$task` object before redirecting to the edit page, which caused a null pointer exception.