### PR TITLE
Fix: Add redirection to notification handling

### DIFF
--- a/app/Http/Middleware/MarkNotificationAsRead.php
+++ b/app/Http/Middleware/MarkNotificationAsRead.php
@@ -11,6 +11,11 @@ class MarkNotificationAsRead
             $notification = $request->user()->notifications()->where('id', $request->notification_id)->first();
             if ($notification) {
                 $notification->markAsRead();
+
+                // Redirect to the URL from the notification data, if it exists
+                if (isset($notification->data['url'])) {
+                    return redirect($notification->data['url']);
+                }
             }
         }
         return $next($request);


### PR DESCRIPTION
- Modifies the MarkNotificationAsRead middleware to redirect to the URL stored in the notification's data.
- This ensures that when a user clicks on a notification, they are taken to the relevant page (e.g., the project or task page).