### PR TITLE
Fix: Add dynamic colors to user initials display

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -384,6 +384,43 @@ class User extends Authenticatable
         return $initials;
     }
 
+    /**
+     * Get a unique background color for the user's avatar.
+     *
+     * @return string
+     */
+    public function getAvatarColorAttribute()
+    {
+        // Daftar warna-warna yang bagus dan profesional
+        $colors = [
+            '#4285F4', // Google Blue
+            '#DB4437', // Google Red
+            '#F4B400', // Google Yellow
+            '#0F9D58', // Google Green
+            '#673AB7', // Deep Purple
+            '#E91E63', // Pink
+            '#009688', // Teal
+            '#FF5722', // Deep Orange
+            '#607D8B', // Blue Grey
+            '#03A9F4', // Light Blue
+            '#8BC34A', // Light Green
+            '#FF9800', // Orange
+        ];
+
+        // Ambil karakter pertama dari nama pengguna
+        $firstChar = substr($this->name, 0, 1);
+
+        // Jika nama tidak kosong, gunakan nilai numerik dari karakter tersebut
+        // untuk memilih warna dari daftar secara konsisten.
+        if (!empty($firstChar)) {
+            $hash = ord($firstChar);
+            return $colors[$hash % count($colors)];
+        }
+
+        // Warna default jika nama kosong
+        return '#CCCCCC';
+    }
+
     // --- FORMULA PERHITUNGAN KINERJA (VERSI PRE-CALCULATED) ---
 
     /**

--- a/resources/views/components/user-card.blade.php
+++ b/resources/views/components/user-card.blade.php
@@ -3,7 +3,7 @@
 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
     <div class="p-6 bg-white border-b border-gray-200">
         <div class="flex items-center">
-            <div class="flex-shrink-0 h-12 w-12 rounded-full bg-gray-200 text-gray-700 flex items-center justify-center">
+            <div class="flex-shrink-0 h-12 w-12 rounded-full flex items-center justify-center" style="background-color: {{ $user->avatar_color }}; color: #fff;">
                 <span class="text-xl font-bold">{{ $user->initials }}</span>
             </div>
             <div class="ml-4">


### PR DESCRIPTION
This commit resolves the follow-up issue where user initials were displayed with a uniform gray background. This change implements the user's provided logic to assign a unique, deterministic color to each user's avatar background.

The `getAvatarColorAttribute` method has been added to the `User` model. This accessor generates a HEX color code based on the first character of the user's name, ensuring each user has a consistent and visually distinct avatar.

The `user-card.blade.php` component has been updated to use this new accessor via an inline style, setting the `background-color` dynamically and ensuring the text color is white for readability.