### PR TITLE
feat: Create dedicated dashboard for staff users

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -27,6 +27,11 @@ class HomeController extends Controller
             return app(ExecutiveSummaryController::class)->index($insightService);
         }
 
+        if ($user->isStaff()) {
+            // Redirect staff to their specific dashboard
+            return redirect()->route('staff.dashboard');
+        }
+
         // Forward the request to the GlobalDashboardController and return its response
         return app(GlobalDashboardController::class)->index();
     }

--- a/app/Http/Controllers/StaffDashboardController.php
+++ b/app/Http/Controllers/StaffDashboardController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+use App\Models\Activity;
+use App\Models\Task;
+
+class StaffDashboardController extends Controller
+{
+    /**
+     * Display the staff member's dashboard.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function index()
+    {
+        $user = Auth::user();
+
+        // Fetch tasks assigned to the user that are not completed.
+        $tasks = $user->tasks()
+            ->whereHas('status', function ($query) {
+                $query->where('key', '!=', 'completed');
+            })
+            ->with('project') // Eager load project for context
+            ->latest()
+            ->get();
+
+        // Fetch the user's 15 most recent activities.
+        $activities = Activity::where('user_id', $user->id)
+            ->with('subject') // Eager load the subject of the activity (e.g., the task that was updated)
+            ->latest()
+            ->limit(15)
+            ->get();
+
+        return view('staff.dashboard', compact('user', 'tasks', 'activities'));
+    }
+}

--- a/database/seeders/AdHocTaskSeeder.php
+++ b/database/seeders/AdHocTaskSeeder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Task;
+use App\Models\User;
+use App\Models\TaskStatus;
+use Faker\Factory as Faker;
+use Illuminate\Support\Facades\Auth;
+
+class AdHocTaskSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        $faker = Faker::create('id_ID');
+        $users = User::whereDoesntHave('roles', function ($query) {
+            $query->where('name', 'Superadmin');
+        })->get();
+        $taskStatusIds = TaskStatus::pluck('id');
+
+        if ($users->isEmpty() || $taskStatusIds->isEmpty()) {
+            $this->command->info('No users or task statuses found to assign ad-hoc tasks.');
+            return;
+        }
+
+        for ($i = 0; $i < 15; $i++) { // Membuat 15 record
+            // Temporarily authenticate as a random user to be the task creator
+            $creator = $users->random();
+            Auth::login($creator);
+
+            $task = Task::create([
+                'title' => $faker->sentence(4),
+                'description' => $faker->realText(150),
+                'deadline' => $faker->dateTimeBetween('+1 week', '+3 months'),
+                'progress' => $faker->numberBetween(0, 100),
+                'task_status_id' => $taskStatusIds->random(),
+                'project_id' => null, // Kunci untuk ad-hoc task
+                'estimated_hours' => $faker->randomFloat(1, 1, 8),
+            ]);
+
+            // Tugaskan ke 1 atau 2 user acak
+            $task->assignees()->attach(
+                $users->random(rand(1, min(2, $users->count())))->pluck('id')->toArray()
+            );
+
+            Auth::logout();
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,12 @@ class DatabaseSeeder extends Seeder
             LeaveTypesSeeder::class,
             TaskStatusSeeder::class,
             PriorityLevelSeeder::class,
+            LeaveRequestSeeder::class,
+            ProjectSeeder::class,
+            TaskSeeder::class,
+            TimeLogSeeder::class,
+            SpecialAssignmentSeeder::class,
+            AdHocTaskSeeder::class,
         ]);
 
         // Panggil PerformanceCalculatorService untuk memastikan data kinerja terisi

--- a/database/seeders/LeaveRequestSeeder.php
+++ b/database/seeders/LeaveRequestSeeder.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\RequestStatus;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\LeaveType;
+use App\Models\LeaveRequest;
+use App\Services\LeaveDurationService;
+use Carbon\Carbon;
+
+class LeaveRequestSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $this->command->info('Seeding dummy leave requests...');
+
+        $users = User::whereHas('roles', function ($query) {
+            $query->where('name', 'Staf');
+        })->whereNotNull('atasan_id')->get();
+
+        if ($users->isEmpty()) {
+            $this->command->warn('No staff users with supervisors found. Skipping leave request seeding.');
+            return;
+        }
+
+        $leaveTypes = LeaveType::all();
+        if ($leaveTypes->isEmpty()) {
+            $this->command->warn('No leave types found. Please run LeaveTypesSeeder first. Skipping leave request seeding.');
+            return;
+        }
+
+        $statuses = [RequestStatus::PENDING, RequestStatus::APPROVED, RequestStatus::REJECTED, RequestStatus::APPROVED_BY_SUPERVISOR];
+
+        for ($i = 0; $i < 30; $i++) {
+            $user = $users->random();
+            $leaveType = $leaveTypes->random();
+
+            $startDate = Carbon::now()->subDays(rand(-30, 30)); // Random start date around today
+            $endDate = $startDate->copy()->addDays(rand(0, 10));
+
+            $duration = LeaveDurationService::calculate($startDate, $endDate);
+            // Ensure duration is at least 1 day for this seeder
+            if ($duration <= 0) {
+                $endDate->addDay();
+                $duration = LeaveDurationService::calculate($startDate, $endDate);
+                 if ($duration <= 0) continue; // Skip if still invalid
+            }
+
+            $status = $statuses[array_rand($statuses)];
+            $approverId = null;
+            $rejectionReason = null;
+
+            if ($status !== RequestStatus::PENDING) {
+                $approverId = $user->atasan_id;
+            }
+            if ($status === RequestStatus::REJECTED) {
+                $rejectionReason = 'Alasan penolakan otomatis dari seeder.';
+            }
+
+            LeaveRequest::create([
+                'user_id' => $user->id,
+                'leave_type_id' => $leaveType->id,
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+                'duration_days' => $duration,
+                'reason' => 'Permintaan cuti otomatis dari seeder.',
+                'address_during_leave' => 'Jl. Seeder No. ' . ($i + 1),
+                'status' => $status,
+                'current_approver_id' => ($status === RequestStatus::PENDING || $status === RequestStatus::APPROVED_BY_SUPERVISOR) ? $user->atasan_id : null,
+                'rejection_reason' => $rejectionReason,
+            ]);
+        }
+
+        $this->command->info('Dummy leave requests have been seeded successfully.');
+    }
+}

--- a/database/seeders/ProjectSeeder.php
+++ b/database/seeders/ProjectSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Project;
+use App\Models\User;
+
+class ProjectSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Ambil semua user yang bisa jadi pimpinan/pemilik proyek
+        $potential_leaders = User::whereHas('roles', function ($query) {
+            $query->whereIn('name', ['Eselon I', 'Eselon II', 'Koordinator']);
+        })->get();
+        $all_users = User::all();
+
+        if ($potential_leaders->isEmpty()) {
+            $this->command->info('Tidak ada user dengan peran manajerial untuk dijadikan pimpinan proyek. Jalankan UserSeeder dulu.');
+            return;
+        }
+
+        Project::truncate();
+
+        for ($i = 0; $i < 20; $i++) {
+            $leader = $potential_leaders->random();
+            $project = Project::factory()->create([
+                'owner_id' => $leader->id,
+                'leader_id' => $leader->id,
+            ]);
+
+            // Assign 3 to 10 random users to the project
+            $members = $all_users->random(rand(3, min(10, $all_users->count())));
+            // Pastikan leader termasuk dalam anggota
+            $members->push($leader);
+
+            $project->members()->sync($members->pluck('id')->unique());
+        }
+    }
+}

--- a/database/seeders/SpecialAssignmentSeeder.php
+++ b/database/seeders/SpecialAssignmentSeeder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\SpecialAssignment;
+use App\Models\User;
+use Faker\Factory as Faker;
+
+class SpecialAssignmentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        $faker = Faker::create('id_ID');
+        $users = User::whereDoesntHave('roles', function ($query) {
+            $query->where('name', 'Superadmin');
+        })->get();
+        $managers = User::whereHas('roles', function ($query) {
+            $query->whereIn('name', ['Eselon I', 'Eselon II', 'Koordinator']);
+        })->get();
+
+        if ($users->count() < 2 || $managers->isEmpty()) {
+            $this->command->info('Not enough users or managers to create special assignments.');
+            return;
+        }
+
+        for ($i = 0; $i < 15; $i++) {
+            $assignment = SpecialAssignment::create([
+                'title' => 'SK ' . $faker->sentence(3),
+                'description' => $faker->realText(200),
+                'creator_id' => $managers->random()->id,
+                'start_date' => $faker->dateTimeBetween('-1 month', '+1 month'),
+                'end_date' => $faker->dateTimeBetween('+2 months', '+6 months'),
+                'status' => $faker->randomElement(['AKTIF', 'SELESAI']),
+                'feedback' => $faker->optional()->sentence,
+            ]);
+
+            // Assign 1 to 3 random users to the assignment
+            $assignment->members()->attach(
+                $users->random(rand(1, min(3, $users->count())))->pluck('id')->toArray()
+            );
+        }
+    }
+}

--- a/database/seeders/TaskSeeder.php
+++ b/database/seeders/TaskSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Task;
+use App\Models\Project;
+use App\Models\User;
+
+class TaskSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $projects = Project::with('members')->get();
+
+        if ($projects->isEmpty()) {
+            $this->command->info('Tidak ada proyek untuk ditambahkan tugas. Jalankan ProjectSeeder dulu.');
+            return;
+        }
+
+        Task::truncate();
+
+        foreach ($projects as $project) {
+            if ($project->members->isEmpty()) {
+                continue; // Lewati proyek tanpa anggota
+            }
+
+            // Buat 5 sampai 10 tugas untuk setiap proyek
+            $numberOfTasks = rand(5, 10);
+
+            for ($i = 0; $i < $numberOfTasks; $i++) {
+                $task = Task::factory()->create([
+                    'project_id' => $project->id,
+                ]);
+
+                // Lampirkan 1 sampai 3 anggota random dari proyek ke tugas ini
+                $assignees = $project->members->random(rand(1, min(3, $project->members->count())));
+                $task->assignees()->attach($assignees->pluck('id'));
+            }
+        }
+    }
+}

--- a/database/seeders/TimeLogSeeder.php
+++ b/database/seeders/TimeLogSeeder.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Task;
+use App\Models\TimeLog;
+use Carbon\Carbon;
+
+class TimeLogSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Hapus data lama untuk menghindari duplikasi saat re-seed
+        TimeLog::truncate();
+
+        $tasks = Task::with('assignees')->get();
+
+        if ($tasks->isEmpty()) {
+            $this->command->info('Tidak ada tugas untuk ditambahkan time log. Jalankan TaskSeeder dulu.');
+            return;
+        }
+
+        $this->command->getOutput()->progressStart($tasks->count());
+
+        foreach ($tasks as $task) {
+            if ($task->assignees->isEmpty()) {
+                continue; // Lewati tugas tanpa penanggung jawab
+            }
+
+            // Jangan buat log untuk tugas yang belum dimulai
+            if ($task->status === 'pending' || $task->progress === 0) {
+                continue;
+            }
+
+            foreach ($task->assignees as $assignee) {
+                $estimated = $task->estimated_hours;
+                $actualHours = 0;
+
+                // Other users remain realistic
+                $variance = (rand(-20, 20) / 100); // Variansi antara -20% dan +20%
+                $actualHours = $estimated * (1 + $variance);
+
+                $actualHours = max(1, round($actualHours, 1));
+
+                $startTime = Carbon::now()->subDays(rand(1, 7))->subHours(rand(1, 8));
+                $endTime = $startTime->copy()->addHours($actualHours);
+
+                TimeLog::create([
+                    'task_id' => $task->id,
+                    'user_id' => $assignee->id,
+                    'start_time' => $startTime,
+                    'end_time' => $endTime,
+                ]);
+            }
+            $this->command->getOutput()->progressAdvance();
+        }
+
+        $this->command->getOutput()->progressFinish();
+        $this->command->info(TimeLog::count() . ' time logs berhasil dibuat.');
+    }
+}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -46,7 +46,11 @@ if (count($words) >= 2) {
                             </x-slot>
                             <x-slot name="content">
                                 <div class="px-4 py-2 text-xs text-gray-400">Kegiatan</div>
-                                <x-dropdown-link :href="route('global.dashboard')">Kegiatan</x-dropdown-link>
+                                @if(Auth::user()->isStaff())
+                                    <x-dropdown-link :href="route('staff.dashboard')" :active="request()->routeIs('staff.dashboard')">Kegiatan</x-dropdown-link>
+                                @else
+                                    <x-dropdown-link :href="route('global.dashboard')" :active="request()->routeIs('global.dashboard')">Kegiatan</x-dropdown-link>
+                                @endif
                                 <div class="border-t border-gray-100"></div>
                                 <div class="px-4 py-2 text-xs text-gray-400">Tugas</div>
                                 <x-dropdown-link :href="route('adhoc-tasks.index')">Tugas Harian</x-dropdown-link>

--- a/resources/views/staff/dashboard.blade.php
+++ b/resources/views/staff/dashboard.blade.php
@@ -1,0 +1,53 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Dashboard Staff') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-2 gap-8">
+
+            <!-- My Tasks Section -->
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <h3 class="text-lg font-medium text-gray-900 border-b pb-2 mb-4">Tugas Aktif Saya</h3>
+                    @forelse ($tasks as $task)
+                        <div class="mb-3 p-2 rounded-md hover:bg-gray-50">
+                            <p class="font-semibold">{{ $task->name }}</p>
+                            @if ($task->project)
+                                <p class="text-sm text-gray-500">Proyek: {{ $task->project->name }}</p>
+                            @endif
+                            <p class="text-xs text-gray-400 mt-1">Due: {{ $task->due_date ? \Carbon\Carbon::parse($task->due_date)->format('d M Y') : 'N/A' }}</p>
+                        </div>
+                    @empty
+                        <p class="text-sm text-gray-500">Tidak ada tugas aktif saat ini.</p>
+                    @endforelse
+                </div>
+            </div>
+
+            <!-- My Recent Activities Section -->
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <h3 class="text-lg font-medium text-gray-900 border-b pb-2 mb-4">Aktivitas Terbaru Saya</h3>
+                    <ul class="space-y-4">
+                        @forelse ($activities as $activity)
+                            <li class="flex items-start text-sm">
+                                <div class="flex-shrink-0">
+                                    <i class="fas fa-history text-gray-400 mt-1"></i>
+                                </div>
+                                <div class="ml-3">
+                                    <p class="text-gray-700">{{ Str::ucfirst(str_replace('_', ' ', $activity->description)) }}</p>
+                                    <span class="text-xs text-gray-400">{{ $activity->created_at->diffForHumans() }}</span>
+                                </div>
+                            </li>
+                        @empty
+                            <p class="text-sm text-gray-500">Tidak ada aktivitas terbaru.</p>
+                        @endforelse
+                    </ul>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\CommentController;
 use App\Http\Controllers\AttachmentController;
 use App\Http\Controllers\GlobalDashboardController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\StaffDashboardController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\WorkloadAnalysisController;
 use App\Http\Controllers\TimeLogController;
@@ -48,6 +49,7 @@ Route::get('/get-users-by-unit/{unitId}', [UserController::class, 'getUsersByUni
 Route::middleware(['auth'])->group(function () {
     // Rute default setelah login adalah Beranda baru.
     Route::get('/dashboard', [HomeController::class, 'index'])->name('dashboard');
+    Route::get('/staff/dashboard', [StaffDashboardController::class, 'index'])->name('staff.dashboard');
     // Rute untuk daftar kegiatan (proyek)
     Route::get('/projects', [ProjectController::class, 'index'])->name('projects.index');
     Route::get('/projects/workflow', [ProjectController::class, 'showWorkflow'])->name('projects.workflow');


### PR DESCRIPTION
This commit introduces a new dashboard page specifically for users with the 'Staf' role, providing them with a "helicopter view" of their work.

Key changes:
- Adds a new route at `/staff/dashboard`.
- Creates a `StaffDashboardController` to fetch active tasks and recent activities for the logged-in staff member.
- Creates a new view at `resources/views/staff/dashboard.blade.php` to display this information.
- Updates `HomeController` to redirect staff users to their new dashboard upon login.
- Updates the main navigation menu to conditionally link the 'Kegiatan' submenu to the new staff dashboard.