### PR TITLE
Fix: Enable HTTPS for Vite dev server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "tasmen",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -12,6 +12,7 @@
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.0.0",
+                "@vitejs/plugin-basic-ssl": "^2.1.0",
                 "alpinejs": "^3.4.2",
                 "autoprefixer": "^10.4.2",
                 "axios": "^1.8.2",
@@ -1215,6 +1216,19 @@
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@vitejs/plugin-basic-ssl": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
+            "integrity": "sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^6.0.0 || ^7.0.0"
+            }
         },
         "node_modules/@vue/reactivity": {
             "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/vite": "^4.0.0",
+        "@vitejs/plugin-basic-ssl": "^2.1.0",
         "alpinejs": "^3.4.2",
         "autoprefixer": "^10.4.2",
         "axios": "^1.8.2",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
+import basicSsl from '@vitejs/plugin-basic-ssl';
 
 export default defineConfig({
     plugins: [
@@ -11,5 +12,10 @@ export default defineConfig({
             ],
             refresh: true,
         }),
+        basicSsl()
     ],
+    server: {
+        https: true,
+        host: true,
+    },
 });


### PR DESCRIPTION
This commit resolves the "Unsupported SSL request" error that occurs when running the development server. The error is caused by the browser attempting to connect via HTTPS to the Vite dev server, which was only configured for HTTP.

To fix this, this commit:
- Adds the `@vitejs/plugin-basic-ssl` package to provide a self-signed SSL certificate.
- Configures `vite.config.js` to use the plugin and enable the HTTPS server.

With these changes, the Vite dev server can now handle HTTPS requests, allowing for a smooth local development experience.