### PR TITLE
feat: Allow all roles to create ad-hoc tasks

### DIFF
--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -45,6 +45,15 @@ class TaskPolicy
     }
 
     /**
+     * Tentukan apakah pengguna dapat membuat tugas baru.
+     * Sesuai permintaan, semua pengguna bisa membuat tugas harian.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
      * Tentukan apakah pengguna bisa mengupdate tugas.
      */
     public function update(User $user, Task $task): bool


### PR DESCRIPTION
This commit updates the authorization policy for Tasks to allow any authenticated user to create a new task.

Previously, this permission was implicitly denied for all roles except Superadmin because a 'create' method was missing from the TaskPolicy.

A new `create` method has been added to `app/Policies/TaskPolicy.php` which always returns true, granting this permission to all users as per the user's request.