### PR TITLE
fix: Correct data loading for dependent dropdowns on profile completion

### DIFF
--- a/app/Http/Controllers/CompleteProfileController.php
+++ b/app/Http/Controllers/CompleteProfileController.php
@@ -22,7 +22,8 @@ class CompleteProfileController extends Controller
         }
 
         $user = Auth::user();
-        $eselonIUnits = Unit::whereNull('parent_unit_id')->orderBy('name')->get();
+        // PERBAIKAN: Ambil semua unit dengan level 'Eselon I'
+        $eselonIUnits = Unit::where('level', 'Eselon I')->orderBy('name')->get();
         $selectedUnitPath = [];
         // These are required by the form partial but not strictly needed for this page's logic.
         $supervisors = collect();


### PR DESCRIPTION
This commit fixes a critical bug on the `/profile/complete` page where the dependent dropdowns for unit selection failed to populate.

The root cause was that the controller was fetching the top-level unit (parent_unit_id is null) instead of the list of 'Eselon I' units, causing the cascading dropdown chain to fail at the first step.

The Eloquent query in `CompleteProfileController@create` has been changed from `Unit::whereNull('parent_unit_id')` to `Unit::where('level', 'Eselon I')` to load the correct initial dataset.