### PR TITLE
Fix(Unit): Filter head candidates by hierarchy and availability

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -100,23 +100,23 @@ class UnitController extends Controller
             $potentialHeadsQuery = User::query();
         }
 
-        // Exclude users who are already heads of other units.
+        // Get a list of all user IDs that are already heads of other units.
         $existingHeadIds = Unit::whereNotNull('kepala_unit_id')
             ->where('id', '!=', $unit->id)
             ->pluck('kepala_unit_id');
 
-        $potentialHeadsQuery->whereNotIn('id', $existingHeadIds);
-
         if ($expectedRole) {
-            // Filter users by the expected role.
-            $potentialHeadsQuery->where(function ($query) use ($expectedRole, $unit) {
+            // Filter users by the expected role, and exclude those already leading other units.
+            $potentialHeadsQuery->where(function ($query) use ($expectedRole, $unit, $existingHeadIds) {
+                // This sub-query finds potential new heads:
+                // they must have the expected role AND must not already be a head of another unit.
                 $query->whereHas('roles', function ($subQuery) use ($expectedRole) {
                     $subQuery->where('name', $expectedRole);
-                });
+                })->whereNotIn('users.id', $existingHeadIds);
 
-                // Always include the current head of the unit, even if their role doesn't match.
+                // Always include the current head of the unit, regardless of the filters above.
                 if ($unit->kepala_unit_id) {
-                    $query->orWhere('id', $unit->kepala_unit_id);
+                    $query->orWhere('users.id', $unit->kepala_unit_id);
                 }
             });
         } else {


### PR DESCRIPTION
This commit provides a definitive fix for an issue where the list of potential unit heads was incorrect. The list was not properly scoped to the correct Eselon II hierarchy, included individuals who were already heads of other units, and could become empty if the current head held multiple positions.

This comprehensive fix addresses all issues by:
1. Refactoring `getEselonIIAncestor` and adding `getAllDescendantIds` in the `Unit` model to robustly determine the hierarchy without relying on a potentially inconsistent `unit_paths` table.
2. Restructuring the query in `UnitController` to correctly filter the candidate list. It now properly excludes individuals who are already heads of other units, while always ensuring the current head of the unit being edited is included in the list, preventing the dropdown from becoming empty.

These changes together ensure the candidate list is correctly and reliably filtered by hierarchy, role, and availability.