### PR TITLE
refactor: Unify hierarchy logic in WorkloadAnalysisController

### DIFF
--- a/app/Http/Controllers/WorkloadAnalysisController.php
+++ b/app/Http/Controllers/WorkloadAnalysisController.php
@@ -55,10 +55,14 @@ class WorkloadAnalysisController extends Controller
 
         // --- Base Subordinates Query ---
         if ($manager->isSuperAdmin()) {
+            // Superadmin sees everyone except themself.
             $baseSubordinatesQuery = User::where('id', '!=', $manager->id);
         } else {
-            $subordinateUnitIds = $manager->unit ? $manager->unit->getAllSubordinateUnitIds() : [];
-            $baseSubordinatesQuery = User::whereIn('unit_id', $subordinateUnitIds)->where('id', '!=', $manager->id);
+            // Use the standard, correct method for getting all subordinate IDs.
+            // This includes users in subordinate units AND the manager's own unit.
+            $subordinateIds = $manager->getAllSubordinateIds();
+            // We still need to exclude the manager themself from the list.
+            $baseSubordinatesQuery = User::whereIn('id', $subordinateIds)->where('id', '!=', $manager->id);
         }
 
         if ($search) {


### PR DESCRIPTION
This commit addresses a follow-up issue where the Workload Analysis page was displaying an incorrect user hierarchy, even after the underlying data was fixed.

The controller was using its own custom and flawed logic to fetch subordinates, which omitted colleagues in the manager's own unit. This has been replaced with the standard `getAllSubordinateIds()` method from the User model.

This change ensures that the Workload Analysis page now uses the same, correct hierarchy logic as the rest of the application, providing a consistent and accurate view of the team structure.