### PR TITLE
refactor: Overhaul user management, roles, and hierarchy logic

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -45,12 +45,11 @@ class UserPolicy
             $userEselonII = $user->unit?->getEselonIIAncestor();
             $modelEselonII = $model->unit?->getEselonIIAncestor();
 
-            if ($userEselonII && $modelEselonII && $userEselonII->id === $modelEselonII->id) {
-                return true;
-            }
+            return $userEselonII && $modelEselonII && $userEselonII->id === $modelEselonII->id;
+        } else {
+            // A regular manager can only view their direct subordinates.
+            return $model->isSubordinateOf($user);
         }
-
-        return $model->isSubordinateOf($user);
     }
 
     /**


### PR DESCRIPTION
This is a comprehensive refactoring that addresses multiple issues across the user management, unit management, and role synchronization systems.

Key Changes:

1.  **RBAC for User Management:**
    - Replaced an obsolete `can_manage_users` flag on the `jabatans` table with a new `can_manage_users_in_unit` boolean permission on the `roles` table.
    - Introduced a 'Sub Koordinator Admin' role to grant specific users unit management capabilities without assigning an inappropriate structural role.
    - Updated `UserPolicy` to use this new, consistent permission, and clarified its logic.
    - Updated the `isManager()` method in the `User` model to correctly identify users with these new permissions, fixing UI visibility issues.

2.  **Role Synchronization:**
    - The `syncRoleFromUnit` method in the `User` model has been rewritten.
    - For 'Struktural' units, it now correctly uses the `eselon` value from the user's profile to determine their role, as per new business requirements.
    - The logic now correctly preserves administrative roles (e.g., 'Sub Koordinator Admin') during synchronization.

3.  **Unit Hierarchy & Form Data:**
    - Fixed a systemic bug in `UserController` and `CompleteProfileController` that caused cascading dropdowns for unit selection to show incorrect data. The controllers now correctly provide the top-level 'Eselon I' units to the views.

4.  **Bug Fixes & Cleanup:**
    - Fixed a regression where the 'Superadmin' role lost access to menus.
    - Fixed a SQL error in `UserController` caused by attempting to write to the deleted `can_manage_users` column.
    - Removed the obsolete 'Dapat Mengelola Pengguna' checkbox from the user form UI.