### PR TITLE
feat: Prefill ad-hoc task form from letter

### DIFF
--- a/app/Http/Controllers/AdHocTaskController.php
+++ b/app/Http/Controllers/AdHocTaskController.php
@@ -114,8 +114,18 @@ class AdHocTaskController extends Controller
         
         $priorities = \App\Models\PriorityLevel::all();
 
+        $task = new Task();
+        // Check for flashed session data to pre-fill the form
+        if (session()->has('prefill_title')) {
+            $task->title = session('prefill_title');
+        }
+        if (session()->has('prefill_start_date')) {
+            $task->start_date = session('prefill_start_date');
+        }
+
+
         return view('adhoc-tasks.create', [
-            'task' => new Task(),
+            'task' => $task,
             'assignableUsers' => $assignableUsers,
             'priorities' => $priorities,
         ]);

--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -148,36 +148,9 @@ class SuratController extends Controller
      */
     public function makeTask(Request $request, Surat $surat)
     {
-        $defaultStatus = \App\Models\TaskStatus::where('key', 'pending')->firstOrFail();
-        $defaultPriority = \App\Models\PriorityLevel::where('name', 'Normal')->firstOrFail();
-
-        $task = Task::create([
-            'title' => $surat->perihal,
-            'description' => 'Tugas ini dibuat berdasarkan surat dengan perihal: ' . $surat->perihal . '. Lihat surat terlampir untuk detail.',
-            'creator_id' => Auth::id(),
-            'task_status_id' => $defaultStatus->id,
-            'priority_level_id' => $defaultPriority->id,
-            'due_date' => now()->addDays(7),
-            'surat_id' => $surat->id,
-        ]);
-
-        $task->assignees()->attach(Auth::id());
-
-    // Automatically attach the letter's file to the new task
-    if ($surat->file_path) {
-        $task->attachments()->create([
-            'user_id' => Auth::id(),
-            'filename' => 'Surat Asal - ' . Str::slug($surat->perihal) . '.' . pathinfo($surat->file_path, PATHINFO_EXTENSION),
-            'path' => $surat->file_path,
-        ]);
-    }
-
-    $task->load('status');
-
-        $surat->status = 'disetujui';
-        $surat->save();
-
-        return redirect()->route('tasks.edit', $task)->with('success', 'Tugas berhasil dibuat dari surat. Silakan lengkapi detail tugas.');
+        return redirect()->route('adhoc-tasks.create')
+            ->with('prefill_title', $surat->perihal)
+            ->with('prefill_start_date', $surat->tanggal_surat->format('Y-m-d'));
     }
 
     /**


### PR DESCRIPTION
This commit changes the functionality of the 'Jadikan Tugas' (Make Task) button on the letter detail page.

Previously, it created a task directly. Now, it redirects to the ad-hoc task creation form and pre-fills the task title and start date using the letter's subject and date, respectively.

This was accomplished by:
1. Modifying the `makeTask` method in `SuratController` to redirect and flash the necessary data to the session.
2. Updating the `create` method in `AdHocTaskController` to check for the flashed data and populate the `$task` object.
3. The existing ad-hoc task form view uses this populated object to pre-fill the fields.