### PR TITLE
fix: improve handling of missing seed data in SuratController

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -114,8 +114,8 @@ class SuratController extends Controller
      */
     public function makeTask(Request $request, Surat $surat)
     {
-        $defaultStatus = \App\Models\TaskStatus::where('key', 'pending')->first();
-        $defaultPriority = \App\Models\PriorityLevel::where('name', 'Normal')->first();
+        $defaultStatus = \App\Models\TaskStatus::where('key', 'pending')->firstOrFail();
+        $defaultPriority = \App\Models\PriorityLevel::where('name', 'Normal')->firstOrFail();
 
         $task = Task::create([
             'title' => $surat->perihal,


### PR DESCRIPTION
This commit addresses an `Attempt to read property "id" on null` error in the `makeTask` method of `SuratController`.

The error occurred when default records for TaskStatus (key='pending') or PriorityLevel (name='Normal') were missing from the database, causing `first()` to return null.

The code has been updated to use `firstOrFail()` instead. This ensures that if the required seed data is missing, a more descriptive `ModelNotFoundException` is thrown, making the root cause of the problem immediately clear.