### PR TITLE
fix: correct route order for surat workflow

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -204,8 +204,8 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/profile/complete', [CompleteProfileController::class, 'store'])->name('profile.complete.store');
 
     // --- UNIFIED SURAT ROUTES ---
-    Route::resource('surat', SuratController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
     Route::get('/surat/workflow', [SuratController::class, 'showWorkflow'])->name('surat.workflow');
+    Route::resource('surat', SuratController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
     Route::get('/surat/{surat}/download', [SuratController::class, 'download'])->name('surat.download');
     Route::get('/surat/{surat}/make-task', [SuratController::class, 'makeTask'])->name('surat.make-task');
 


### PR DESCRIPTION
This commit fixes a route model binding error that occurred because the specific `/surat/workflow` route was defined after the wildcard `/surat/{surat}` resource route. The router was incorrectly interpreting 'workflow' as a model ID.

The order has been corrected to ensure the specific route is matched first, resolving the `Invalid text representation` SQL error.