### PR TITLE
feat: Add cancel button and improve task creation flow

### DIFF
--- a/resources/views/projects/create_step1.blade.php
+++ b/resources/views/projects/create_step1.blade.php
@@ -82,6 +82,9 @@
                         </div>
 
                         <div class="flex items-center justify-end mt-8 border-t border-gray-200 pt-6">
+                            <a href="{{ route('projects.index') }}" class="text-sm text-gray-600 hover:text-gray-900 font-medium mr-6 transition-colors duration-200">
+                                Batal
+                            </a>
                             <button type="submit"
                                     class="inline-flex items-center justify-center px-5 py-2.5 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg transform hover:scale-105 disabled:opacity-50"
                                     :disabled="isSubmitting">


### PR DESCRIPTION
This commit introduces two new features based on user requests:

1.  **Add Cancel Button to Project Creation:** A 'Batal' (Cancel) link has been added to the first step of the project creation page (`/projects/create-step-1`). This allows users to easily exit the creation process and return to the project index page.

2.  **Prefill Task Form from Letter:** The 'Jadikan Tugas' (Make Task) button on the letter detail page now redirects to the ad-hoc task creation form, pre-filling the task title and start date from the letter's subject and date. This improves the workflow by reducing manual data entry.