### PR TITLE
feat: Add Jabatan edit and improve module integration

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -44,6 +44,11 @@ class UserController extends Controller
             });
         }
 
+        if ($request->filled('unit_id')) {
+            $unitId = $request->input('unit_id');
+            $query->where('unit_id', $unitId);
+        }
+
         $users = $query->paginate(15)->withQueryString();
 
         return view('users.index', compact('users'));

--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -7,12 +7,16 @@
 
     <div class="py-12 bg-gray-50"> {{-- Latar belakang konsisten --}}
         <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8">
-            <div class="mb-4">
+            <div class="mb-4 flex justify-between items-center">
                 <a href="javascript:history.back()" class="inline-flex items-center text-sm font-semibold text-gray-600 hover:text-gray-900">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
                     </svg>
                     Kembali
+                </a>
+                <a href="{{ route('users.index', ['unit_id' => $unit->id]) }}" class="inline-flex items-center px-4 py-2 bg-blue-500 border border-transparent rounded-lg font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition ease-in-out duration-150 shadow-md hover:shadow-lg transform hover:scale-105">
+                    <i class="fas fa-users mr-2"></i>
+                    Lihat Anggota Unit
                 </a>
             </div>
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg"> {{-- Shadow dan rounded-lg konsisten --}}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,8 +1,16 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Edit User: ') }} <span class="font-bold text-indigo-600">{{ $user->name }}</span>
-        </h2>
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Edit User: ') }} <span class="font-bold text-indigo-600">{{ $user->name }}</span>
+            </h2>
+            @if ($user->jabatan)
+            <a href="{{ route('users.hierarchy') }}#user-{{ $user->id }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-lg font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150 transform hover:scale-105">
+                <i class="fas fa-sitemap mr-2"></i>
+                Lihat di Hirarki
+            </a>
+            @endif
+        </div>
     </x-slot>
 
     {{-- Latar belakang dan padding konsisten dengan halaman lain --}}

--- a/resources/views/users/partials/unit-hierarchy-row.blade.php
+++ b/resources/views/users/partials/unit-hierarchy-row.blade.php
@@ -37,7 +37,7 @@
         <h5 class="font-semibold text-gray-600 mb-2 ml-1">Pengguna di Unit Ini:</h5>
         <ul class="pl-6 border-l-2 border-indigo-200 space-y-2">
             @forelse($unit->users as $user)
-                <li class="flex items-center text-gray-800">
+                <li id="user-{{ $user->id }}" class="flex items-center text-gray-800 scroll-mt-20">
                     <i class="fas fa-user mr-3 text-gray-400"></i>
                     <div>
                         <span class="font-medium">{{ $user->name }}</span>


### PR DESCRIPTION
This commit introduces two main features:

1.  **Jabatan Editing from Unit Page:**
    - Implements the ability to edit a 'Jabatan' (Position) directly from the 'Manajemen Unit' edit page.
    - Adds 'edit' and 'update' methods to JabatanController.
    - Creates a new view for editing a Jabatan's name and the 'can_manage_users' permission.
    - Updates the Unit edit view to include an 'Edit' button and a status badge for the 'can_manage_users' permission on each Jabatan.

2.  **Improved Module Cross-Linking:**
    - Enhances `UserController` to allow filtering the user list by `unit_id`.
    - Adds a "View Members" button on the Unit edit page to link to the pre-filtered user list.
    - Adds unique IDs to users in the Hierarchy View to enable anchor linking.
    - Adds a "View in Hierarchy" link on the User edit page to jump directly to the user's position in the organizational tree.