### PR TITLE
fix: Resolve mixed content issue by implementing TrustProxies middleware

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
+use Illuminate\Http\Request;
+
+class TrustProxies extends Middleware
+{
+    /**
+     * The trusted proxies for this application.
+     *
+     * @var array|string|null
+     */
+    protected $proxies = '*';
+
+    /**
+     * The headers that should be used to detect proxies.
+     *
+     * @var int
+     */
+    protected $headers =
+        Request::HEADER_X_FORWARDED_FOR |
+        Request::HEADER_X_FORWARDED_HOST |
+        Request::HEADER_X_FORWARDED_PORT |
+        Request::HEADER_X_FORWARDED_PROTO |
+        Request::HEADER_X_FORWARDED_AWS_ELB;
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,16 +58,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // Set trusted proxies for environments behind a reverse proxy
-        \Illuminate\Http\Request::setTrustedProxies(
-            ['*'],
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_FOR |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_HOST |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_PORT |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_PROTO |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB
-        );
-
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,8 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->prepend(\App\Http\Middleware\TrustProxies::class);
+
         // Daftarkan middleware di sini
         $middleware->web(append: [
             \App\Http\Middleware\MarkNotificationAsRead::class,


### PR DESCRIPTION
This commit fixes a 'not secure' browser warning that occurred on form submissions when accessing the site via HTTPS. The issue was caused by the application running behind a reverse proxy and not being configured to trust the proxy's `X-Forwarded-*` headers.

The fix implements the standard Laravel solution for this problem:
1.  A new `app/Http/Middleware/TrustProxies.php` middleware file has been created with the `$proxies` property set to `'*'` to trust all incoming proxy requests.
2.  This new middleware has been registered globally by prepending it to the middleware stack in `bootstrap/app.php`.
3.  A previous, incorrect workaround in `AppServiceProvider.php` has been removed to avoid conflicting configurations.

This ensures that Laravel can correctly detect the original request scheme (HTTPS) and generate secure URLs, resolving the mixed content warnings.