### PR TITLE
fix: Redirect to correct route after task creation from letter

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -184,7 +184,7 @@ class SuratController extends Controller
         // Refresh the model to ensure all attributes (especially dates) are properly cast.
         $task->refresh();
 
-        return redirect()->route('tasks.edit', $task)->with('success', 'Tugas berhasil dibuat dari surat. Silakan lengkapi detail tugas.');
+        return redirect()->route('adhoc-tasks.edit', $task)->with('success', 'Tugas berhasil dibuat dari surat. Silakan lengkapi detail tugas.');
     }
 
     /**


### PR DESCRIPTION
This commit fixes a 404 Not Found error that occurred after a task was created from a letter.

The `makeTask` method in `SuratController` was incorrectly redirecting to the `tasks.edit` route, which is intended for tasks associated with a project. A task created from a letter is an ad-hoc task and should use a different route.

The redirect has been changed to point to the correct `adhoc-tasks.edit` route, resolving the 404 error.