### PR TITLE
feat: Add unit-level admin role for user management

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -315,15 +315,18 @@ class User extends Authenticatable
 
     public function canManageUsers(): bool
     {
-        // This check is now centralized in UserPolicy, but we keep this for any other
-        // part of the app that might be using it. It now checks the role flag.
+        // Superadmin role has universal access, this is a fallback for UI checks.
+        if ($this->hasRole('Superadmin')) {
+            return true;
+        }
+        // For other roles, check for the explicit permission flag.
         return $this->roles->some('can_manage_users_in_unit', true);
     }
 
     public function canManageLeaveSettings(): bool
     {
-        // Only Superadmins or users with the explicit unit management permission can manage leave settings.
-        return $this->isSuperAdmin() || $this->canManageUsers();
+        // This permission is now fully governed by the canManageUsers logic.
+        return $this->canManageUsers();
     }
 
     public function isSuperAdmin(): bool


### PR DESCRIPTION
Introduces a new, flexible permission system for user management at the organizational unit level. This resolves an issue where users required an inappropriately high-level role (e.g., 'Menteri') to manage other users within their own Eselon II unit.

Key changes:
- Added a `can_manage_users_in_unit` boolean column to the `roles` table via migration.
- Created a new 'Sub Koordinator Admin' role with this permission enabled.
- Refactored `UserPolicy` to use this new, unified permission check for all user management actions.
- The permission logic remains correctly scoped to the same Eselon II unit.
- Cleaned up legacy logic by removing the unused `can_manage_users` column from the `jabatans` table.

fix: Restore Superadmin menu visibility

The `canManageUsers()` helper method in the User model was also updated to explicitly grant access to the 'Superadmin' role. This fixes a regression where the user/unit management menus were hidden for Superadmins after the initial refactoring.