### PR TITLE
fix: Further improve readability of SKP formulas

### DIFF
--- a/resources/views/workload-analysis/show.blade.php
+++ b/resources/views/workload-analysis/show.blade.php
@@ -43,9 +43,19 @@
                                 @else
                                     <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
                                         @php
-                                            $iki_human_labels = collect($performanceDetails['iki_components'])->mapWithKeys(function ($value, $key) {
-                                                // Create a friendlier label from the key
-                                                return [$key => '('.ucwords(str_replace('_', ' ', $key)).')'];
+                                            $formatLabel = function($key) {
+                                                $label = $key;
+                                                if (str_starts_with($label, 'capped_')) {
+                                                    $label = str_replace('capped_', '', $label);
+                                                    $label = ucwords(str_replace('_', ' ', $label)) . ' (dibatasi)';
+                                                } else {
+                                                    $label = ucwords(str_replace('_', ' ', $label));
+                                                }
+                                                return '(' . $label . ')';
+                                            };
+
+                                            $iki_human_labels = collect($performanceDetails['iki_components'])->mapWithKeys(function ($value, $key) use ($formatLabel) {
+                                                return [$key => $formatLabel($key)];
                                             })->all();
                                             $human_iki_formula = str_replace(array_keys($iki_human_labels), array_values($iki_human_labels), $performanceDetails['iki_formula']);
                                         @endphp
@@ -79,9 +89,19 @@
                                 @else
                                     <div class="text-xs p-2 rounded bg-gray-100 border font-mono mb-2">
                                         @php
-                                            $nkf_human_labels = collect($performanceDetails['nkf_components'])->mapWithKeys(function ($value, $key) {
-                                                // Create a friendlier label from the key
-                                                return [$key => '('.ucwords(str_replace('_', ' ', $key)).')'];
+                                            $formatLabel = function($key) {
+                                                $label = $key;
+                                                if (str_starts_with($label, 'capped_')) {
+                                                    $label = str_replace('capped_', '', $label);
+                                                    $label = ucwords(str_replace('_', ' ', $label)) . ' (dibatasi)';
+                                                } else {
+                                                    $label = ucwords(str_replace('_', ' ', $label));
+                                                }
+                                                return '(' . $label . ')';
+                                            };
+
+                                            $nkf_human_labels = collect($performanceDetails['nkf_components'])->mapWithKeys(function ($value, $key) use ($formatLabel) {
+                                                return [$key => $formatLabel($key)];
                                             })->all();
                                             $human_nkf_formula = str_replace(array_keys($nkf_human_labels), array_values($nkf_human_labels), $performanceDetails['nkf_formula']);
                                         @endphp


### PR DESCRIPTION
This commit improves upon the previous refactoring of the performance formula display. The initial change did not fully handle technical prefixes like 'capped_' in variable names.

This patch enhances the string replacement logic in the `workload-analysis/show.blade.php` view. It now uses a small helper closure to intelligently format the labels, specifically handling the 'capped_' prefix and ensuring all underscores are replaced with spaces.

This results in a fully human-readable formula as requested by the user.