### PR TITLE
fix: Correct key in makeTask method

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -157,7 +157,7 @@ class SuratController extends Controller
             'creator_id' => Auth::id(),
             'task_status_id' => $defaultStatus->id,
             'priority_level_id' => $defaultPriority->id,
-            'due_date' => now()->addDays(7),
+            'deadline' => now()->addDays(7),
             'surat_id' => $surat->id,
         ]);
 


### PR DESCRIPTION
This commit fixes a bug that caused an error when creating a Task from a Surat. The `Task::create` method was being called with a `due_date` key, but the Task model's fillable property is `deadline`.

This commit changes the key to `deadline` to match the model, resolving the creation error.