### PR TITLE
Fix mixed content on login form submission

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,6 +58,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        if ($this->app->environment('production')) {
+            \Illuminate\Support\Facades\URL::forceScheme('https');
+        }
+
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);
 


### PR DESCRIPTION
The login form at /login was being submitted over an insecure HTTP connection, causing a browser security warning. This occurred because the application, running behind a reverse proxy, was not aware of the SSL termination.

This change forces the URL scheme to 'https' in the production environment by updating the AppServiceProvider. This ensures that all generated URLs, including the login form action, are secure.