### PR TITLE
fix: disable failing query for missing TemplateSurat model

### DIFF
--- a/app/Http/Controllers/SpecialAssignmentController.php
+++ b/app/Http/Controllers/SpecialAssignmentController.php
@@ -103,10 +103,12 @@ class SpecialAssignmentController extends Controller
         }
 
         // Ambil template surat yang relevan untuk SK Penugasan.
-        $skTemplates = TemplateSurat::where('judul', 'LIKE', '%SK%')
-            ->orWhere('judul', 'LIKE', '%Penugasan%')
-            ->orWhere('deskripsi', 'LIKE', '%Penugasan%')
-            ->get();
+        // NOTE: This feature is temporarily disabled because the TemplateSurat model does not exist.
+        $skTemplates = collect();
+        // $skTemplates = TemplateSurat::where('judul', 'LIKE', '%SK%')
+        //     ->orWhere('judul', 'LIKE', '%Penugasan%')
+        //     ->orWhere('deskripsi', 'LIKE', '%Penugasan%')
+        //     ->get();
 
         $klasifikasiSurat = KlasifikasiSurat::orderBy('kode')->get();
 


### PR DESCRIPTION
This commit addresses a fatal error on the 'Create Special Assignment' page.

The error `Failed to open stream: No such file or directory for TemplateSurat.php` occurred because the controller was trying to use a model that does not exist.

The query has been commented out and the `$skTemplates` variable is initialized as an empty collection to prevent the application from crashing. This temporarily disables the template selection feature but makes the page functional.