### PR TITLE
fix: Update letter status to diarsipkan upon archiving

### DIFF
--- a/app/Http/Controllers/SpecialAssignmentController.php
+++ b/app/Http/Controllers/SpecialAssignmentController.php
@@ -193,8 +193,13 @@ class SpecialAssignmentController extends Controller
             }
 
             // --- Archive the new Surat if a Berkas is selected ---
-            if (isset($validated['berkas_id']) && !empty($validated['berkas_id'])) {
-                $surat->berkas()->attach($validated['berkas_id']);
+            if ($request->filled('berkas_id')) {
+                $berkas = Berkas::find($validated['berkas_id']);
+                if ($berkas && $berkas->user_id == $user->id) {
+                    $berkas->surat()->attach($surat->id);
+                    // Update status to 'diarsipkan' so it appears in the archive list
+                    $surat->update(['status' => 'diarsipkan']);
+                }
             }
 
         } catch (\Exception $e) {


### PR DESCRIPTION
This commit fixes a bug where a newly created Special Assignment (SK Penugasan), when added to a digital archive ('Berkas'), would not appear on the main archive page.

The issue was that the letter's ('Surat') status was not being updated to 'diarsipkan' after being attached to the archive. This change modifies the `store` method in `SpecialAssignmentController` to explicitly update the status, ensuring the letter is correctly displayed in the archive list immediately after creation.