### PR TITLE
Fix(Unit): Reliably filter unit heads by Eselon II hierarchy

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -88,8 +88,8 @@ class UnitController extends Controller
 
         // If we are editing a unit under an Eselon II unit, scope the query.
         if ($eselonIIAncestor) {
-            // Get the ID of the Eselon II unit itself.
-            $unitIds = $eselonIIAncestor->descendants()->pluck('id')->toArray();
+            // Get the ID of the Eselon II unit itself and all its descendants.
+            $unitIds = $eselonIIAncestor->getAllDescendantIds();
             $unitIds[] = $eselonIIAncestor->id;
 
             // Query for users within the Eselon II unit's hierarchy.


### PR DESCRIPTION
This commit provides a comprehensive fix for an issue where the list of potential unit heads was not correctly filtered by the parent Eselon II unit.

The root cause was an unreliable `unit_paths` closure table, which affected both finding the Eselon II ancestor and fetching its descendant units.

This fix addresses the issue in two ways:
1. The `getEselonIIAncestor` method now robustly finds the ancestor by traversing the direct `parentUnit` relationship instead of relying on the closure table.
2. A new `getAllDescendantIds` method has been added to recursively traverse the `childUnits` relationship, providing a reliable way to fetch all descendant IDs.

The `UnitController` has been updated to use these new, more reliable methods, ensuring the candidate list is always correctly scoped.