### PR TITLE
fix: Correct HTTP method for make-task action

### DIFF
--- a/resources/views/surat/show.blade.php
+++ b/resources/views/surat/show.blade.php
@@ -11,9 +11,12 @@
                 <a href="{{ route('disposisi.lacak', $surat) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-semibold text-sm hover:bg-blue-700">
                     <i class="fas fa-sitemap mr-2"></i> Lacak Disposisi
                 </a>
-                <a href="{{ route('surat.make-task', $surat) }}" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg font-semibold text-sm hover:bg-green-700">
-                    <i class="fas fa-tasks mr-2"></i> Jadikan Tugas
-                </a>
+                <form action="{{ route('surat.make-task', $surat) }}" method="POST" class="inline-block">
+                    @csrf
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg font-semibold text-sm hover:bg-green-700">
+                        <i class="fas fa-tasks mr-2"></i> Jadikan Tugas
+                    </button>
+                </form>
                 <a href="{{ route('surat.make-project', $surat) }}" class="inline-flex items-center px-4 py-2 bg-purple-600 text-white rounded-lg font-semibold text-sm hover:bg-purple-700">
                     <i class="fas fa-folder-plus mr-2"></i> Jadikan Kegiatan
                 </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -207,7 +207,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/surat/workflow', [SuratController::class, 'showWorkflow'])->name('surat.workflow');
     Route::resource('surat', SuratController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
     Route::get('/surat/{surat}/download', [SuratController::class, 'download'])->name('surat.download');
-    Route::get('/surat/{surat}/make-task', [SuratController::class, 'makeTask'])->name('surat.make-task');
+    Route::post('/surat/{surat}/make-task', [SuratController::class, 'makeTask'])->name('surat.make-task');
     Route::get('/surat/{surat}/make-project', [SuratController::class, 'makeProject'])->name('surat.make-project');
 
     // Disposition routes, attached to the unified surat


### PR DESCRIPTION
This commit fixes a 404 Not Found error that occurred when clicking the "Jadikan Tugas" (Make Task) button on the letter detail page.

The action of creating a task is not idempotent and should be handled by a POST request, not a GET request. This change updates the route in `routes/web.php` to accept POST and modifies the button in `surat/show.blade.php` to be a form that submits a POST request.

This resolves the 404 error and aligns the implementation with RESTful best practices.