### PR TITLE
Fix resource pool display and add search functionality

### DIFF
--- a/app/Http/Controllers/ResourcePoolController.php
+++ b/app/Http/Controllers/ResourcePoolController.php
@@ -14,10 +14,20 @@ class ResourcePoolController extends Controller
     /**
      * Menampilkan halaman manajemen resource pool.
      */
-    public function index()
+    public function index(Request $request)
     {
         $manager = Auth::user();
+        $search = $request->input('search');
+
         $teamMembers = $manager->getAllSubordinates();
+
+        if ($search) {
+            $teamMembers = $teamMembers->filter(function ($member) use ($search) {
+                // Search by name (case-insensitive)
+                return stripos($member->name, $search) !== false;
+            });
+        }
+
         $standardHours = config('tasmen.workload.standard_hours', 37.5);
 
         $workloadData = $teamMembers->map(function ($member) use ($standardHours) {
@@ -41,6 +51,7 @@ class ResourcePoolController extends Controller
 
         return view('resource_pool.index', [
             'workloadData' => $workloadData,
+            'search' => $search,
         ]);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -291,7 +291,10 @@ class User extends Authenticatable
         }
 
         $unitIds = $this->unit->getAllSubordinateUnitIds();
-        $query = User::whereIn('unit_id', $unitIds);
+        // Also include the current user's own unit ID to fetch colleagues
+        $unitIds[] = $this->unit->id;
+
+        $query = User::whereIn('unit_id', array_unique($unitIds));
 
         if (!$includeSelf) {
             $query->where('id', '!=', $this->id);

--- a/resources/views/resource_pool/index.blade.php
+++ b/resources/views/resource_pool/index.blade.php
@@ -20,6 +20,17 @@
                         <i class="fas fa-check-circle mr-1"></i> Anggota (beban kerja &lt; 70%)
                     </span>.
                 </p>
+
+                <!-- Search Form -->
+                <div class="mb-4">
+                    <form action="{{ route('resource-pool.index') }}" method="GET" class="flex items-center">
+                        <input type="text" name="search" placeholder="Cari nama anggota..." class="form-input rounded-l-md w-full" value="{{ $search ?? '' }}">
+                        <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-r-md">
+                            Cari
+                        </button>
+                    </form>
+                </div>
+
                 <div class="overflow-x-auto">
                     <table class="min-w-full divide-y divide-gray-200">
                         <thead class="bg-gray-100"> {{-- Header tabel lebih menonjol --}}


### PR DESCRIPTION
This commit addresses two issues with the resource pool management page:

1.  The page was not displaying all staff members for managers (Eselon I, Eselon II, Coordinators). This was because the query only included subordinates in child units, not colleagues in the manager's own unit. The `getAllSubordinates` method in the `User` model has been updated to include the manager's own unit in the query.

2.  The page lacked a search functionality. A search bar has been added to the view, and the controller has been updated to filter the list of staff members by name based on the search query.