### PR TITLE
fix: Resolve 404 error on 'make-task' route

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -150,8 +150,9 @@ class SuratController extends Controller
     /**
      * Create a new task from a letter.
      */
-    public function makeTask(Request $request, Surat $surat)
+    public function makeTask(Request $request, $id)
     {
+        $surat = Surat::findOrFail($id);
         $defaultStatus = \App\Models\TaskStatus::where('key', 'pending')->firstOrFail();
         $defaultPriority = \App\Models\PriorityLevel::where('name', 'Normal')->firstOrFail();
 

--- a/resources/views/surat/show.blade.php
+++ b/resources/views/surat/show.blade.php
@@ -20,7 +20,7 @@
                 <a href="{{ route('disposisi.lacak', $surat) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-semibold text-sm hover:bg-blue-700">
                     <i class="fas fa-sitemap mr-2"></i> Lacak Disposisi
                 </a>
-                <form action="{{ route('surat.make-task', $surat) }}" method="POST" class="inline-block">
+                <form action="{{ route('surat.make-task', $surat->id) }}" method="POST" class="inline-block">
                     @csrf
                     <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg font-semibold text-sm hover:bg-green-700">
                         <i class="fas fa-tasks mr-2"></i> Jadikan Tugas

--- a/routes/web.php
+++ b/routes/web.php
@@ -207,7 +207,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/surat/workflow', [SuratController::class, 'showWorkflow'])->name('surat.workflow');
     Route::resource('surat', SuratController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
     Route::get('/surat/{surat}/download', [SuratController::class, 'download'])->name('surat.download');
-    Route::post('/surat/{surat}/make-task', [SuratController::class, 'makeTask'])->name('surat.make-task');
+    Route::post('/surat/{id}/make-task', [SuratController::class, 'makeTask'])->name('surat.make-task');
     Route::get('/surat/{surat}/make-project', [SuratController::class, 'makeProject'])->name('surat.make-project');
 
     // Disposition routes, attached to the unified surat


### PR DESCRIPTION
This commit fixes a 404 Not Found error that occurred when clicking the "Jadikan Tugas" (Make Task) button on the letter detail page.

The error was caused by a suspected failure in Laravel's Route Model Binding for this specific POST route.

The fix bypasses route model binding for this action:
1.  The route in `routes/web.php` was changed from `/surat/{surat}/make-task` to `/surat/{id}/make-task`.
2.  The `makeTask` method in `SuratController` was updated to accept a raw `$id` and find the model manually using `Surat::findOrFail($id)`.
3.  The form in the `surat.show.blade.php` view was updated to pass `$surat->id` to the `route()` helper.

This ensures the `Surat` model is reliably fetched and the correct action is executed, resolving the 404 error.