### PR TITLE
Fix: Correctly display user initials for names with titles

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -358,6 +358,21 @@ class User extends Authenticatable
     }
 
     /**
+     * Get the user's name without academic titles.
+     *
+     * @return string
+     */
+    public function getNamaTanpaGelarAttribute(): string
+    {
+        $name = trim($this->name);
+        $commaPosition = strpos($name, ',');
+        if ($commaPosition !== false) {
+            return trim(substr($name, 0, $commaPosition));
+        }
+        return $name;
+    }
+
+    /**
      * Get the user's initials from their name.
      *
      * @return string

--- a/resources/views/components/user-card.blade.php
+++ b/resources/views/components/user-card.blade.php
@@ -4,7 +4,7 @@
     <div class="p-6 bg-white border-b border-gray-200">
         <div class="flex items-center">
             <div class="flex-shrink-0">
-                <img class="h-12 w-12 rounded-full" src="https://ui-avatars.com/api/?name={{ urlencode($user->name) }}&color=7F9CF5&background=EBF4FF" alt="">
+                <img class="h-12 w-12 rounded-full" src="https://ui-avatars.com/api/?name={{ urlencode($user->nama_tanpa_gelar) }}&color=7F9CF5&background=EBF4FF" alt="">
             </div>
             <div class="ml-4">
                 <div class="text-sm font-medium text-gray-900">


### PR DESCRIPTION
The user initials were not displaying for names that included academic titles (e.g., ", S.T."). This was because the `ui-avatars.com` service was being passed the full name, which it could not always parse correctly.

This commit introduces a new accessor `getNamaTanpaGelarAttribute` on the `User` model. This accessor returns the user's name with any part of the name following a comma removed.

The `user-card.blade.php` component has been updated to use this new accessor when generating the avatar URL, ensuring that only the name is passed to the avatar service.

Could not run tests due to missing PHP executable in the environment.