### PR TITLE
fix: Ensure project leaders can see all project tasks

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -161,7 +161,8 @@ class ProjectController extends Controller
 
         $taskQuery = $project->tasks()->with(['assignees', 'comments.user', 'attachments', 'subTasks', 'status', 'priorityLevel', 'asalSurat']);
 
-        if ($user->isStaff()) {
+        // Filter tasks for staff members, but not for the project leader.
+        if ($user->isStaff() && $user->id !== $project->leader_id) {
             $taskQuery->whereHas('assignees', fn($q) => $q->where('user_id', $user->id));
         }
 


### PR DESCRIPTION
This commit fixes a bug where a project leader ('Pemimpin Kegiatan') who also has a 'Staf' role could not see all tasks in the project they lead. They were only able to see tasks directly assigned to them.

The filtering logic in `ProjectController@show` has been adjusted to exclude the project leader from the staff-specific task filtering. This ensures that project leaders always have full visibility of all tasks within their projects, as intended.