### PR TITLE
Fix: Correct Initial Unit Data and Refactor Jabatan Workflow

### DIFF
--- a/app/Http/Controllers/CompleteProfileController.php
+++ b/app/Http/Controllers/CompleteProfileController.php
@@ -21,7 +21,8 @@ class CompleteProfileController extends Controller
             return redirect()->route('dashboard');
         }
 
-        $eselonIUnits = Unit::whereNull('parent_unit_id')->orderBy('name')->get();
+        $rootUnit = Unit::whereNull('parent_unit_id')->first();
+        $eselonIUnits = $rootUnit ? $rootUnit->childUnits()->orderBy('name')->get() : collect();
         $selectedUnitPath = []; // For the form partial
 
         return view('profile.complete', compact('eselonIUnits', 'selectedUnitPath'));


### PR DESCRIPTION
This commit resolves a persistent bug on the "Complete Profile" page and finalizes the refactoring of the "Jabatan" (job title) workflow.

**Bug Fix:**
- Corrects the query in `CompleteProfileController` to load the proper list of "Eselon I" units in the initial dropdown, instead of the root "Kementerian" unit. This prevents downstream JavaScript errors caused by invalid API calls.

**Jabatan Workflow Refactoring:**
- "Jabatan" is now a user-defined text field, not a pre-defined entity.
- Admin User Management (`/users/*`) and the user "Complete Profile" page (`/profile/complete`) have been updated to use a text input for job titles.
- Backend controllers (`UserController`, `CompleteProfileController`) now dynamically manage `Jabatan` records.
- The "Unit Management" page now shows a read-only list of officials.
- The Units API (`/api/units/{id}/children`) has been hardened to prevent crashes.