### PR TITLE
Fix: Display user roles correctly on unit edit page

### DIFF
--- a/PENJELASAN_NIP.md
+++ b/PENJELASAN_NIP.md
@@ -1,0 +1,14 @@
+Tentu, saya akan jelaskan perubahan yang saya lakukan terkait NIP.
+
+Pada perubahan terakhir, saya telah membuat kolom **NIP (Nomor Induk Pegawai) menjadi tidak wajib diisi (opsional)** saat Anda menambah atau mengedit data pengguna.
+
+Secara teknis, saya melakukan hal berikut:
+1.  Saya membuka file controller yang mengatur validasi pengguna, yaitu `app/Http/Controllers/UserController.php`.
+2.  Di dalam file tersebut, saya menemukan aturan validasi untuk NIP yang sebelumnya diatur sebagai `required` (wajib diisi).
+3.  Saya mengubah aturan tersebut dari `required` menjadi `nullable` (boleh dikosongkan).
+
+Perubahan ini saya terapkan pada dua fungsi di dalam file tersebut:
+-   Fungsi untuk **membuat pengguna baru** (`store`).
+-   Fungsi untuk **memperbarui pengguna yang sudah ada** (`update`).
+
+Dengan begitu, sekarang Anda bisa menyimpan data pengguna meskipun kolom NIP tidak diisi, dan ini berlaku konsisten baik untuk pengguna baru maupun saat mengedit pengguna lama.

--- a/PENJELASAN_PEJABAT.md
+++ b/PENJELASAN_PEJABAT.md
@@ -1,0 +1,19 @@
+Tentu, saya akan jelaskan perubahan yang saya lakukan pada bagian "Daftar Pejabat di Unit Ini" di halaman edit unit.
+
+**Sebelum Perubahan:**
+-   Bagian ini sebelumnya bernama "Daftar Jabatan di Unit Ini".
+-   Fungsinya adalah untuk mengelola "slot" atau posisi jabatan yang tersedia di unit tersebut. Anda bisa menambah atau menghapus nama-nama jabatan (misalnya, "Analis", "Pranata Komputer") langsung dari halaman ini.
+
+**Mengapa Diubah?**
+-   Sistem lama ini tidak lagi sesuai dengan alur kerja baru yang telah kita sepakati, di mana **Jabatan sekarang melekat pada pengguna dan diinput secara manual**, bukan lagi "slot" kosong yang ada di sebuah unit.
+
+**Setelah Perubahan (Yang Sekarang):**
+-   **Judul diubah** menjadi "Daftar Pejabat di Unit Ini" agar lebih akurat.
+-   **Fungsi manajemen dihapus:** Saya telah menghapus total semua tombol, form, dan logika untuk menambah/menghapus jabatan dari halaman ini.
+-   **Menjadi Tampilan Informasi (Read-Only):** Bagian ini sekarang murni untuk menampilkan informasi. Isinya adalah sebuah tabel yang menampilkan **siapa saja orang (pejabat) yang saat ini terdaftar di dalam unit tersebut**.
+-   **Isi Tabel:** Tabel tersebut menampilkan:
+    -   Nama Pejabat (`$user->name`)
+    -   Nama Jabatan yang mereka isi (`$user->jabatan->name`)
+    -   Peran (Role) mereka
+
+Singkatnya, bagian tersebut sekarang berfungsi sebagai daftar nama (roster) anggota unit, bukan lagi sebagai alat untuk mengelola posisi jabatan.

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -75,7 +75,7 @@ class UnitController extends Controller
         $this->authorize('update', $unit);
 
         // Eager load relationships for efficiency
-        $unit->load('jabatans.user', 'jabatans.delegations.user', 'users', 'approvalWorkflow', 'parentUnitRecursive');
+        $unit->load('jabatans.user', 'jabatans.delegations.user', 'users.roles', 'approvalWorkflow', 'parentUnitRecursive');
 
         $units = Unit::where('id', '!=', $unit->id)->orderBy('name')->get();
         $workflows = ApprovalWorkflow::orderBy('name')->get();

--- a/resources/views/admin/units/edit.blade.php
+++ b/resources/views/admin/units/edit.blade.php
@@ -124,7 +124,7 @@
                                     <tr>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $user->name }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($user->jabatan)->name ?? 'N/A' }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $user->role }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $user->roles->pluck('name')->join(', ') }}</td>
                                     </tr>
                                 @empty
                                     <tr>


### PR DESCRIPTION
This commit fixes a bug where the "Role" column was empty in the "Daftar Pejabat" table on the unit edit page.

The fix includes:
1. Eager-loading the `users.roles` relationship in the `UnitController` to prevent N+1 issues and ensure data is available.
2. Updating the view to correctly display the role names by iterating over the `roles` relationship (`$user->roles->pluck('name')->join(', ')`) instead of calling a non-existent `role` attribute.