### PR TITLE
feat: Implement edit, delete, and move functionality for virtual folders

### DIFF
--- a/app/Models/Berkas.php
+++ b/app/Models/Berkas.php
@@ -30,6 +30,6 @@ class Berkas extends Model
      */
     public function surat()
     {
-        return $this->belongsToMany(Surat::class, 'berkas_surat');
+        return $this->hasMany(Surat::class);
     }
 }

--- a/app/Models/Surat.php
+++ b/app/Models/Surat.php
@@ -26,6 +26,7 @@ class Surat extends Model
         'suratable_type',
         'klasifikasi_id',
         'collaborators',
+        'berkas_id',
     ];
 
     protected $casts = [
@@ -68,6 +69,6 @@ class Surat extends Model
 
     public function berkas()
     {
-        return $this->belongsToMany(Berkas::class, 'berkas_surat');
+        return $this->belongsTo(Berkas::class);
     }
 }

--- a/database/migrations/2025_09_15_011500_add_berkas_id_to_surat_table.php
+++ b/database/migrations/2025_09_15_011500_add_berkas_id_to_surat_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('surat', function (Blueprint $table) {
+            $table->foreignId('berkas_id')->nullable()->constrained('berkas')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('surat', function (Blueprint $table) {
+            $table->dropForeign(['berkas_id']);
+            $table->dropColumn('berkas_id');
+        });
+    }
+};

--- a/database/migrations/2025_09_15_011600_migrate_data_from_berkas_surat_to_surat_table.php
+++ b/database/migrations/2025_09_15_011600_migrate_data_from_berkas_surat_to_surat_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Get all entries from the pivot table
+        $berkas_surat = DB::table('berkas_surat')->get();
+
+        foreach ($berkas_surat as $entry) {
+            // Update the surat table with the berkas_id
+            // If a surat is in multiple berkas, this will only keep the last one.
+            DB::table('surat')
+                ->where('id', $entry->surat_id)
+                ->update(['berkas_id' => $entry->berkas_id]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // This migration is not reversible in a simple way,
+        // as we are moving from a many-to-many to a one-to-many relationship.
+        // We will just clear the berkas_id column.
+        DB::table('surat')->update(['berkas_id' => null]);
+    }
+};

--- a/database/migrations/2025_09_15_011700_drop_berkas_surat_table.php
+++ b/database/migrations/2025_09_15_011700_drop_berkas_surat_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::dropIfExists('berkas_surat');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::create('berkas_surat', function (Blueprint $table) {
+            $table->primary(['berkas_id', 'surat_id']);
+            $table->foreignId('berkas_id')->constrained('berkas')->onDelete('cascade');
+            $table->foreignId('surat_id')->constrained('surat')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+};

--- a/resources/views/arsip/index.blade.php
+++ b/resources/views/arsip/index.blade.php
@@ -39,11 +39,24 @@
                         <h3 class="font-bold text-lg mb-4">Daftar Berkas Virtual</h3>
                         <ul class="space-y-2">
                             @forelse($berkasList as $berkas)
-                                <li class="flex items-center justify-between p-2 rounded-md hover:bg-gray-100">
-                                    <a href="{{ route('arsip.berkas.show', $berkas) }}" class="flex items-center text-sm text-gray-700 hover:text-indigo-600">
+                                <li class="flex items-center justify-between p-2 rounded-md hover:bg-gray-100 group">
+                                    <a href="{{ route('arsip.berkas.show', $berkas) }}" class="flex items-center text-sm text-gray-700 hover:text-indigo-600 flex-grow">
                                         <i class="fas fa-folder text-yellow-500 mr-3"></i>
-                                        <span>{{ $berkas->name }} ({{ $berkas->surat()->count() }})</span>
+                                        <span class="flex-grow">{{ $berkas->name }} ({{ $berkas->surat_count ?? $berkas->surat->count() }})</span>
                                     </a>
+                                    <div class="relative opacity-0 group-hover:opacity-100 transition-opacity">
+                                        <button onclick="event.stopPropagation(); this.nextElementSibling.classList.toggle('hidden');" class="text-gray-500 hover:text-gray-700 focus:outline-none">
+                                            <i class="fas fa-ellipsis-v"></i>
+                                        </button>
+                                        <div class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg z-10 hidden">
+                                            <a href="#" onclick="event.preventDefault(); openEditModal({{ json_encode($berkas) }})" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Edit</a>
+                                            <form action="{{ route('arsip.berkas.destroy', $berkas) }}" method="POST" onsubmit="return confirm('Apakah Anda yakin ingin menghapus berkas ini? Semua surat di dalamnya akan dikeluarkan dari berkas.');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-gray-100">Hapus</button>
+                                            </form>
+                                        </div>
+                                    </div>
                                 </li>
                             @empty
                                 <li class="text-sm text-gray-500">Belum ada berkas.</li>
@@ -88,7 +101,7 @@
                     </form>
 
                     {{-- Form for Filing Letters --}}
-                    <form action="{{ route('arsip.berkas.add-surat') }}" method="POST">
+                    <form action="{{ route('arsip.berkas.move-surat') }}" method="POST">
                         @csrf
 
                         {{-- Validation Errors --}}
@@ -107,7 +120,6 @@
                             <table class="min-w-full divide-y divide-gray-200">
                                 <thead class="bg-gray-50">
                                     <tr>
-                                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><input type="checkbox" id="select-all"></th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nomor Surat</th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Perihal</th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tanggal</th>
@@ -119,22 +131,22 @@
                             <tbody class="bg-white divide-y divide-gray-200">
                                 @forelse ($suratList as $surat)
                                     <tr>
-                                        <td class="px-4 py-4 whitespace-nowrap"><input type="checkbox" name="surat_ids[]" value="{{ $surat->id }}" class="rounded border-gray-300 shadow-sm surat-checkbox"></td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $surat->nomor_surat ?? 'N/A' }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-800">{{ $surat->perihal }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $surat->tanggal_surat->format('d M Y') }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($surat->klasifikasi)->kode }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                            @if($surat->berkas->isNotEmpty())
+                                            @if($surat->berkas)
                                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                                                     <i class="fas fa-folder-open mr-1.5"></i>
-                                                    {{ $surat->berkas->first()->name }}
+                                                    {{ $surat->berkas->name }}
                                                 </span>
                                             @else
                                                 <span class="text-gray-400 italic">Belum Diarsipkan</span>
                                             @endif
                                         </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                            <button onclick="openMoveModal({{ json_encode($surat) }})" class="text-green-600 hover:text-green-900">Pindahkan</button>
                                             @if ($surat->file_path)
                                                 <a href="{{ route('surat.download', $surat) }}" class="text-indigo-600 hover:text-indigo-900">Unduh</a>
                                             @else
@@ -144,32 +156,12 @@
                                     </tr>
                                 @empty
                                     <tr>
-                                        <td colspan="7" class="px-6 py-12 text-center text-gray-500">Tidak ada surat yang cocok dengan kriteria pencarian.</td>
+                                        <td colspan="6" class="px-6 py-12 text-center text-gray-500">Tidak ada surat yang cocok dengan kriteria pencarian.</td>
                                     </tr>
                                 @endforelse
                             </tbody>
                         </table>
                         </div>
-
-                        <div class="mt-4 p-4 border-t flex items-center space-x-4 bg-gray-50 rounded-b-lg">
-                            @php
-                                $unarchivedExists = $suratList->contains(fn($surat) => $surat->berkas->isEmpty());
-                            @endphp
-                            <label for="berkas_id" class="text-sm font-medium">Pilih Berkas:</label>
-                            <select name="berkas_id" id="berkas_id" class="rounded-md border-gray-300 shadow-sm text-sm" @if(!$unarchivedExists) disabled @endif>
-                                <option value="">-- Tujuan Berkas --</option>
-                                @foreach($berkasList as $berkas)
-                                    <option value="{{ $berkas->id }}">{{ $berkas->name }}</option>
-                                @endforeach
-                            </select>
-                            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md text-xs hover:bg-indigo-700 @if(!$unarchivedExists) opacity-50 cursor-not-allowed @endif" @if(!$unarchivedExists) disabled @endif>
-                                <i class="fas fa-folder-plus mr-1"></i> Masukkan ke Berkas
-                            </button>
-                            @if(!$unarchivedExists && $suratList->isNotEmpty())
-                            <p class="text-xs text-gray-500 italic">Semua surat yang ditampilkan sudah diarsipkan.</p>
-                            @endif
-                        </div>
-                    </form>
 
                     <div class="mt-6">
                         {{ $suratList->links() }}
@@ -178,19 +170,97 @@
             </div>
         </div>
     </div>
+
+    <!-- Edit Berkas Modal -->
+    <div id="editBerkasModal" class="fixed z-10 inset-0 overflow-y-auto hidden" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+            <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+            <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+                <form id="editBerkasForm" action="" method="POST">
+                    @csrf
+                    @method('PUT')
+                    <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                        <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">Edit Berkas</h3>
+                        <div class="mt-4 space-y-4">
+                            <div>
+                                <label for="edit_name" class="block text-sm font-medium text-gray-700">Nama Berkas</label>
+                                <input type="text" name="name" id="edit_name" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                            </div>
+                            <div>
+                                <label for="edit_description" class="block text-sm font-medium text-gray-700">Deskripsi</label>
+                                <textarea name="description" id="edit_description" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                        <button type="submit" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 sm:ml-3 sm:w-auto sm:text-sm">Simpan</button>
+                        <button type="button" onclick="closeEditModal()" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:mt-0 sm:w-auto sm:text-sm">Batal</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Move Surat Modal -->
+    <div id="moveSuratModal" class="fixed z-10 inset-0 overflow-y-auto hidden" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+            <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+            <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+                <form id="moveSuratForm" action="{{ route('arsip.berkas.move-surat') }}" method="POST">
+                    @csrf
+                    <input type="hidden" name="surat_ids[]" id="move_surat_id">
+                    <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                        <h3 class="text-lg leading-6 font-medium text-gray-900">Pindahkan Surat</h3>
+                        <p class="text-sm text-gray-600 mt-2" id="move_surat_perihal"></p>
+                        <div class="mt-4">
+                            <label for="move_berkas_id" class="block text-sm font-medium text-gray-700">Pilih Berkas Tujuan</label>
+                            <select name="berkas_id" id="move_berkas_id" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                                <option value="">-- Pilih Berkas --</option>
+                                @foreach($berkasList as $berkas)
+                                    <option value="{{ $berkas->id }}">{{ $berkas->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+                    <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                        <button type="submit" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-green-600 text-base font-medium text-white hover:bg-green-700 sm:ml-3 sm:w-auto sm:text-sm">Pindahkan</button>
+                        <button type="button" onclick="closeMoveModal()" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:mt-0 sm:w-auto sm:text-sm">Batal</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
     @push('scripts')
         <script>
-            document.addEventListener('DOMContentLoaded', function() {
-                // Checkbox select-all logic
-                const selectAll = document.getElementById('select-all');
-                if (selectAll) {
-                    selectAll.addEventListener('change', function(event) {
-                        document.querySelectorAll('.surat-checkbox').forEach(function(checkbox) {
-                            checkbox.checked = event.target.checked;
-                        });
-                    });
-                }
+            function openEditModal(berkas) {
+                const modal = document.getElementById('editBerkasModal');
+                const form = document.getElementById('editBerkasForm');
+                form.action = `/arsip/berkas/${berkas.id}`;
+                document.getElementById('edit_name').value = berkas.name;
+                document.getElementById('edit_description').value = berkas.description;
+                modal.classList.remove('hidden');
+            }
 
+            function closeEditModal() {
+                const modal = document.getElementById('editBerkasModal');
+                modal.classList.add('hidden');
+            }
+
+            function openMoveModal(surat) {
+                const modal = document.getElementById('moveSuratModal');
+                document.getElementById('move_surat_id').value = surat.id;
+                document.getElementById('move_surat_perihal').textContent = `Anda akan memindahkan surat dengan perihal: "${surat.perihal}"`;
+                modal.classList.remove('hidden');
+            }
+
+            function closeMoveModal() {
+                const modal = document.getElementById('moveSuratModal');
+                modal.classList.add('hidden');
+            }
+
+            document.addEventListener('DOMContentLoaded', function() {
                 // Date range picker logic
                 const dateRange = document.getElementById('date_range');
                 if(dateRange) {

--- a/resources/views/arsip/show_berkas.blade.php
+++ b/resources/views/arsip/show_berkas.blade.php
@@ -71,7 +71,8 @@
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-800">{{ $surat->perihal }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $surat->tanggal_surat->format('d M Y') }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($surat->klasifikasi)->kode }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                            <button onclick="openMoveModal({{ json_encode($surat) }})" class="text-green-600 hover:text-green-900">Pindahkan</button>
                                             @if ($surat->file_path)
                                                 <a href="{{ route('surat.download', $surat) }}" class="text-indigo-600 hover:text-indigo-900">Unduh</a>
                                             @else
@@ -95,4 +96,51 @@
             </div>
         </div>
     </div>
+
+    <!-- Move Surat Modal -->
+    <div id="moveSuratModal" class="fixed z-10 inset-0 overflow-y-auto hidden" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+            <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+            <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+                <form id="moveSuratForm" action="{{ route('arsip.berkas.move-surat') }}" method="POST">
+                    @csrf
+                    <input type="hidden" name="surat_ids[]" id="move_surat_id">
+                    <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                        <h3 class="text-lg leading-6 font-medium text-gray-900">Pindahkan Surat</h3>
+                        <p class="text-sm text-gray-600 mt-2" id="move_surat_perihal"></p>
+                        <div class="mt-4">
+                            <label for="move_berkas_id" class="block text-sm font-medium text-gray-700">Pilih Berkas Tujuan</label>
+                            <select name="berkas_id" id="move_berkas_id" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                                <option value="">-- Pilih Berkas --</option>
+                                @foreach($berkasList as $berkasItem)
+                                    <option value="{{ $berkasItem->id }}">{{ $berkasItem->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+                    <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                        <button type="submit" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-green-600 text-base font-medium text-white hover:bg-green-700 sm:ml-3 sm:w-auto sm:text-sm">Pindahkan</button>
+                        <button type="button" onclick="closeMoveModal()" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:mt-0 sm:w-auto sm:text-sm">Batal</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    @push('scripts')
+        <script>
+            function openMoveModal(surat) {
+                const modal = document.getElementById('moveSuratModal');
+                document.getElementById('move_surat_id').value = surat.id;
+                document.getElementById('move_surat_perihal').textContent = `Anda akan memindahkan surat dengan perihal: "${surat.perihal}"`;
+                modal.classList.remove('hidden');
+            }
+
+            function closeMoveModal() {
+                const modal = document.getElementById('moveSuratModal');
+                modal.classList.add('hidden');
+            }
+        </script>
+    @endpush
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -219,7 +219,9 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/arsip/workflow', [ArsipController::class, 'showWorkflow'])->name('arsip.workflow');
     Route::post('/arsip/berkas', [ArsipController::class, 'storeBerkas'])->name('arsip.berkas.store');
     Route::get('/arsip/berkas/{berkas}', [ArsipController::class, 'showBerkas'])->name('arsip.berkas.show');
-    Route::post('/arsip/berkas/add-surat', [ArsipController::class, 'addSuratToBerkas'])->name('arsip.berkas.add-surat');
+    Route::put('/arsip/berkas/{berkas}', [ArsipController::class, 'updateBerkas'])->name('arsip.berkas.update');
+    Route::delete('/arsip/berkas/{berkas}', [ArsipController::class, 'destroyBerkas'])->name('arsip.berkas.destroy');
+    Route::post('/arsip/berkas/move-surat', [ArsipController::class, 'moveSuratToBerkas'])->name('arsip.berkas.move-surat');
 
 });
 


### PR DESCRIPTION
This commit introduces several enhancements to the virtual folder (`berkas`) functionality in the digital archive:

1.  **Edit and Delete Folders:** Users can now edit the name and description of a virtual folder, or delete it entirely.
2.  **Move Letters:** Letters can now be moved from one virtual folder to another. This replaces the previous "add to folder" functionality.
3.  **Database Schema Change:** The relationship between letters (`surat`) and virtual folders (`berkas`) has been changed from many-to-many to one-to-many. This ensures that a letter can only be in one folder at a time, which simplifies the logic for moving letters.
4.  **Cascade on Delete:** When a folder is deleted, all letters within it are automatically un-filed (their `berkas_id` is set to `null`).

These changes address the user's request to have more control over the management of virtual folders and the letters within them.