### PR TITLE
fix: Configure trusted proxies to resolve mixed content issues

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,6 +58,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Set trusted proxies for environments behind a reverse proxy
+        \Illuminate\Http\Request::setTrustedProxies(['*'], \Illuminate\Http\Request::HEADER_X_FORWARDED_ALL);
+
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);
 


### PR DESCRIPTION
This commit fixes a browser warning about submitting data over an insecure connection. The issue was caused by the application running behind a reverse proxy and not being aware of the original `https` scheme, causing it to generate `http` URLs for form actions.

The standard `app/Http/Middleware/TrustProxies.php` file was missing in this project. The fix was implemented by adding the trusted proxy configuration directly to the `boot()` method of `app/Providers/AppServiceProvider.php`.

The code `\Illuminate\Http\Request::setTrustedProxies(['*'], \Illuminate\Http\Request::HEADER_X_FORWARDED_ALL);` has been added to trust all proxies and correctly detect the original protocol, resolving the mixed content warnings.