### PR TITLE
fix: Force HTTPS scheme in production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Http\View\Composers\BreadcrumbComposer;
 use App\Services\PageTitleService;
 use App\Services\NotificationService;
 use App\Http\View\Composers\PageTitleComposer;
+use Illuminate\Support\Facades\URL;
 
 
 use App\Models\Project;
@@ -58,6 +59,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        if ($this->app->environment('production')) {
+            URL::forceScheme('https');
+        }
+
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);
 


### PR DESCRIPTION
This commit addresses a browser warning about submitting information over an insecure connection. The warning was caused by the application generating `http://` URLs for form actions, creating a mixed content issue.

The fix modifies the `boot()` method in `AppServiceProvider.php` to programmatically force all generated URLs to use the `https` scheme when the application is running in the 'production' environment. This is the standard Laravel approach to ensure secure asset and URL generation, especially when running behind a reverse proxy.