### PR TITLE
fix: Update letter status to 'diarsipkan' when archiving

### DIFF
--- a/app/Http/Controllers/ArsipController.php
+++ b/app/Http/Controllers/ArsipController.php
@@ -111,7 +111,10 @@ class ArsipController extends Controller
             abort(403);
         }
 
-        Surat::whereIn('id', $validated['surat_ids'])->update(['berkas_id' => $validated['berkas_id']]);
+        Surat::whereIn('id', $validated['surat_ids'])->update([
+            'berkas_id' => $validated['berkas_id'],
+            'status' => 'diarsipkan',
+        ]);
 
         return back()->with('success', count($validated['surat_ids']) . ' surat berhasil dipindahkan ke berkas "' . $berkas->name . '".');
     }


### PR DESCRIPTION
This commit fixes a bug where a letter's status was not being updated to 'diarsipkan' when it was moved into a virtual folder.

The `moveSuratToBerkas` method in `ArsipController` was only updating the `berkas_id` of the letter. The method has been updated to also set the `status` to 'diarsipkan' in the same database query.