### PR TITLE
Refactor: Jabatan Workflow and API Fix

### DIFF
--- a/app/Http/Controllers/Api/UnitApiController.php
+++ b/app/Http/Controllers/Api/UnitApiController.php
@@ -14,9 +14,15 @@ class UnitApiController extends Controller
         return response()->json($units);
     }
 
-    public function getChildUnits(Unit $parentUnit)
+    public function getChildUnits($parentUnitId)
     {
-        $childUnits = $parentUnit->childUnits;
+        $parentUnit = Unit::find($parentUnitId);
+
+        if (!$parentUnit) {
+            return response()->json([]);
+        }
+
+        $childUnits = $parentUnit->childUnits()->orderBy('name')->get();
         return response()->json($childUnits);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -233,7 +233,7 @@ Route::get('/surat/verify/{id}', [SuratVerificationController::class, 'verify'])
 
 // API routes for units, accessible without authentication
 Route::get('/api/units/eselon-i', [UnitApiController::class, 'getEselonIUnits']);
-Route::get('/api/units/{parentUnit}/children', [UnitApiController::class, 'getChildUnits']);
+Route::get('/api/units/{parentUnitId}/children', [UnitApiController::class, 'getChildUnits']);
 
 Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('units/workflow', [UnitController::class, 'showWorkflow'])->name('units.workflow');


### PR DESCRIPTION
This commit introduces a major refactoring of the "Jabatan" (job title) workflow and fixes a critical bug in the units API.

**Jabatan Workflow Refactoring:**
- "Jabatan" is no longer a pre-defined entity. It is now a user-defined text field.
- The Admin User Management (`/users/create`, `/users/{user}/edit`) and the user-facing "Complete Profile" (`/profile/complete`) pages have been updated to use a text input for the job title.
- The backend controllers (`UserController`, `CompleteProfileController`) now dynamically create and manage `Jabatan` records based on this text input.
- The "Unit Management" page (`/admin/units/{unit}/edit`) has been updated to show a read-only list of officials, removing the obsolete Jabatan management interface.

**API Bug Fix:**
- The `/api/units/{parentUnitId}/children` endpoint has been made more robust.
- It now manually looks up the parent unit and returns an empty JSON array `[]` if the ID is not found, preventing JavaScript errors on the frontend when a user clears a unit selection dropdown.
- The route was changed from `/api/units/{parentUnit}/children` to use a simple ID, avoiding route-model binding issues.