### PR TITLE
Fix: Overhaul and implement features for Arsip page

### DIFF
--- a/app/Http/Controllers/ArsipController.php
+++ b/app/Http/Controllers/ArsipController.php
@@ -44,10 +44,6 @@ class ArsipController extends Controller
             $query->where('klasifikasi_id', $request->input('klasifikasi_id'));
         }
 
-        // Filter by type
-        if ($request->filled('jenis')) {
-            $query->where('jenis', $request->input('jenis'));
-        }
 
         $suratList = $query->paginate(25)->withQueryString();
         $klasifikasi = KlasifikasiSurat::orderBy('kode')->get();
@@ -94,5 +90,19 @@ class ArsipController extends Controller
         $breadcrumbService->add('Arsip Digital', route('arsip.index'));
         $breadcrumbService->add('Alur Kerja');
         return view('arsip.workflow');
+    }
+
+    public function showBerkas(Berkas $berkas)
+    {
+        // Authorize that the user owns the Berkas
+        if ($berkas->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $berkas->load(['surat' => function ($query) {
+            $query->with('klasifikasi')->latest();
+        }]);
+
+        return view('arsip.show_berkas', compact('berkas'));
     }
 }

--- a/resources/views/arsip/index.blade.php
+++ b/resources/views/arsip/index.blade.php
@@ -40,7 +40,7 @@
                         <ul class="space-y-2">
                             @forelse($berkasList as $berkas)
                                 <li class="flex items-center justify-between p-2 rounded-md hover:bg-gray-100">
-                                    <a href="#" class="flex items-center text-sm text-gray-700 hover:text-indigo-600">
+                                    <a href="{{ route('arsip.berkas.show', $berkas) }}" class="flex items-center text-sm text-gray-700 hover:text-indigo-600">
                                         <i class="fas fa-folder text-yellow-500 mr-3"></i>
                                         <span>{{ $berkas->name }} ({{ $berkas->surat()->count() }})</span>
                                     </a>
@@ -71,14 +71,6 @@
                                             {{ $item->kode }} - {{ $item->deskripsi }}
                                         </option>
                                     @endforeach
-                                </select>
-                            </div>
-                            <div>
-                                <label for="jenis" class="block text-sm font-medium text-gray-700">Jenis Surat</label>
-                                <select name="jenis" id="jenis" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
-                                    <option value="">Semua Jenis</option>
-                                    <option value="masuk" @selected(request('jenis') == 'masuk')>Masuk</option>
-                                    <option value="keluar" @selected(request('jenis') == 'keluar')>Keluar</option>
                                 </select>
                             </div>
                             <div>
@@ -118,7 +110,6 @@
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nomor Surat</th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Perihal</th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tanggal</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jenis</th>
                                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Klasifikasi</th>
                                     <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Aksi</th>
                                 </tr>
@@ -130,17 +121,12 @@
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $surat->nomor_surat }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-800">{{ $surat->perihal }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $surat->tanggal_surat->format('d M Y') }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
-                                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full {{ $surat->jenis == 'masuk' ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800' }}">
-                                                {{ ucfirst($surat->jenis) }}
-                                            </span>
-                                        </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($surat->klasifikasi)->kode }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                            @if ($surat->final_pdf_path && Storage::disk('public')->exists($surat->final_pdf_path))
-                                                 <a href="{{ route('surat-keluar.download', $surat) }}" class="text-indigo-600 hover:text-indigo-900">Unduh</a>
+                                            @if ($surat->file_path)
+                                                <a href="{{ route('surat.download', $surat) }}" class="text-indigo-600 hover:text-indigo-900">Unduh</a>
                                             @else
-                                                 <span class="text-gray-400">N/A</span>
+                                                <span class="text-gray-400">N/A</span>
                                             @endif
                                         </td>
                                     </tr>

--- a/resources/views/arsip/show_berkas.blade.php
+++ b/resources/views/arsip/show_berkas.blade.php
@@ -1,0 +1,63 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center">
+            <a href="{{ route('arsip.index') }}" class="text-indigo-600 hover:text-indigo-900">
+                <i class="fas fa-arrow-left mr-2"></i>
+                Kembali ke Arsip
+            </a>
+            <span class="mx-2 text-gray-500">/</span>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                Detail Berkas: {{ $berkas->name }}
+            </h2>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <div class="mb-4">
+                        <h3 class="text-lg font-bold">{{ $berkas->name }}</h3>
+                        <p class="text-sm text-gray-600">{{ $berkas->description }}</p>
+                        <p class="text-xs text-gray-500 mt-1">Dibuat pada: {{ $berkas->created_at->format('d M Y') }} | Jumlah Surat: {{ $berkas->surat->count() }}</p>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nomor Surat</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Perihal</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tanggal</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Klasifikasi</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Aksi</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($berkas->surat as $surat)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $surat->nomor_surat }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-800">{{ $surat->perihal }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $surat->tanggal_surat->format('d M Y') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($surat->klasifikasi)->kode }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                            @if ($surat->file_path)
+                                                <a href="{{ route('surat.download', $surat) }}" class="text-indigo-600 hover:text-indigo-900">Unduh</a>
+                                            @else
+                                                <span class="text-gray-400">N/A</span>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="px-6 py-12 text-center text-gray-500">Belum ada surat di dalam berkas ini.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -217,6 +217,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/arsip', [ArsipController::class, 'index'])->name('arsip.index');
     Route::get('/arsip/workflow', [ArsipController::class, 'showWorkflow'])->name('arsip.workflow');
     Route::post('/arsip/berkas', [ArsipController::class, 'storeBerkas'])->name('arsip.berkas.store');
+    Route::get('/arsip/berkas/{berkas}', [ArsipController::class, 'showBerkas'])->name('arsip.berkas.show');
     Route::post('/arsip/berkas/add-surat', [ArsipController::class, 'addSuratToBerkas'])->name('arsip.berkas.add-surat');
 
 });


### PR DESCRIPTION
This commit addresses several bugs and missing features on the /arsip page based on user feedback.

- Removes the obsolete 'Jenis Surat' filter and table column, as the 'jenis' attribute no longer exists on the Surat model.
- Fixes the 'Aksi' (Action) column to provide a working download link. It now correctly checks for the `file_path` attribute and uses the `surat.download` route.
- Implements the 'Berkas' (Dossier) detail page, which was previously a non-functional link. This includes:
    - A new route: `arsip/berkas/{berkas}`
    - A new controller method: `ArsipController@showBerkas`
    - A new view: `arsip/show_berkas.blade.php` to display the contents of a dossier.
- Updates the links on the main arsip page to point to the new detail page.