### PR TITLE
Fix 404 error on 'Jadikan Tugas' button

### DIFF
--- a/resources/views/surat/show.blade.php
+++ b/resources/views/surat/show.blade.php
@@ -11,12 +11,9 @@
                 <a href="{{ route('disposisi.lacak', $surat) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-semibold text-sm hover:bg-blue-700">
                     <i class="fas fa-sitemap mr-2"></i> Lacak Disposisi
                 </a>
-                <form action="{{ route('surat.make-task', $surat) }}" method="POST" class="inline-block">
-                    @csrf
-                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg font-semibold text-sm hover:bg-green-700">
-                        <i class="fas fa-tasks mr-2"></i> Jadikan Tugas
-                    </button>
-                </form>
+                <a href="{{ route('surat.make-task', $surat) }}" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg font-semibold text-sm hover:bg-green-700">
+                    <i class="fas fa-tasks mr-2"></i> Jadikan Tugas
+                </a>
                 <a href="{{ route('surat.make-project', $surat) }}" class="inline-flex items-center px-4 py-2 bg-purple-600 text-white rounded-lg font-semibold text-sm hover:bg-purple-700">
                     <i class="fas fa-folder-plus mr-2"></i> Jadikan Kegiatan
                 </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -207,7 +207,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/surat/workflow', [SuratController::class, 'showWorkflow'])->name('surat.workflow');
     Route::resource('surat', SuratController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
     Route::get('/surat/{surat}/download', [SuratController::class, 'download'])->name('surat.download');
-    Route::post('/surat/{surat}/make-task', [SuratController::class, 'makeTask'])->name('surat.make-task');
+    Route::get('/surat/{surat}/make-task', [SuratController::class, 'makeTask'])->name('surat.make-task');
     Route::get('/surat/{surat}/make-project', [SuratController::class, 'makeProject'])->name('surat.make-project');
 
     // Disposition routes, attached to the unified surat


### PR DESCRIPTION
The 'Jadikan Tugas' button on the surat detail page was causing a 404 Not Found error. This was likely due to a mismatch between the expected HTTP method in the route definition and the actual request being made by the browser.

This commit resolves the issue by:
1. Changing the `surat.make-task` route from `POST` to `GET`.
2. Updating the button in the view from a `<form>` to a simple `<a>` hyperlink to match the `GET` route.

This ensures the request method is consistent and resolves the 404 error.