### PR TITLE
Fix: Add missing User model import in CompleteProfileController

### DIFF
--- a/app/Http/Controllers/CompleteProfileController.php
+++ b/app/Http/Controllers/CompleteProfileController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Unit;
+use App\Models\User;
 use App\Models\Jabatan;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;


### PR DESCRIPTION
This commit resolves a "Class not found" fatal error on the profile completion page. The `App\Models\User` class was being called statically without being imported at the top of the `CompleteProfileController.php` file.

This change adds the required `use App\Models\User;` statement.