### PR TITLE
feat(ui): Add dynamic colors to user avatars

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -381,6 +381,31 @@ class User extends Authenticatable
 
         return strtoupper($initials);
     }
+
+    /**
+     * Get a deterministic, colorful set of Tailwind CSS classes for the user's avatar.
+     *
+     * @return string
+     */
+    public function getAvatarColorClassesAttribute(): string
+    {
+        $colors = [
+            'bg-red-100 text-red-800',
+            'bg-yellow-100 text-yellow-800',
+            'bg-green-100 text-green-800',
+            'bg-blue-100 text-blue-800',
+            'bg-indigo-100 text-indigo-800',
+            'bg-purple-100 text-purple-800',
+            'bg-pink-100 text-pink-800',
+            'bg-teal-100 text-teal-800',
+            'bg-orange-100 text-orange-800',
+        ];
+
+        // Use the user's ID to deterministically pick a color.
+        $index = $this->id % count($colors);
+
+        return $colors[$index];
+    }
     
     // --- FORMULA PERHITUNGAN KINERJA (VERSI PRE-CALCULATED) ---
 

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -65,8 +65,8 @@
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     <div class="flex items-center">
                                         <div class="flex-shrink-0 h-10 w-10">
-                                            {{-- Use the same style as navigation for consistency --}}
-                                            <div class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-300 text-gray-600 font-bold text-sm">
+                                            {{-- Use the new avatar_color_classes accessor to apply dynamic, consistent colors --}}
+                                            <div class="flex items-center justify-center h-10 w-10 rounded-full font-bold text-sm {{ $user->avatar_color_classes }}">
                                                 {{ $user->initials }}
                                             </div>
                                         </div>


### PR DESCRIPTION
Added a `getAvatarColorClassesAttribute` accessor to the User model. This method contains a palette of Tailwind CSS color classes and uses the user's ID to deterministically assign a color pair to each user.

The user list view has been updated to use this accessor, replacing a hardcoded gray background. This restores the colorful avatar functionality while ensuring each user has a consistent color.