### PR TITLE
fix: Resolve dependent dropdown bug on Complete Profile page

### DIFF
--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -136,6 +136,7 @@ function form_textarea($label, $name, $user, $is_required = false) {
         @endif
         @endcan
 
+        @if(!$isCompleteProfile)
         <div class="mb-4">
             <label for="password" class="block font-semibold text-sm text-gray-700 mb-1">Password</label>
             <input id="password" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300" type="password" name="password" autocomplete="new-password">
@@ -152,6 +153,7 @@ function form_textarea($label, $name, $user, $is_required = false) {
                 <option value="suspended" @selected(old('status', $user->status ?? '') == 'suspended')>Ditangguhkan</option>
             </select>
         </div>
+        @endif
     </div>
 </div>
 
@@ -199,7 +201,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
         let url = `/api/units/${unitId}/vacant-jabatans`;
         @if ($user->exists)
-            url += `?user_id={{ $user->id }}`;
+            if ('{{ $isCompleteProfile }}' !== '1') {
+                url += `?user_id={{ $user->id }}`;
+            }
         @endif
 
         const data = await fetchJson(url);


### PR DESCRIPTION
This commit fixes a critical bug on the `/profile/complete` page where the cascading dropdowns for unit selection failed to populate. It also removes irrelevant form fields from this page.

The root cause was identified as an incorrect API call for vacant positions being made in the context of a user completing their profile.

The fix includes:
1.  A targeted logic update in the form's JavaScript to ensure the correct API call is made for the 'complete profile' scenario.
2.  Hiding unnecessary fields (like 'Status' and 'Password') on the 'Complete Profile' page for a cleaner UI.
3.  This was achieved by enhancing the centralized form partial `new-form-fields.blade.php` to be context-aware.