### PR TITLE
feat: Add edit functionality for Jabatan from Unit page

### DIFF
--- a/app/Http/Controllers/Admin/JabatanController.php
+++ b/app/Http/Controllers/Admin/JabatanController.php
@@ -66,6 +66,36 @@ class JabatanController extends Controller
 
 
     /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Jabatan $jabatan)
+    {
+        $this->authorize('update', $jabatan->unit);
+        // No need to fetch roles here as we are not changing the role in this form.
+        return view('admin.jabatans.edit', compact('jabatan'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Jabatan $jabatan)
+    {
+        $this->authorize('update', $jabatan->unit);
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'can_manage_users' => ['nullable', 'boolean'],
+        ]);
+
+        $jabatan->update([
+            'name' => $validated['name'],
+            'can_manage_users' => $request->has('can_manage_users'),
+        ]);
+
+        return redirect()->route('admin.units.edit', $jabatan->unit_id)->with('success', 'Jabatan berhasil diperbarui.');
+    }
+
+    /**
      * Remove the specified resource from storage.
      */
     public function destroy(Jabatan $jabatan)

--- a/resources/views/admin/jabatans/edit.blade.php
+++ b/resources/views/admin/jabatans/edit.blade.php
@@ -1,0 +1,70 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Jabatan') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 bg-gray-50">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="{{ route('admin.units.edit', $jabatan->unit_id) }}" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Kembali ke Edit Unit
+                </a>
+            </div>
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
+                <div class="p-8 bg-white border-b border-gray-200">
+                    <h3 class="text-xl font-semibold text-gray-800 mb-6">Edit Jabatan: {{ $jabatan->name }}</h3>
+                    <form action="{{ route('admin.jabatans.update', $jabatan) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+
+                        @if ($errors->any())
+                            <div class="mb-6 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg shadow-md" role="alert">
+                                <strong class="font-bold">Oops! Ada yang salah:</strong>
+                                <ul class="mt-1.5 list-disc list-inside text-sm">
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        <div class="space-y-6">
+                            {{-- Nama Jabatan --}}
+                            <div>
+                                <label for="jabatan_name" class="block text-sm font-medium text-gray-700">Nama Jabatan <span class="text-red-500 font-bold">*</span></label>
+                                <input type="text" name="name" id="jabatan_name" value="{{ old('name', $jabatan->name) }}" class="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 transition duration-150" required>
+                                @error('name')
+                                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            {{-- Can Manage Users Checkbox --}}
+                            <div class="mt-4">
+                                <label for="can_manage_users" class="flex items-center">
+                                    <input type="checkbox" name="can_manage_users" id="can_manage_users" value="1" {{ old('can_manage_users', $jabatan->can_manage_users) ? 'checked' : '' }} class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500">
+                                    <span class="ml-2 text-sm text-gray-600">Dapat Mengelola Pengguna (Izin Khusus)</span>
+                                </label>
+                                <p class="mt-1 text-xs text-gray-500 ml-6">Beri izin pada jabatan ini untuk menambah/mengubah pengguna dalam lingkup unitnya.</p>
+                                @error('can_manage_users')
+                                     <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <div class="flex justify-end items-center mt-8 border-t border-gray-200 pt-6">
+                            <a href="{{ route('admin.units.edit', $jabatan->unit_id) }}" class="text-sm font-medium text-gray-700 hover:text-gray-900 mr-6">Batal</a>
+                            <button type="submit" class="inline-flex items-center px-5 py-2.5 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg transform hover:scale-105">
+                                <i class="fas fa-save mr-2"></i> Simpan Perubahan
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -112,10 +112,17 @@
 
                     <ul class="space-y-3 mb-6">
                         @forelse($unit->jabatans as $jabatan)
-                            <li class="flex items-center justify-between bg-gray-50 p-3 rounded-md">
-                                <div>
-                                    <p class="font-semibold text-gray-700">{{ $jabatan->name }}</p>
-                                    <p class="text-sm text-gray-500">
+                            <li class="flex items-center justify-between bg-gray-50 p-4 rounded-lg hover:bg-gray-100 transition-colors duration-150">
+                                <div class="flex-grow">
+                                    <div class="flex items-center">
+                                        <p class="font-semibold text-gray-800">{{ $jabatan->name }}</p>
+                                        @if($jabatan->can_manage_users)
+                                            <span class="ml-3 text-xs font-semibold inline-flex items-center px-2.5 py-0.5 rounded-full bg-blue-100 text-blue-800 border border-blue-200">
+                                                <i class="fas fa-users-cog mr-1.5 opacity-80"></i> Dapat Mengelola Pengguna
+                                            </span>
+                                        @endif
+                                    </div>
+                                    <p class="text-sm text-gray-500 mt-1">
                                         @if($jabatan->user)
                                             <i class="fas fa-user-check text-green-500 mr-2"></i>Diisi oleh: {{ $jabatan->user->name }}
                                         @else
@@ -123,13 +130,18 @@
                                         @endif
                                     </p>
                                 </div>
-                                @if(!$jabatan->user_id)
-                                    <form action="{{ route('admin.jabatans.destroy', $jabatan) }}" method="POST" onsubmit="return confirm('Yakin ingin menghapus jabatan ini?');">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="text-red-500 hover:text-red-700 text-sm font-medium">Hapus</button>
-                                    </form>
-                                @endif
+                                <div class="flex items-center space-x-4 ml-4 flex-shrink-0">
+                                    <a href="{{ route('admin.jabatans.edit', $jabatan) }}" class="font-medium text-indigo-600 hover:text-indigo-800 transition-colors duration-150">Edit</a>
+                                    @if(!$jabatan->user_id)
+                                        <form action="{{ route('admin.jabatans.destroy', $jabatan) }}" method="POST" onsubmit="return confirm('Yakin ingin menghapus jabatan ini?');" class="inline-block">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="font-medium text-red-600 hover:text-red-800 transition-colors duration-150">Hapus</button>
+                                        </form>
+                                    @else
+                                         <span class="font-medium text-gray-400 cursor-not-allowed" title="Jabatan ini tidak dapat dihapus karena ada pengguna yang menempatinya.">Hapus</span>
+                                    @endif
+                                </div>
                             </li>
                         @empty
                             <li class="text-center text-gray-500 py-4">Belum ada jabatan yang didefinisikan untuk unit ini.</li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -242,7 +242,7 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
     Route::resource('units', UnitController::class);
 
     // Refactored to use JabatanController
-    Route::resource('jabatans', JabatanController::class)->except(['show', 'edit', 'update']);
+    Route::resource('jabatans', JabatanController::class)->except(['show']);
 
     // User Import Routes
     Route::get('/users/import', [UserController::class, 'showImportForm'])->name('users.import.show');


### PR DESCRIPTION
This commit introduces the ability to edit a 'Jabatan' (Position) directly from the 'Manajemen Unit' edit page.

Key changes include:
- Enabled the 'edit' and 'update' routes for the Jabatan resource.
- Added 'edit' and 'update' methods to the JabatanController to handle the logic for modifying a position.
- Created a new view for editing a Jabatan, allowing modification of its name and the 'can_manage_users' permission.
- Updated the Unit edit view to include an 'Edit' button and a visual badge for the 'can_manage_users' status on each listed Jabatan.