### PR TITLE
Fix: Robustly handle Surat and Task status logic

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -60,6 +60,17 @@ class TaskController extends Controller
     {
         // Eager load relasi untuk efisiensi
     $task->load('assignees', 'attachments', 'project.members', 'status');
+
+    // DEFENSIVE CODING: Handle tasks that were created with a null status before the bug was fixed.
+    if (is_null($task->status)) {
+        $defaultStatus = \App\Models\TaskStatus::where('key', 'pending')->first();
+        if ($defaultStatus) {
+            $task->task_status_id = $defaultStatus->id;
+            $task->save();
+            $task->load('status'); // Reload the relationship
+        }
+    }
+
         $this->authorize('update', $task);
         
         $user = Auth::user();


### PR DESCRIPTION
This commit provides a comprehensive fix for a series of errors related to `Surat` and `Task` status management.

Resolves `QueryException` for `Surat` status:
- Aligns all `Surat` status updates ('Baru', 'Didisposisikan', 'Ditugaskan') with the allowed database schema values ('draft', 'dikirim', 'disetujui') across `SuratController` and `DisposisiController`.
- Updates the `surat.show` view to correctly display and style the valid statuses.

Resolves `ErrorException` for `Task` status:
- Corrects the task creation logic in `SuratController@makeTask` to use the correct foreign key (`task_status_id`) and dynamically look up default status and priority, preventing the creation of tasks with a `null` status.
- Adds defensive, self-healing code to `TaskController@edit` to automatically assign a default "pending" status to any legacy tasks that were created with a `null` status. This prevents fatal errors when editing old tasks and repairs the data.