### PR TITLE
fix: Use correct constants for trusted proxy headers

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -59,7 +59,14 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         // Set trusted proxies for environments behind a reverse proxy
-        \Illuminate\Http\Request::setTrustedProxies(['*'], \Illuminate\Http\Request::HEADER_X_FORWARDED_ALL);
+        \Illuminate\Http\Request::setTrustedProxies(
+            ['*'],
+            \Illuminate\Http\Request::HEADER_X_FORWARDED_FOR |
+            \Illuminate\Http\Request::HEADER_X_FORWARDED_HOST |
+            \Illuminate\Http\Request::HEADER_X_FORWARDED_PORT |
+            \Illuminate\Http\Request::HEADER_X_FORWARDED_PROTO |
+            \Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB
+        );
 
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);


### PR DESCRIPTION
This commit fixes a fatal 'Undefined constant' error that occurred on application boot. The error was caused by using the non-existent constant `HEADER_X_FORWARDED_ALL` when attempting to configure trusted proxies.

The fix replaces the incorrect constant with a bitmask of the correct, individual header constants (`HEADER_X_FORWARDED_FOR`, `HEADER_X_FORWARDED_HOST`, etc.) in the `setTrustedProxies` call within `AppServiceProvider.php`.

This resolves the fatal error and correctly configures the application to handle requests from behind a reverse proxy, which also resolves the original mixed content issue.