### PR TITLE
feat: Enhance resource pool with search and pagination

### DIFF
--- a/resources/views/resource_pool/index.blade.php
+++ b/resources/views/resource_pool/index.blade.php
@@ -102,6 +102,11 @@
                         </tbody>
                     </table>
                 </div>
+
+                <!-- Pagination Links -->
+                <div class="mt-4">
+                    {{ $workloadData->links() }}
+                </div>
             </x-card>
         </div>
     </div>


### PR DESCRIPTION
This commit enhances the resource pool management page with several improvements:

1.  **Fix Staff Display:** The page now correctly displays all staff members for managers (Eselon I, Eselon II, Coordinators). The query has been corrected to include staff from the manager's own unit, not just subordinate units.

2.  **Add Search Functionality:** A search bar has been added, allowing users to filter the list of staff members by name.

3.  **Add Pagination:** The resource pool list is now paginated to improve performance and user experience when dealing with a large number of staff members. The controller logic has been refactored to support pagination.