### PR TITLE
feat: Allow Sub Koordinator to create projects

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -305,7 +305,7 @@ class User extends Authenticatable
 
     public function canCreateProjects(): bool
     {
-        return $this->hasRole(['Menteri', 'Superadmin', 'Eselon I', 'Eselon II', 'Koordinator']);
+        return $this->hasRole(['Menteri', 'Superadmin', 'Eselon I', 'Eselon II', 'Koordinator', 'Sub Koordinator']);
     }
 
     public function isTopLevelManager(): bool


### PR DESCRIPTION
This commit updates the project creation policy to grant 'Sub Koordinator' role the permission to create new projects or activities.

The `canCreateProjects` method in the `User` model has been modified to include 'Sub Koordinator' in the array of authorized roles.