### PR TITLE
revert: Remove force HTTPS scheme configuration

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,7 +11,6 @@ use App\Http\View\Composers\BreadcrumbComposer;
 use App\Services\PageTitleService;
 use App\Services\NotificationService;
 use App\Http\View\Composers\PageTitleComposer;
-use Illuminate\Support\Facades\URL;
 
 
 use App\Models\Project;
@@ -59,10 +58,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if ($this->app->environment('production')) {
-            URL::forceScheme('https');
-        }
-
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);
 


### PR DESCRIPTION
This commit reverts a previous change that forced the URL scheme to 'https' in the production environment.

The user has clarified that their production domain uses `http`, so the `forceScheme('https')` configuration was incorrect and caused issues.

The `if` block for forcing the scheme and the corresponding `use URL;` statement have been removed from `AppServiceProvider.php`, restoring the application's default URL generation behavior.