### PR TITLE
fix: Correct method for archiving on surat creation

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -81,8 +81,10 @@ class SuratController extends Controller
             $berkas = Berkas::find($validated['berkas_id']);
             // Ensure the user owns the folder
             if ($berkas && $berkas->user_id == Auth::id()) {
-                $berkas->surat()->attach($surat->id);
-                $surat->update(['status' => 'diarsipkan']);
+                $surat->update([
+                    'berkas_id' => $berkas->id,
+                    'status' => 'diarsipkan'
+                ]);
                 return redirect()->route('arsip.index')->with('success', 'Surat berhasil diunggah dan langsung diarsipkan.');
             }
         }


### PR DESCRIPTION
This commit fixes a `BadMethodCallException` that occurred when creating a new letter (`Surat`) and simultaneously archiving it into a virtual folder (`Berkas`).

The error was caused by the use of the `attach()` method on a `HasMany` relationship in the `SuratController@store` method. This was an oversight from a previous refactoring where the relationship between `Berkas` and `Surat` was changed from many-to-many to one-to-many.

The `attach()` method has been replaced with an `update()` call on the newly created `Surat` object, which correctly sets the `berkas_id` and `status` for the one-to-many relationship.