### PR TITLE
refactor: Overhaul User and Unit Management workflows

### DIFF
--- a/app/Http/Controllers/CompleteProfileController.php
+++ b/app/Http/Controllers/CompleteProfileController.php
@@ -22,7 +22,9 @@ class CompleteProfileController extends Controller
             return redirect()->route('dashboard');
         }
 
-        $eselonIUnits = Unit::whereNull('parent_unit_id')->orderBy('name')->get();
+        // Find the root unit (Kementerian) and get its direct children (Eselon I)
+        $rootUnit = Unit::whereNull('parent_unit_id')->first();
+        $eselonIUnits = $rootUnit ? $rootUnit->childUnits()->orderBy('name')->get() : collect();
         $selectedUnitPath = []; // For the form partial
 
         return view('profile.complete', compact('eselonIUnits', 'selectedUnitPath'));

--- a/resources/views/users/partials/new-form-fields.blade.php
+++ b/resources/views/users/partials/new-form-fields.blade.php
@@ -131,14 +131,6 @@ function form_textarea($label, $name, $user, $is_required = false) {
             <p class="mt-1 text-xs text-gray-500 ml-6">Menetapkan pengguna ini sebagai kepala dari unit kerja mereka saat ini.</p>
         </div>
 
-        {{-- Can Manage Users Checkbox --}}
-        <div class="mb-4">
-            <label for="can_manage_users" class="flex items-center">
-                <input type="checkbox" name="can_manage_users" id="can_manage_users" value="1" @checked(old('can_manage_users', optional($user->jabatan)->can_manage_users)) class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500">
-                <span class="ml-2 text-sm text-gray-600 font-semibold">Dapat Mengelola Pengguna (Izin Khusus)</span>
-            </label>
-            <p class="mt-1 text-xs text-gray-500 ml-6">Memberikan izin untuk menambah/mengubah pengguna di dalam unit kerjanya.</p>
-        </div>
 
         @if ($user->exists)
         <div class="mb-4">


### PR DESCRIPTION
This comprehensive update addresses multiple issues in the user management, unit management, and profile completion flows, stemming from an initial request to fix an inflexible authorization system.

Key Changes:

1.  **RBAC Refactoring for User Management:**
    - Replaced an obsolete `can_manage_users` flag on the `jabatans` table with a new `can_manage_users_in_unit` boolean permission on the `roles` table.
    - Introduced a 'Sub Koordinator Admin' role to grant specific users unit management capabilities without assigning them an inappropriately high-level structural role (e.g., 'Menteri').
    - Updated `UserPolicy` to use this new, consistent permission.
    - Fixed a regression where the 'Superadmin' role lost access to menus by adding a fallback check in the `User` model.
    - Fixed a SQL error in `UserController` by removing write attempts to the now-deleted `can_manage_users` column.

2.  **Unit Hierarchy and Form Data Correction:**
    - Fixed a systemic bug in `UserController` and `CompleteProfileController` where the root 'Kementerian' unit was being passed to the view instead of the 'Eselon I' units. This caused an off-by-one error in the entire cascading dropdown hierarchy.
    - The controllers now correctly fetch the children of the root unit, ensuring the dropdowns for Eselon I, Eselon II, etc., are populated with the correct data.

3.  **UI Cleanup:**
    - Removed the obsolete "Dapat Mengelola Pengguna" checkbox from the user creation/edit form to align the UI with the new backend logic.