### PR TITLE
fix: Refresh task model on creation to prevent casting error

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -181,6 +181,9 @@ class SuratController extends Controller
         $surat->status = 'disetujui';
         $surat->save();
 
+        // Refresh the model to ensure all attributes (especially dates) are properly cast.
+        $task->refresh();
+
         return redirect()->route('tasks.edit', $task)->with('success', 'Tugas berhasil dibuat dari surat. Silakan lengkapi detail tugas.');
     }
 


### PR DESCRIPTION
This commit fixes a 'Call to a member function format() on string' error that occurred on the task edit page when a task was created from a letter.

The error was caused by the `deadline` attribute on the Task model not being properly cast to a Carbon object before being passed to the edit view. The newly created model instance still held the pre-serialization state of the attributes.

The fix adds `$task->refresh()` to the `makeTask` method in `SuratController` immediately after creation and before the redirect. This reloads the model's attributes from the database, ensuring that all casts, including for date fields, are correctly applied.