### PR TITLE
fix(ui): Harden user initials generation logic

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -370,9 +370,14 @@ class User extends Authenticatable
             return '??';
         }
 
-        $words = explode(' ', $name);
-        $firstName = $words[0] ?? '';
-        // Get the second word, not the last word.
+        // Use a regex to split by any whitespace and filter out empty parts.
+        $words = array_values(array_filter(preg_split('/\s+/', $name)));
+
+        if (empty($words)) {
+            return '??';
+        }
+
+        $firstName = $words[0];
         $secondName = $words[1] ?? '';
 
         $initials = mb_substr($firstName, 0, 1);
@@ -382,6 +387,11 @@ class User extends Authenticatable
         } elseif (mb_strlen($firstName) > 1) {
             // Fallback for single-word names: use the first two letters.
             $initials .= mb_substr($firstName, 1, 1);
+        }
+
+        // Final fallback to ensure a non-empty string is always returned.
+        if (empty(trim($initials))) {
+            return '??';
         }
 
         return strtoupper($initials);


### PR DESCRIPTION
The getInitialsAttribute accessor on the User model has been made more robust to handle various edge cases.

The logic now uses preg_split to handle different types of whitespace and includes multiple fallbacks to return a '??' placeholder if a valid initial cannot be generated (e.g., for users with null, empty, or whitespace-only names). This definitively fixes the issue of missing initials in the UI.