### PR TITLE
style(ui): Use prominent and varied colors for user avatars

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -387,6 +387,32 @@ class User extends Authenticatable
         return strtoupper($initials);
     }
 
+    /**
+     * Get a deterministic, colorful set of Tailwind CSS classes for the user's avatar.
+     *
+     * @return string
+     */
+    public function getAvatarColorClassesAttribute(): string
+    {
+        $colors = [
+            'bg-red-600 text-white',
+            'bg-yellow-600 text-white',
+            'bg-green-600 text-white',
+            'bg-blue-600 text-white',
+            'bg-indigo-600 text-white',
+            'bg-purple-600 text-white',
+            'bg-pink-600 text-white',
+            'bg-teal-600 text-white',
+            'bg-orange-600 text-white',
+            'bg-gray-600 text-white',
+        ];
+
+        // Use the user's ID to deterministically pick a color.
+        $index = $this->id % count($colors);
+
+        return $colors[$index];
+    }
+
     // --- FORMULA PERHITUNGAN KINERJA (VERSI PRE-CALCULATED) ---
 
     /**

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -65,8 +65,8 @@
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     <div class="flex items-center">
                                         <div class="flex-shrink-0 h-10 w-10">
-                                            {{-- Use the same style as the main navigation avatar for consistency --}}
-                                            <div class="flex items-center justify-center h-10 w-10 rounded-full bg-green-700/75 text-white font-bold text-sm">
+                                            {{-- Use the new avatar_color_classes accessor to apply dynamic, consistent colors --}}
+                                            <div class="flex items-center justify-center h-10 w-10 rounded-full font-bold text-sm {{ $user->avatar_color_classes }}">
                                                 {{ $user->initials }}
                                             </div>
                                         </div>


### PR DESCRIPTION
Re-instated the dynamic color generation for user avatars and updated the color palette to use darker, more prominent colors with white text.

This change addresses user feedback to make the avatars on the /users page visually striking while maintaining a unique, consistent color for each user.