### PR TITLE
Fix: Align Surat statuses and fix Task edit bug

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -59,7 +59,7 @@ class TaskController extends Controller
     public function edit(Task $task, BreadcrumbService $breadcrumbService, PageTitleService $pageTitleService)
     {
         // Eager load relasi untuk efisiensi
-        $task->load('assignees', 'attachments', 'project.members');
+    $task->load('assignees', 'attachments', 'project.members', 'status');
         $this->authorize('update', $task);
         
         $user = Auth::user();


### PR DESCRIPTION
This commit resolves a series of `QueryException` errors caused by a mismatch between the application's status values and the database's `surat_status_check` constraint.

The `Surat` status values have been aligned with the database schema:
- 'Baru' is now 'draft'
- 'Didisposisikan' is now 'dikirim'
- 'Ditugaskan' is now 'disetujui'

The `surat.show` view has been updated to correctly display and style all the valid statuses.

This commit also fixes a bug in the `makeTask` method and the `TaskController@edit` method where the `status` relationship was not loaded on the `$task` object before redirecting to the edit page, which caused a null pointer exception.