### PR TITLE
feat: Handle PostTooLargeException gracefully

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Exceptions\PostTooLargeException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -29,5 +30,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        $exceptions->render(function (PostTooLargeException $e, \Illuminate\Http\Request $request) {
+            return back()->withErrors(['file' => 'Ukuran file yang diunggah terlalu besar. Silakan coba lagi dengan file yang lebih kecil.']);
+        });
     })->create();


### PR DESCRIPTION
This commit improves the application's error handling by gracefully managing `PostTooLargeException`.

Previously, uploading a file that exceeded the server's `post_max_size` limit would result in a generic, unhelpful server error page.

This change modifies the exception handling in `bootstrap/app.php` to catch this specific exception. The user is now redirected back to the form they were on with a user-friendly error message, improving the overall user experience.