### PR TITLE
Force HTTPS to fix mixed content on login form

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,9 +58,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if ($this->app->environment('production')) {
-            \Illuminate\Support\Facades\URL::forceScheme('https');
-        }
+        \Illuminate\Support\Facades\URL::forceScheme('https');
 
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);


### PR DESCRIPTION
The login form at /login was being submitted over an insecure HTTP connection. The initial fix to force the scheme in production was not sufficient.

This change unconditionally forces the URL scheme to 'https' in the AppServiceProvider. This ensures that all generated URLs, including the login form action, are secure across all environments, resolving the mixed content issue.