### PR TITLE
Fix: Correct Mermaid syntax error in Arsip workflow

### DIFF
--- a/resources/views/arsip/workflow.blade.php
+++ b/resources/views/arsip/workflow.blade.php
@@ -45,7 +45,7 @@ graph TD
         A3 --> A5["<i class='fa fa-check-square'></i> Pilih Satu atau Lebih Surat"]:::action;
     end
 
-    subgraph "B. Pengelolaan & Pengisian Berkas"
+    subgraph "B. Pengelolaan dan Pengisian Berkas"
         B1["<i class='fa fa-folder-plus'></i> Buat Berkas Baru"]:::action;
         A5 -- Pilih Berkas Tujuan --> B2["<i class='fa fa-folder-open'></i> Dropdown Berkas"]:::page;
         B2 --> B3["<i class='fa fa-share-square'></i> Klik 'Masukkan ke Berkas'"]:::action;


### PR DESCRIPTION
This commit fixes a Mermaid.js syntax error on the Arsip workflow page (`arsip/workflow.blade.php`).

The ampersand character `&` in a subgraph title was causing a parsing error. This has been replaced with the word 'dan' to resolve the issue.