### PR TITLE
Fix: Strip titles from names for avatar initials

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -364,7 +364,8 @@ class User extends Authenticatable
      */
     public function getInitialsAttribute(): string
     {
-        $name = trim($this->name);
+        // Strip out academic titles and other suffixes starting with a comma.
+        $name = trim(preg_replace('/,.*$/', '', $this->name));
 
         if (empty($name)) {
             return '??';


### PR DESCRIPTION
The previous implementation of the `getInitialsAttribute` method did not correctly handle user names that included academic titles or other suffixes after a comma. This resulted in some user avatars not displaying because the initial generation failed.

This commit fixes the issue by using a regular expression to strip any text following a comma from the user's name before the initials are generated. This ensures that the logic operates on the core name, providing consistent and correct initials for all users.