### PR TITLE
Refactor: Jabatan Workflow and Fix API Route Handling

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,21 @@ use App\Http\Controllers\Api\V1\ProjectApiController;
 use App\Http\Controllers\Api\V1\StatusController;
 use App\Http\Controllers\Api\V1\TaskApiController;
 use App\Http\Controllers\Api\V1\UserApiController;
+use App\Http\Controllers\Api\UnitApiController;
 use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Public API Routes (for internal UI)
+|--------------------------------------------------------------------------
+|
+| These routes are stateless and used by the frontend UI components.
+| They do not fall under the versioned API for external consumers.
+|
+*/
+Route::get('/units/eselon-i', [UnitApiController::class, 'getEselonIUnits']);
+Route::get('/units/{parentUnitId}/children', [UnitApiController::class, 'getChildUnits']);
+
 
 /*
 |--------------------------------------------------------------------------

--- a/routes/web.php
+++ b/routes/web.php
@@ -231,9 +231,7 @@ require __DIR__.'/auth.php';
 // Public route for letter verification
 Route::get('/surat/verify/{id}', [SuratVerificationController::class, 'verify'])->name('surat.verify');
 
-// API routes for units, accessible without authentication
-Route::get('/api/units/eselon-i', [UnitApiController::class, 'getEselonIUnits']);
-Route::get('/api/units/{parentUnitId}/children', [UnitApiController::class, 'getChildUnits']);
+// API routes for units are now defined in routes/api.php.
 
 Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('units/workflow', [UnitController::class, 'showWorkflow'])->name('units.workflow');


### PR DESCRIPTION
This commit resolves a persistent JavaScript error on the "Complete Profile" page and finalizes a major refactoring of the "Jabatan" (job title) workflow.

**Root Cause Fix:**
- The unit hierarchy API routes (`/api/units/*`) were moved from `routes/web.php` to `routes/api.php`. This ensures they are processed by the stateless API middleware stack, preventing web middleware from interfering and causing HTML responses that break the frontend JSON parser.

**Jabatan Workflow Refactoring:**
- "Jabatan" is now a user-defined text field, not a pre-defined, selectable entity.
- The Admin User Management and "Complete Profile" pages have been updated to use a text input for job titles.
- Backend controllers (`UserController`, `CompleteProfileController`) now dynamically manage `Jabatan` records.
- The `CompleteProfileController` now loads the correct initial list of "Eselon I" units.
- The "Unit Management" page now shows a read-only list of officials.