### PR TITLE
Fix: Add user feedback to Arsip page

### DIFF
--- a/resources/views/arsip/index.blade.php
+++ b/resources/views/arsip/index.blade.php
@@ -97,6 +97,19 @@
                     {{-- Form for Filing Letters --}}
                     <form action="{{ route('arsip.berkas.add-surat') }}" method="POST">
                         @csrf
+
+                        {{-- Validation Errors --}}
+                        @if ($errors->any())
+                            <div class="mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg" role="alert">
+                                <strong class="font-bold">Oops! Ada yang salah:</strong>
+                                <ul class="mt-1 list-disc list-inside text-sm">
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
                         <div class="overflow-x-auto">
                             <table class="min-w-full divide-y divide-gray-200">
                                 <thead class="bg-gray-50">


### PR DESCRIPTION
This commit addresses an issue where clicking the 'Masukkan ke Berkas' button on the /arsip page appeared to do nothing.

The root cause was that the view was not displaying validation errors. If the user submitted the form without selecting a destination 'berkas' or any 'surat' checkboxes, the form would fail validation and redirect back with no visible feedback.

This commit adds a validation error display to the view. Now, if the form submission fails, the user will see a clear error message explaining what is required. This ensures the button always provides feedback, either a success message (which was already implemented in the controller and layout) or a validation error message.