### PR TITLE
fix: display archived letters on archive index page

### DIFF
--- a/app/Http/Controllers/ArsipController.php
+++ b/app/Http/Controllers/ArsipController.php
@@ -15,8 +15,7 @@ class ArsipController extends Controller
     public function index(Request $request)
     {
         $query = Surat::whereIn('status', ['disetujui', 'diarsipkan', 'terverifikasi'])
-            ->whereDoesntHave('berkas') // Only show letters that are not in any folder yet
-            ->with(['klasifikasi', 'pembuat'])
+            ->with(['klasifikasi', 'pembuat', 'berkas']) // Eager load berkas relationship
             ->latest();
 
         // Keyword search

--- a/resources/views/arsip/index.blade.php
+++ b/resources/views/arsip/index.blade.php
@@ -13,127 +13,191 @@
 
     <div class="py-12">
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                {{-- Main content for Berkas list --}}
-                <div class="lg:col-span-2 space-y-6">
-                    <div class="bg-white p-6 rounded-lg shadow-md">
-                        <div class="flex justify-between items-center mb-4">
-                            <h3 class="font-bold text-lg">Daftar Berkas Virtual Anda</h3>
-                            <button @click="showCreateBerkasModal = true" class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm">
-                                <i class="fas fa-plus-circle mr-1"></i> Buat Berkas Baru
-                            </button>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                            @forelse($berkasList as $berkas)
-                                <a href="{{ route('arsip.berkas.show', $berkas) }}" class="block p-4 rounded-lg hover:bg-gray-100 border border-gray-200 hover:shadow-lg transition-all">
-                                    <div class="flex items-center">
-                                        <i class="fas fa-folder fa-2x text-yellow-500 mr-4"></i>
-                                        <div>
-                                            <p class="font-semibold text-gray-800">{{ $berkas->name }}</p>
-                                            <p class="text-sm text-gray-500">{{ $berkas->surat()->count() }} surat</p>
-                                        </div>
-                                    </div>
-                                </a>
-                            @empty
-                                <div class="md:col-span-3 text-center py-8 text-gray-500">
-                                    <p>Anda belum memiliki berkas. Buat satu untuk mulai mengarsipkan surat.</p>
-                                </div>
-                            @endforelse
-                        </div>
-                    </div>
-                </div>
-
-                {{-- Sidebar for un-archived letters --}}
-                <div class="lg:col-span-1 bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <div class="p-6 text-gray-900">
-                        <h3 class="font-bold text-lg mb-4 border-b pb-2">Surat Belum Diarsipkan</h3>
-
-                        {{-- Form for Filing Letters --}}
-                        <form action="{{ route('arsip.berkas.add-surat') }}" method="POST">
+            <div class="grid grid-cols-1 lg:grid-cols-4 gap-8">
+                {{-- Sidebar for Berkas Management --}}
+                <div class="lg:col-span-1 space-y-6">
+                    <div class="bg-white p-4 rounded-lg shadow-md">
+                        <h3 class="font-bold text-lg mb-4">Buat Berkas Baru</h3>
+                        <form action="{{ route('arsip.berkas.store') }}" method="POST">
                             @csrf
-                            @if($errors->any())
-                                <div class="mb-4 bg-red-100 border-l-4 border-red-500 text-red-700 p-4" role="alert">
-                                    @foreach($errors->all() as $error)
-                                        <p>{{ $error }}</p>
-                                    @endforeach
+                            <div class="space-y-3">
+                                <div>
+                                    <label for="name" class="block text-sm font-medium text-gray-700">Nama Berkas</label>
+                                    <input type="text" name="name" id="name" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
                                 </div>
-                            @endif
-
-                            <div class="space-y-2 max-h-96 overflow-y-auto border rounded-md p-2">
-                                @forelse ($suratList as $surat)
-                                    <div class="flex items-center space-x-3 p-2 rounded hover:bg-gray-50">
-                                        <input type="checkbox" name="surat_ids[]" value="{{ $surat->id }}" class="rounded border-gray-300 shadow-sm surat-checkbox">
-                                        <div class="text-sm">
-                                            <p class="font-medium text-gray-800">{{ $surat->perihal }}</p>
-                                            <p class="text-xs text-gray-500">{{ $surat->nomor_surat ?? 'No. Belum Ada' }}</p>
-                                        </div>
-                                    </div>
-                                @empty
-                                    <p class="text-sm text-gray-500 p-4 text-center">Semua surat sudah diarsipkan.</p>
-                                @endforelse
+                                <div>
+                                    <label for="description" class="block text-sm font-medium text-gray-700">Deskripsi</label>
+                                    <textarea name="description" id="description" rows="2" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"></textarea>
+                                </div>
+                                <button type="submit" class="w-full px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700">
+                                    <i class="fas fa-plus-circle mr-1"></i> Buat
+                                </button>
                             </div>
-
-                            @if($suratList->isNotEmpty())
-                                <div class="mt-4 p-2 border-t flex items-center space-x-4">
-                                    <label for="berkas_id_sidebar" class="text-sm font-medium">Arsipkan ke:</label>
-                                    <select name="berkas_id" id="berkas_id_sidebar" class="flex-grow rounded-md border-gray-300 shadow-sm text-sm" required>
-                                        <option value="">-- Pilih Berkas --</option>
-                                        @foreach($berkasList as $berkas)
-                                            <option value="{{ $berkas->id }}">{{ $berkas->name }}</option>
-                                        @endforeach
-                                    </select>
-                                    <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md text-xs hover:bg-indigo-700">
-                                        <i class="fas fa-folder-plus mr-1"></i> Simpan
-                                    </button>
-                                </div>
-                            @endif
                         </form>
                     </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {{-- Modal for Creating Berkas --}}
-    <div x-data="{ showCreateBerkasModal: false }" @keydown.escape.window="showCreateBerkasModal = false" x-cloak>
-        <div x-show="showCreateBerkasModal" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex items-center justify-center">
-            <div @click.away="showCreateBerkasModal = false" class="bg-white p-6 rounded-lg shadow-xl w-full max-w-md">
-                <h3 class="font-bold text-lg mb-4">Buat Berkas Baru</h3>
-                <form action="{{ route('arsip.berkas.store') }}" method="POST">
-                    @csrf
-                    <div class="space-y-4">
-                        <div>
-                            <label for="modal_name" class="block text-sm font-medium text-gray-700">Nama Berkas</label>
-                            <input type="text" name="name" id="modal_name" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
-                        </div>
-                        <div>
-                            <label for="modal_description" class="block text-sm font-medium text-gray-700">Deskripsi</label>
-                            <textarea name="description" id="modal_description" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"></textarea>
-                        </div>
-                        <div class="flex justify-end space-x-3 pt-4 border-t">
-                            <x-secondary-button type="button" @click="showCreateBerkasModal = false">Batal</x-secondary-button>
-                            <x-primary-button type="submit">Buat</x-primary-button>
-                        </div>
+                    <div class="bg-white p-4 rounded-lg shadow-md">
+                        <h3 class="font-bold text-lg mb-4">Daftar Berkas Virtual</h3>
+                        <ul class="space-y-2">
+                            @forelse($berkasList as $berkas)
+                                <li class="flex items-center justify-between p-2 rounded-md hover:bg-gray-100">
+                                    <a href="{{ route('arsip.berkas.show', $berkas) }}" class="flex items-center text-sm text-gray-700 hover:text-indigo-600">
+                                        <i class="fas fa-folder text-yellow-500 mr-3"></i>
+                                        <span>{{ $berkas->name }} ({{ $berkas->surat()->count() }})</span>
+                                    </a>
+                                </li>
+                            @empty
+                                <li class="text-sm text-gray-500">Belum ada berkas.</li>
+                            @endforelse
+                        </ul>
                     </div>
-                </form>
+                </div>
+
+                {{-- Main Content for Surat List --}}
+                <div class="lg:col-span-3 bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        {{-- Filter Form --}}
+                        <form action="{{ route('arsip.index') }}" method="GET" class="mb-8 p-4 bg-gray-50 rounded-lg border">
+                             <h3 class="font-bold text-lg mb-4">Pencarian & Filter Surat</h3>
+                            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                                <div>
+                                <label for="keyword" class="block text-sm font-medium text-gray-700">Kata Kunci</label>
+                                <input type="text" name="keyword" id="keyword" value="{{ request('keyword') }}" placeholder="Perihal atau Nomor Surat" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                            </div>
+                            <div>
+                                <label for="klasifikasi_id" class="block text-sm font-medium text-gray-700">Klasifikasi</label>
+                                <select name="klasifikasi_id" id="klasifikasi_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                                    <option value="">Semua Klasifikasi</option>
+                                    @foreach ($klasifikasi as $item)
+                                        <option value="{{ $item->id }}" @selected(request('klasifikasi_id') == $item->id)>
+                                            {{ $item->kode }} - {{ $item->deskripsi }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div>
+                                <label for="date_range" class="block text-sm font-medium text-gray-700">Rentang Tanggal</label>
+                                <input type="text" name="date_range" id="date_range" value="{{ request('date_range') }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" placeholder="Pilih rentang tanggal...">
+                            </div>
+                        </div>
+                        <div class="mt-4 flex justify-end space-x-2">
+                            <a href="{{ route('arsip.index') }}" class="px-4 py-2 bg-gray-600 text-white rounded-md text-xs hover:bg-gray-700">Reset</a>
+                            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-md text-xs hover:bg-blue-700">
+                                <i class="fas fa-search mr-1"></i> Cari
+                            </button>
+                        </div>
+                    </form>
+
+                    {{-- Form for Filing Letters --}}
+                    <form action="{{ route('arsip.berkas.add-surat') }}" method="POST">
+                        @csrf
+
+                        {{-- Validation Errors --}}
+                        @if ($errors->any())
+                            <div class="mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg" role="alert">
+                                <strong class="font-bold">Oops! Ada yang salah:</strong>
+                                <ul class="mt-1 list-disc list-inside text-sm">
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200">
+                                <thead class="bg-gray-50">
+                                    <tr>
+                                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><input type="checkbox" id="select-all"></th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nomor Surat</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Perihal</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tanggal</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Klasifikasi</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Lokasi Arsip</th>
+                                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Aksi</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($suratList as $surat)
+                                    <tr>
+                                        <td class="px-4 py-4 whitespace-nowrap"><input type="checkbox" name="surat_ids[]" value="{{ $surat->id }}" class="rounded border-gray-300 shadow-sm surat-checkbox"></td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $surat->nomor_surat ?? 'N/A' }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-800">{{ $surat->perihal }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $surat->tanggal_surat->format('d M Y') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($surat->klasifikasi)->kode }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                            @if($surat->berkas->isNotEmpty())
+                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                                    <i class="fas fa-folder-open mr-1.5"></i>
+                                                    {{ $surat->berkas->first()->name }}
+                                                </span>
+                                            @else
+                                                <span class="text-gray-400 italic">Belum Diarsipkan</span>
+                                            @endif
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                            @if ($surat->file_path)
+                                                <a href="{{ route('surat.download', $surat) }}" class="text-indigo-600 hover:text-indigo-900">Unduh</a>
+                                            @else
+                                                <span class="text-gray-400">N/A</span>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="7" class="px-6 py-12 text-center text-gray-500">Tidak ada surat yang cocok dengan kriteria pencarian.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                        </div>
+
+                        <div class="mt-4 p-4 border-t flex items-center space-x-4 bg-gray-50 rounded-b-lg">
+                            <label for="berkas_id" class="text-sm font-medium">Pilih Berkas:</label>
+                            <select name="berkas_id" id="berkas_id" class="rounded-md border-gray-300 shadow-sm text-sm" @if($suratList->where('berkas', 'isEmpty')->isEmpty()) disabled @endif>
+                                <option value="">-- Tujuan Berkas --</option>
+                                @foreach($berkasList as $berkas)
+                                    <option value="{{ $berkas->id }}">{{ $berkas->name }}</option>
+                                @endforeach
+                            </select>
+                            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md text-xs hover:bg-indigo-700" @if($suratList->where('berkas', 'isEmpty')->isEmpty()) disabled @endif>
+                                <i class="fas fa-folder-plus mr-1"></i> Masukkan ke Berkas
+                            </button>
+                            @if($suratList->where('berkas', 'isEmpty')->isEmpty() && $suratList->isNotEmpty())
+                            <p class="text-xs text-gray-500 italic">Semua surat yang ditampilkan sudah diarsipkan.</p>
+                            @endif
+                        </div>
+                    </form>
+
+                    <div class="mt-6">
+                        {{ $suratList->links() }}
+                    </div>
+                </div>
             </div>
         </div>
     </div>
     @push('scripts')
         <script>
-            document.getElementById('select-all').addEventListener('change', function(event) {
-                document.querySelectorAll('.surat-checkbox').forEach(function(checkbox) {
-                    checkbox.checked = event.target.checked;
-                });
-            });
-
             document.addEventListener('DOMContentLoaded', function() {
-                flatpickr("#date_range", {
-                    mode: "range",
-                    dateFormat: "Y-m-d",
-                    altInput: true,
-                    altFormat: "d M Y",
-                });
+                // Checkbox select-all logic
+                const selectAll = document.getElementById('select-all');
+                if (selectAll) {
+                    selectAll.addEventListener('change', function(event) {
+                        document.querySelectorAll('.surat-checkbox').forEach(function(checkbox) {
+                            checkbox.checked = event.target.checked;
+                        });
+                    });
+                }
+
+                // Date range picker logic
+                const dateRange = document.getElementById('date_range');
+                if(dateRange) {
+                    flatpickr(dateRange, {
+                        mode: "range",
+                        dateFormat: "Y-m-d",
+                        altInput: true,
+                        altFormat: "d M Y",
+                    });
+                }
             });
         </script>
     @endpush


### PR DESCRIPTION
This commit fixes a bug where letters that were successfully archived were not appearing on the main digital archive page (`/arsip`).

The issue was caused by a query that explicitly excluded letters that were already in an archive folder (`berkas`). This filter has been removed to ensure all relevant letters are displayed.

Additionally, the view has been updated to include a new 'Lokasi Arsip' (Archive Location) column, making it clear to the user which folder a letter belongs to, or if it is un-archived. This resolves the user's confusion and makes the page's function more intuitive.