### PR TITLE
Fix: Implement robust notification click and redirect

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -26,4 +26,21 @@ class NotificationController extends Controller
         }
         return response()->json(['success' => true]);
     }
+
+    public function readAndRedirect(\Illuminate\Notifications\DatabaseNotification $notification)
+    {
+        // Ensure the user is authorized to read this notification
+        if (auth()->user()->id !== $notification->notifiable_id) {
+            abort(403);
+        }
+
+        $notification->markAsRead();
+
+        if (isset($notification->data['url'])) {
+            return redirect($notification->data['url']);
+        }
+
+        // Fallback if there's no URL
+        return redirect()->route('dashboard');
+    }
 }

--- a/resources/views/components/notification-dropdown.blade.php
+++ b/resources/views/components/notification-dropdown.blade.php
@@ -9,7 +9,7 @@
     <div x-show="isOpen" @click.away="isOpen = false" class="absolute right-0 z-20 w-80 mt-2 overflow-hidden bg-white rounded-md shadow-lg" x-cloak>
         <div class="py-2">
             <template x-for="notification in unread" :key="notification.id">
-                <a :href="notification.data.url" @click="markAsRead(notification.id)" class="flex items-start px-4 py-3 -mx-2 border-b hover:bg-gray-100 bg-blue-50">
+                <a :href="`{{ url('/notifications') }}/${notification.id}/read`" class="flex items-start px-4 py-3 -mx-2 border-b hover:bg-gray-100 bg-blue-50">
                     <div class="flex-shrink-0 w-10 text-center pt-1">
                         <template x-if="notification.type.includes('Leave')"><i class="fas fa-calendar-alt text-blue-500"></i></template>
                         <template x-if="notification.type.includes('Surat')"><i class="fas fa-envelope-open-text text-green-500"></i></template>
@@ -43,16 +43,6 @@
                         this.unread = data.unread;
                         this.count = data.count;
                     });
-            },
-            markAsRead(notificationId) {
-                fetch('{{ route("notifications.markAsRead") }}', {
-                    method: 'POST',
-                    headers: {
-                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ id: notificationId })
-                });
             }
         }
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -185,6 +185,7 @@ Route::middleware(['auth'])->group(function () {
 
     Route::get('/notifications/unread', [NotificationController::class, 'getUnread'])->name('notifications.unread');
     Route::post('/notifications/mark-as-read', [NotificationController::class, 'markAsRead'])->name('notifications.markAsRead');
+    Route::get('/notifications/{notification}/read', [\App\Http\Controllers\NotificationController::class, 'readAndRedirect'])->name('notifications.readAndRedirect');
 
     // Leave Management Module Routes
     Route::group(['prefix' => 'leaves', 'as' => 'leaves.'], function () {


### PR DESCRIPTION
- Removes the fire-and-forget AJAX call from the notification dropdown.
- Adds a new route `notifications.readAndRedirect` and a corresponding controller method.
- The new route handles marking the notification as read and redirecting to the correct URL in a single, reliable GET request.
- This fixes the bug where clicking a notification did not navigate to the correct page.