### PR TITLE
feat: Add robust hierarchy rebuild command and fix observer logic

### DIFF
--- a/app/Console/Commands/RebuildHierarchyCommand.php
+++ b/app/Console/Commands/RebuildHierarchyCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+
+class RebuildHierarchyCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hierarchy:rebuild';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rebuilds the unit hierarchy closure table (unit_paths) for data integrity.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Starting unit hierarchy rebuild...');
+
+        try {
+            $this->line('Calling Unit::rebuildHierarchy()...');
+
+            $result = Unit::rebuildHierarchy();
+
+            $this->info("\nUnit hierarchy rebuild completed successfully!");
+            $this->info("Processed {$result['total_units']} units and created {$result['processed_paths']} paths.");
+
+            return 0; // Success
+        } catch (\Exception $e) {
+            $this->error("\nAn error occurred during the hierarchy rebuild:");
+            $this->error($e->getMessage());
+            // Optionally log the full stack trace for debugging
+            // \Log::error($e);
+            return 1; // Failure
+        }
+    }
+}

--- a/app/Observers/UnitObserver.php
+++ b/app/Observers/UnitObserver.php
@@ -59,9 +59,8 @@ class UnitObserver
         if ($unit->isDirty('parent_unit_id')) {
             // The logic for incrementally updating a closure table is complex.
             // For simplicity and guaranteed correctness, we will rebuild the entire
-            // table on any parent_unit_id change. This is less performant on
-            // large datasets but ensures data integrity.
-            Unit::rebuildPaths();
+            // table on any parent_unit_id change using the new robust method.
+            Unit::rebuildHierarchy();
 
             // Clear all relevant caches after the rebuild
             $this->clearHierarchyCache($unit);


### PR DESCRIPTION
The organizational hierarchy was failing to display correctly because the underlying `unit_paths` closure table was being corrupted. This was caused by a flawed `rebuildPaths` method in the `Unit` model that was susceptible to race conditions and stale data when processing unit updates.

This commit introduces three main changes to fix the issue:

1.  A new, robust `Unit::rebuildHierarchy()` method has been created. It safely rebuilds the `unit_paths` table by first loading all units into a collection and then traversing the parent-child relationships from the collection, avoiding stale Eloquent relationship data.

2.  A new Artisan command, `php artisan hierarchy:rebuild`, is added. This command allows an administrator to manually trigger the new, robust rebuild process to fix any existing data corruption.

3.  The `UnitObserver` has been updated to call the new `Unit::rebuildHierarchy()` method, ensuring that future updates to the unit structure are handled correctly and do not corrupt the hierarchy data.