### PR TITLE
Feat: Add Nomor Surat to Surat module

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -38,6 +38,7 @@ class SuratController extends Controller
     {
         $validated = $request->validate([
             'perihal' => 'required|string|max:255',
+            'nomor_surat' => 'nullable|string|max:255|unique:surat,nomor_surat',
             'tanggal_surat' => 'required|date',
             'file' => 'required|file|mimes:pdf,jpg,jpeg,png,doc,docx|max:10240', // Max 10MB
         ]);
@@ -46,6 +47,7 @@ class SuratController extends Controller
 
         Surat::create([
             'perihal' => $validated['perihal'],
+            'nomor_surat' => $validated['nomor_surat'] ?? null,
             'tanggal_surat' => $validated['tanggal_surat'],
             'file_path' => $path,
             'status' => 'draft',

--- a/resources/views/surat/create.blade.php
+++ b/resources/views/surat/create.blade.php
@@ -20,17 +20,23 @@
                     <form action="{{ route('surat.store') }}" method="POST" enctype="multipart/form-data">
                         @csrf
                         <div class="space-y-6">
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                <div>
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                                <div class="md:col-span-2">
                                     <label for="perihal" class="block font-semibold text-sm text-gray-700 mb-1">Perihal Surat <span class="text-red-500">*</span></label>
                                     <input type="text" name="perihal" id="perihal" value="{{ old('perihal') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required autofocus>
                                     @error('perihal') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
                                 </div>
                                 <div>
-                                    <label for="tanggal_surat" class="block font-semibold text-sm text-gray-700 mb-1">Tanggal Dokumen Surat <span class="text-red-500">*</span></label>
-                                    <input type="date" name="tanggal_surat" id="tanggal_surat" value="{{ old('tanggal_surat', date('Y-m-d')) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-                                    @error('tanggal_surat') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
+                                    <label for="nomor_surat" class="block font-semibold text-sm text-gray-700 mb-1">Nomor Surat (Opsional)</label>
+                                    <input type="text" name="nomor_surat" id="nomor_surat" value="{{ old('nomor_surat') }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">
+                                    @error('nomor_surat') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
                                 </div>
+                            </div>
+
+                            <div>
+                                <label for="tanggal_surat" class="block font-semibold text-sm text-gray-700 mb-1">Tanggal Dokumen Surat <span class="text-red-500">*</span></label>
+                                <input type="date" name="tanggal_surat" id="tanggal_surat" value="{{ old('tanggal_surat', date('Y-m-d')) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+                                @error('tanggal_surat') <p class="text-sm text-red-600 mt-2">{{ $message }}</p> @enderror
                             </div>
 
                             <div>

--- a/resources/views/surat/index.blade.php
+++ b/resources/views/surat/index.blade.php
@@ -33,6 +33,7 @@
                         <table class="min-w-full divide-y divide-gray-200">
                             <thead class="bg-gray-100">
                                 <tr>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Nomor Surat</th>
                                     <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Perihal</th>
                                     <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Tanggal Surat</th>
                                     <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Diunggah Oleh</th>
@@ -43,17 +44,21 @@
                             <tbody class="bg-white divide-y divide-gray-100">
                                 @forelse ($surat as $item)
                                     <tr class="hover:bg-gray-50">
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 font-mono">{{ $item->nomor_surat ?? 'N/A' }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ Str::limit($item->perihal, 60) }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{{ $item->tanggal_surat->format('d M Y') }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{{ $item->pembuat->name ?? 'N/A' }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                                            <span class="px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full
-                                                @if($item->status == 'Baru') bg-blue-100 text-blue-800 @endif
-                                                @if($item->status == 'Didisposisikan') bg-yellow-100 text-yellow-800 @endif
-                                                @if($item->status == 'Ditugaskan') bg-purple-100 text-purple-800 @endif
-                                                @if($item->status == 'Diarsipkan') bg-gray-100 text-gray-800 @endif
-                                            ">
-                                                {{ $item->status }}
+                                            <span @class([
+                                                'px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full',
+                                                'bg-blue-100 text-blue-800' => $item->status === 'draft',
+                                                'bg-yellow-100 text-yellow-800' => $item->status === 'dikirim',
+                                                'bg-green-100 text-green-800' => $item->status === 'disetujui',
+                                                'bg-red-100 text-red-800' => $item->status === 'ditolak',
+                                                'bg-purple-100 text-purple-800' => $item->status === 'perlu_revisi',
+                                                'bg-gray-100 text-gray-800' => $item->status === 'diarsipkan',
+                                            ])>
+                                                {{ ucfirst(str_replace('_', ' ', $item->status)) }}
                                             </span>
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">


### PR DESCRIPTION
This commit adds the `nomor_surat` (letter number) field to the Surat module to make it consistent with the Arsip (Archive) module.

- The 'Tambah Surat Baru' (Create New Letter) form now includes an optional text field for 'Nomor Surat'.
- The `SuratController@store` method has been updated to include validation for this new field (`nullable|string|max:255|unique:surat,nomor_surat`).
- The 'Daftar Surat' (Letter List) table now includes a 'Nomor Surat' column, making the information visible on the index page.
- The status display on the index page has also been updated to use the new, consistent status labels.