### PR TITLE
refactor: Overhaul User and Unit Management workflows

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -405,6 +405,11 @@ class UserController extends Controller
             return redirect()->route('users.index')->with('error', 'Tidak dapat meniru pengguna yang belum memverifikasi emailnya.');
         }
 
+        // Mencegah infinite loop dengan melarang impersonate user yang profilnya belum lengkap.
+        if (is_null($user->unit_id)) {
+            return redirect()->route('users.index')->with('error', 'Tidak dapat meniru pengguna dengan profil yang belum lengkap.');
+        }
+
         $impersonatorId = Auth::id();
         
         Auth::login($user);

--- a/routes/web.php
+++ b/routes/web.php
@@ -204,6 +204,9 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/profile/complete', [CompleteProfileController::class, 'create'])->name('profile.complete.create');
     Route::post('/profile/complete', [CompleteProfileController::class, 'store'])->name('profile.complete.store');
 
+    // Route to leave impersonation, accessible by any authenticated user in an impersonation session.
+    Route::get('/users/impersonate/leave', [UserController::class, 'leaveImpersonate'])->name('admin.users.impersonate.leave');
+
     // --- UNIFIED SURAT ROUTES ---
     Route::get('/surat/workflow', [SuratController::class, 'showWorkflow'])->name('surat.workflow');
     Route::resource('surat', SuratController::class)->only(['index', 'create', 'store', 'show', 'destroy']);
@@ -248,7 +251,6 @@ Route::middleware(['auth', 'superadmin'])->prefix('admin')->name('admin.')->grou
 
     // Impersonation Routes
     Route::get('/users/{user}/impersonate', [UserController::class, 'impersonate'])->name('users.impersonate');
-    Route::get('/users/impersonate/leave', [UserController::class, 'leaveImpersonate'])->name('users.impersonate.leave');
 
     // Manual Leave Balance Management
     Route::get('/users/{user}/leave-balance/edit', [UserController::class, 'editLeaveBalance'])->name('users.leave-balance.edit');


### PR DESCRIPTION
This comprehensive update addresses multiple issues in the user management, unit management, and role synchronization systems.

Key Changes:

1.  **RBAC for User Management:**
    - Replaced an obsolete `can_manage_users` flag on the `jabatans` table with a new `can_manage_users_in_unit` boolean permission on the `roles` table.
    - Introduced a 'Sub Koordinator Admin' role to grant specific users unit management capabilities without assigning an inappropriate structural role.
    - Updated `UserPolicy` and `User` model methods (`canManageUsers`, `isManager`) to use this new, consistent permission, fixing UI visibility issues.

2.  **Role Synchronization:**
    - The `syncRoleFromUnit` method in the `User` model has been rewritten. For 'Struktural' units, it now correctly uses the `eselon` value from the user's profile to determine their role.
    - The logic now correctly preserves administrative roles (e.g., 'Sub Koordinator Admin') during synchronization.

3.  **Unit Hierarchy & Form Data:**
    - Fixed a systemic bug in `UserController` and `CompleteProfileController` that caused cascading dropdowns for unit selection to show incorrect data. The controllers now correctly provide the top-level 'Eselon I' units to the views.

4.  **Bug Fixes & Cleanup:**
    - Fixed a critical infinite loop in the `impersonate` feature by preventing impersonation of users with incomplete profiles.
    - Fixed the `leaveImpersonate` route by moving it to the correct middleware group, allowing impersonation sessions to be exited reliably.
    - Fixed a SQL error in `UserController` caused by attempting to write to a deleted database column.
    - Removed the obsolete 'Dapat Mengelola Pengguna' checkbox from the user form UI.