### PR TITLE
Fix: Display user initials from model accessor

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -358,21 +358,6 @@ class User extends Authenticatable
     }
 
     /**
-     * Get the user's name without academic titles.
-     *
-     * @return string
-     */
-    public function getNamaTanpaGelarAttribute(): string
-    {
-        $name = trim($this->name);
-        $commaPosition = strpos($name, ',');
-        if ($commaPosition !== false) {
-            return trim(substr($name, 0, $commaPosition));
-        }
-        return $name;
-    }
-
-    /**
      * Get the user's initials from their name.
      *
      * @return string

--- a/resources/views/components/user-card.blade.php
+++ b/resources/views/components/user-card.blade.php
@@ -3,8 +3,8 @@
 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
     <div class="p-6 bg-white border-b border-gray-200">
         <div class="flex items-center">
-            <div class="flex-shrink-0">
-                <img class="h-12 w-12 rounded-full" src="https://ui-avatars.com/api/?name={{ urlencode($user->nama_tanpa_gelar) }}&color=7F9CF5&background=EBF4FF" alt="">
+            <div class="flex-shrink-0 h-12 w-12 rounded-full {{ $user->avatar_color_classes }} flex items-center justify-center">
+                <span class="text-xl font-bold">{{ $user->initials }}</span>
             </div>
             <div class="ml-4">
                 <div class="text-sm font-medium text-gray-900">


### PR DESCRIPTION
This commit updates the user card component to display user initials and a background color that are generated by accessors on the User model. This replaces the previous implementation that used an external service.

The `user-card.blade.php` component is modified to use the `initials` and `avatar_color_classes` attributes from the `User` model. This approach is more robust and correctly handles names with academic titles, as per the user's request.

The `getNamaTanpaGelarAttribute` accessor, which was part of a previous incorrect solution, has been removed.