### PR TITLE
Fix: Align statuses and fix Task creation/edit bugs

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -112,12 +112,15 @@ class SuratController extends Controller
      */
     public function makeTask(Request $request, Surat $surat)
     {
+        $defaultStatus = \App\Models\TaskStatus::where('key', 'pending')->first();
+        $defaultPriority = \App\Models\PriorityLevel::where('name', 'Normal')->first();
+
         $task = Task::create([
             'title' => $surat->perihal,
             'description' => 'Tugas ini dibuat berdasarkan surat dengan perihal: ' . $surat->perihal . '. Lihat surat terlampir untuk detail.',
             'creator_id' => Auth::id(),
-            'status_id' => 1, // Assuming 1 is 'To Do'
-            'priority_id' => 2, // Assuming 2 is 'Normal'
+            'task_status_id' => $defaultStatus->id,
+            'priority_level_id' => $defaultPriority->id,
             'due_date' => now()->addDays(7),
             'surat_id' => $surat->id,
         ]);


### PR DESCRIPTION
This commit resolves a series of `QueryException` and `ErrorException` errors caused by a mismatch between the application's status values and the database schema, as well as incorrect task creation logic.

The `Surat` status values have been aligned with the database schema:
- 'Baru' is now 'draft'
- 'Didisposisikan' is now 'dikirim'
- 'Ditugaskan' is now 'disetujui'

The `surat.show` view has been updated to correctly display and style all the valid statuses.

This commit also fixes a bug in the `makeTask` method by using the correct foreign key (`task_status_id`) and dynamically looking up the default status and priority.

It also fixes a bug in the `TaskController@edit` method by ensuring the `status` relationship is loaded, preventing a null pointer exception in the view.