### PR TITLE
Fix: Correctly implement time-based progress calculation

### DIFF
--- a/app/Http/Controllers/GlobalDashboardController.php
+++ b/app/Http/Controllers/GlobalDashboardController.php
@@ -80,7 +80,7 @@ class GlobalDashboardController extends Controller
                      ->withCount(['tasks', 'completedTasks'])
                      ->withSum('budgetItems', 'total_cost')
                      ->withSum('tasks', 'estimated_hours')
-                     ->withSum('tasks.timeLogs as total_logged_minutes', 'duration_in_minutes');
+                     ->withSum('timeLogs as total_logged_minutes', 'duration_in_minutes');
 
         // Get all projects matching the search criteria first.
         $projects = $projectQuery->latest()->get();

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -154,6 +154,14 @@ class Project extends Model
         return $this->hasMany(Task::class);
     }
 
+    /**
+     * Get all of the time logs for the project through the tasks.
+     */
+    public function timeLogs()
+    {
+        return $this->hasManyThrough(TimeLog::class, Task::class);
+    }
+
     public function activities()
     {
         return $this->hasMany(Activity::class)->latest();


### PR DESCRIPTION
- Fixes a BadMethodCallException caused by using dot notation in a `withSum` clause for a nested relationship.
- Adds a `hasManyThrough` relationship to the Project model to create a direct relationship to TimeLogs.
- Updates the GlobalDashboardController to use this new direct relationship, resolving the error and correctly loading the data.