### PR TITLE
fix(auth): Prevent Staff role from creating projects

### DIFF
--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -47,6 +47,12 @@ class ProjectPolicy
      */
     public function create(User $user): bool
     {
+        // Explicitly deny 'Staf' role from creating projects, as per user requirements.
+        if ($user->hasRole('Staf')) {
+            return false;
+        }
+
+        // For other roles, use the existing centralized logic.
         return $user->canCreateProjects();
     }
 


### PR DESCRIPTION
The `create` method in `ProjectPolicy` has been updated to explicitly deny project creation for users with the 'Staf' role.

This ensures that the "Tambahkan Kegiatan" (Add Activity) button on the dashboard is hidden for Staff users, aligning with the application's intended permissions.