### PR TITLE
style(ui): Use prominent colors for user avatars

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -390,15 +390,16 @@ class User extends Authenticatable
     public function getAvatarColorClassesAttribute(): string
     {
         $colors = [
-            'bg-red-100 text-red-800',
-            'bg-yellow-100 text-yellow-800',
-            'bg-green-100 text-green-800',
-            'bg-blue-100 text-blue-800',
-            'bg-indigo-100 text-indigo-800',
-            'bg-purple-100 text-purple-800',
-            'bg-pink-100 text-pink-800',
-            'bg-teal-100 text-teal-800',
-            'bg-orange-100 text-orange-800',
+            'bg-red-600 text-white',
+            'bg-yellow-600 text-white',
+            'bg-green-600 text-white',
+            'bg-blue-600 text-white',
+            'bg-indigo-600 text-white',
+            'bg-purple-600 text-white',
+            'bg-pink-600 text-white',
+            'bg-teal-600 text-white',
+            'bg-orange-600 text-white',
+            'bg-gray-600 text-white',
         ];
 
         // Use the user's ID to deterministically pick a color.


### PR DESCRIPTION
Updated the color palette in the `getAvatarColorClassesAttribute` accessor on the User model.

The new palette uses darker, solid background colors with white text, making the user avatars on the /users page more prominent and visually consistent with the style of the main navigation avatar.