### PR TITLE
Feat: Auto-attach Surat file to new Task

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -127,6 +127,15 @@ class SuratController extends Controller
 
         $task->assignees()->attach(Auth::id());
 
+    // Automatically attach the letter's file to the new task
+    if ($surat->file_path) {
+        $task->attachments()->create([
+            'user_id' => Auth::id(),
+            'filename' => 'Surat Asal - ' . Str::slug($surat->perihal) . '.' . pathinfo($surat->file_path, PATHINFO_EXTENSION),
+            'path' => $surat->file_path,
+        ]);
+    }
+
     $task->load('status');
 
         $surat->status = 'disetujui';


### PR DESCRIPTION
When a new Task is created from a Surat, this commit automatically attaches the source Surat's file to the new Task.

This improves user workflow by making the relevant document immediately available within the task, rather than requiring the user to navigate back to the original letter.