### PR TITLE
This commit resolves a series of issues that prevented the applicatio…

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,7 +58,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        \Illuminate\Support\Facades\URL::forceScheme('https');
+        if ($this->app->environment('production')) {
+            \Illuminate\Support\Facades\URL::forceScheme('https');
+        }
 
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);


### PR DESCRIPTION
…n from running correctly in a local HTTPS development environment. The primary symptoms were 'Unsupported SSL request' and 'ERR_CONNECTION_CLOSED' errors.

The investigation revealed two root causes:

1.  The Vite dev server was not configured to handle HTTPS requests, while browsers would often attempt to upgrade the connection to HTTPS, causing an initial failure.
2.  The Laravel application was unconditionally forcing all generated URLs to use the 'https' scheme via `URL::forceScheme('https')` in the `AppServiceProvider`. This caused incorrect redirects after actions like login, breaking the connection between the Vite proxy and the Laravel backend.

This commit applies a two-part fix:

1.  **Enable HTTPS for Vite:** The `@vitejs/plugin-basic-ssl` package is added and the `vite.config.js` is updated to run the Vite dev server on HTTPS. This allows the browser to connect securely.
2.  **Conditional URL Forcing:** The `URL::forceScheme('https')` call in `AppServiceProvider` is now wrapped in an `if ($this->app->environment('production'))` block. This ensures that HTTPS URLs are only forced in the production environment, allowing the local HTTP backend to function correctly.

These changes together create a stable and correct local development environment that supports HTTPS, without negatively impacting production behavior.