### PR TITLE
fix: disable failing surat query on global dashboard

### DIFF
--- a/app/Http/Controllers/GlobalDashboardController.php
+++ b/app/Http/Controllers/GlobalDashboardController.php
@@ -125,12 +125,14 @@ class GlobalDashboardController extends Controller
                 ->get();
 
             // 2. Get Surat Keluar awaiting approval
-            $subordinateIds = $currentUser->getAllSubordinateIds();
-            $suratKeluar = Surat::where('jenis', 'keluar')
-                ->where('status', 'draft')
-                ->whereIn('pembuat_id', $subordinateIds)
-                ->with('pembuat')
-                ->get();
+            // NOTE: This feature is temporarily disabled due to a missing 'jenis' column in the 'surat' table.
+            // $subordinateIds = $currentUser->getAllSubordinateIds();
+            // $suratKeluar = Surat::where('jenis', 'keluar')
+            //     ->where('status', 'draft')
+            //     ->whereIn('pembuat_id', $subordinateIds)
+            //     ->with('pembuat')
+            //     ->get();
+            $suratKeluar = collect();
 
             // 3. Get Peminjaman Pegawai awaiting approval
             $peminjamanRequests = PeminjamanRequest::where('approver_id', $currentUser->id)


### PR DESCRIPTION
This commit addresses a fatal error on the Global Dashboard caused by a query attempting to use a non-existent 'jenis' column on the 'surat' table.

The problematic query has been commented out and the `$suratKeluar` variable is initialized as an empty collection to prevent the application from crashing. This temporarily disables the 'Surat Keluar awaiting approval' feature on the dashboard's approval inbox but restores the dashboard's functionality.