### PR TITLE
fix: Make add_can_manage_users_in_unit migration idempotent

### DIFF
--- a/database/migrations/2025_09_19_223400_add_can_manage_users_in_unit_to_roles_table.php
+++ b/database/migrations/2025_09_19_223400_add_can_manage_users_in_unit_to_roles_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('roles', function (Blueprint $table) {
-            $table->boolean('can_manage_users_in_unit')->default(false)->after('level');
-        });
+        if (!Schema::hasColumn('roles', 'can_manage_users_in_unit')) {
+            Schema::table('roles', function (Blueprint $table) {
+                $table->boolean('can_manage_users_in_unit')->default(false)->after('level');
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('roles', function (Blueprint $table) {
-            $table->dropColumn('can_manage_users_in_unit');
-        });
+        if (Schema::hasColumn('roles', 'can_manage_users_in_unit')) {
+            Schema::table('roles', function (Blueprint $table) {
+                $table->dropColumn('can_manage_users_in_unit');
+            });
+        }
     }
 };


### PR DESCRIPTION
Adds `Schema::hasColumn` checks to the `up()` and `down()` methods of the `add_can_manage_users_in_unit_to_roles_table` migration.

This prevents "Duplicate column" or "Column not found" errors if the migration is run or rolled back more than once, which can happen in development environments or after a repository reset. This makes the migration safer and more robust.