### PR TITLE
Feat: Complete Jabatan Workflow Refactor and All Fixes

### DIFF
--- a/app/Http/Controllers/Api/UnitApiController.php
+++ b/app/Http/Controllers/Api/UnitApiController.php
@@ -14,15 +14,9 @@ class UnitApiController extends Controller
         return response()->json($units);
     }
 
-    public function getChildUnits($parentUnitId)
+    public function getChildUnits(Unit $parentUnit)
     {
-        $parentUnit = Unit::find($parentUnitId);
-
-        if (!$parentUnit) {
-            return response()->json([]);
-        }
-
-        $childUnits = $parentUnit->childUnits()->orderBy('name')->get();
+        $childUnits = $parentUnit->childUnits;
         return response()->json($childUnits);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -607,6 +607,7 @@ public function getAvatarColorsAttribute(): array
             // We adjust the depth check to match this 1-based index.
             $depth = $user->unit->ancestors()->count();
 
+            // Determine the base functional role based on depth
             $newRoleName = match ($depth) {
                 2 => 'Eselon I',
                 3 => 'Eselon II',
@@ -616,12 +617,13 @@ public function getAvatarColorsAttribute(): array
             };
         }
 
-        // Apply structural-to-echelon mapping if applicable
+        // If the unit is 'Struktural', map functional roles to their Eselon equivalents.
         if ($user->unit->type === 'Struktural') {
             $roleMap = [
                 'Koordinator' => 'Eselon III',
                 'Sub Koordinator' => 'Eselon IV',
             ];
+            // If the current role exists in our map, transform it.
             if (isset($roleMap[$newRoleName])) {
                 $newRoleName = $roleMap[$newRoleName];
             }

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -102,6 +102,7 @@ function form_textarea($label, $name, $user, $is_required = false) {
             <input type="text" name="jabatan_name" id="jabatan_name" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" value="{{ old('jabatan_name', optional($user->jabatan)->name ?? '') }}" required>
             <p class="text-xs text-gray-500 mt-1">Jabatan akan dibuat atau diperbarui berdasarkan nama yang dimasukkan.</p>
         </div>
+
         <div class="mb-4">
             <label for="atasan_id" class="block font-semibold text-sm text-gray-700 mb-1">Atasan Langsung</label>
             <select name="atasan_id" id="atasan_id" class="block mt-1 w-full rounded-lg shadow-sm border-gray-300">
@@ -120,6 +121,14 @@ function form_textarea($label, $name, $user, $is_required = false) {
                 <span class="ml-2 text-sm text-gray-600 font-semibold">Jadikan Kepala Unit</span>
             </label>
             <p class="mt-1 text-xs text-gray-500 ml-6">Menetapkan pengguna ini sebagai kepala dari unit kerja mereka saat ini.</p>
+        </div>
+
+        <div class="mb-4">
+            <label for="can_manage_users" class="flex items-center">
+                <input type="checkbox" name="can_manage_users" id="can_manage_users" value="1" @checked(old('can_manage_users', optional($user->jabatan)->can_manage_users)) class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500">
+                <span class="ml-2 text-sm text-gray-600 font-semibold">Dapat Mengelola Pengguna (Izin Khusus)</span>
+            </label>
+            <p class="mt-1 text-xs text-gray-500 ml-6">Memberikan izin untuk menambah/mengubah pengguna di dalam unit kerjanya.</p>
         </div>
 
         @if ($user->exists)


### PR DESCRIPTION
This is a comprehensive commit that finalizes the complete refactoring of the Jabatan (job title) workflow and includes all associated bug fixes and feature requests.

**Major Changes:**
1.  **Jabatan as Text Input:** The core application logic has been changed. "Jabatan" is no longer a pre-defined entity but a user-defined text field. This is reflected in the User, Profile, and Unit management modules.
2.  **`can_manage_users` Restored:** The "Dapat Mengelola Pengguna" permission has been re-implemented as a checkbox on the admin user edit form.
3.  **Role Logic Updated:**
    *   The "Role" column in the unit officials list is now correctly populated.
    *   The `syncRoleFromUnit` logic now correctly maps functional roles (Koordinator, Sub Koordinator) to their Eselon equivalents (Eselon III, Eselon IV) in Struktural units.
4.  **Bug Fixes:**
    *   The NIP field is now optional.
    *   The initial data on the "Complete Profile" page is now correct.
    *   The unit API routes have been moved to `api.php` to resolve persistent JSON parsing errors.
    *   All identified "Class not found" errors have been resolved with the correct `use` statements.