### PR TITLE
feat(tasks): Automate progress calculation from time logs

### DIFF
--- a/app/Http/Controllers/TimeLogController.php
+++ b/app/Http/Controllers/TimeLogController.php
@@ -59,6 +59,9 @@ class TimeLogController extends Controller
         $diffInSeconds = $runningLog->start_time->diffInSeconds($runningLog->end_time);
         $runningLog->duration_in_minutes = round($diffInSeconds / 60);
         $runningLog->save();
+
+        // RECALCULATE PROGRESS
+        $task->recalculateProgress();
         
         // Hitung ulang total waktu tercatat untuk tugas ini
         $totalMinutes = $task->timeLogs()->sum('duration_in_minutes');
@@ -107,6 +110,9 @@ class TimeLogController extends Controller
                 'end_time' => $endTime,
                 'duration_in_minutes' => $durationInMinutes,
             ]);
+
+            // RECALCULATE PROGRESS
+            $task->recalculateProgress();
 
             if ($request->wantsJson()) {
                 // Hitung ulang total waktu tercatat untuk tugas ini


### PR DESCRIPTION
The 'recalculateProgress' method on the Task model has been enhanced. If a task has no sub-tasks, its progress is now automatically calculated based on the ratio of total logged time to the estimated hours.

This calculation is triggered automatically whenever a time log is stopped or manually created, ensuring that the task progress bar accurately reflects the work that has been recorded.