### PR TITLE
Fix: Resolve Mermaid.js rendering error

### DIFF
--- a/resources/views/arsip/workflow.blade.php
+++ b/resources/views/arsip/workflow.blade.php
@@ -110,8 +110,8 @@ graph TD
     </div>
 
     @push('scripts')
-        <script type="module">
-            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+        <script src="https://cdn.jsdelivr.net/npm/mermaid@10.3.1/dist/mermaid.min.js"></script>
+        <script>
             mermaid.initialize({
                 startOnLoad: true,
                 fontFamily: 'inherit',

--- a/resources/views/surat/workflow.blade.php
+++ b/resources/views/surat/workflow.blade.php
@@ -103,8 +103,8 @@ graph TD
     </div>
 
     @push('scripts')
-        <script type="module">
-            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+        <script src="https://cdn.jsdelivr.net/npm/mermaid@10.3.1/dist/mermaid.min.js"></script>
+        <script>
             mermaid.initialize({
                 startOnLoad: true,
                 fontFamily: 'inherit',


### PR DESCRIPTION
This commit fixes the persistent "Syntax error in text" error on the workflow pages.

Research indicated that this error is not caused by a syntax error in the diagram code itself, but by a compatibility issue between newer, ES Module-based versions of Mermaid.js (v10.4.0+) and the rendering engine.

The fix involves changing how the Mermaid library is loaded:
- The ES Module import from the CDN (`import mermaid from '...'`) has been replaced with a standard `<script src="...">` tag.
- The script URL now points to a specific, older, more compatible version of Mermaid (v10.3.1).

This change has been applied to both `surat/workflow.blade.php` and `arsip/workflow.blade.php` to ensure the diagrams render correctly and consistently across the application.