### PR TITLE
fix(ui): Add fallback for missing user names in initials

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -365,6 +365,11 @@ class User extends Authenticatable
     public function getInitialsAttribute(): string
     {
         $name = trim($this->name);
+
+        if (empty($name)) {
+            return '??';
+        }
+
         $words = explode(' ', $name);
         $firstName = $words[0] ?? '';
         // Get the second word, not the last word.


### PR DESCRIPTION
The getInitialsAttribute accessor on the User model has been made more robust.

It now checks if a user's name is empty or null and returns a default '??' placeholder if it is. This prevents the user avatar from appearing blank for users with missing name data.