### PR TITLE
fix: Configure environment for HTTP local and HTTPS production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,9 +58,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // if ($this->app->environment('production')) {
-        //     \Illuminate\Support\Facades\URL::forceScheme('https');
-        // }
+        // Enforce HTTPS in production.
+        if ($this->app->environment('production')) {
+            \Illuminate\Support\Facades\URL::forceScheme('https');
+        }
 
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('QrCode', \SimpleSoftwareIO\QrCode\Facades\QrCode::class);


### PR DESCRIPTION
This commit resolves issues related to HTTPS in the local development environment while ensuring HTTPS is still enforced in production.

The initial problem was an incorrect HTTPS redirect on local, which was followed by a mixed-content error preventing assets from loading. This set of changes provides a robust solution.

1.  **`config/app.php`**: The default `APP_ENV` is set to `local`. This makes the application default to a development-friendly environment if a `.env` file is not present.

2.  **`app/Providers/AppServiceProvider.php`**: The logic to force an HTTPS scheme is now correctly enabled, but only when `APP_ENV` is `production`. This secures the production environment while leaving the local environment untouched.

3.  **`vite.config.js`**: The `basicSsl()` plugin and `server.https` options have been removed. This ensures the Vite dev server runs on HTTP, resolving the mixed content errors during local development.