### PR TITLE
fix: Add missing DB facade import in Unit model

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class Unit extends Model
 {


### PR DESCRIPTION
Adds the `use Illuminate\Support\Facades\DB;` statement to the `app/Models/Unit.php` file.

This resolves a fatal error (`Class "App\Models\DB" not found`) that occurred during database seeding when the `rebuildHierarchy()` method was called. The method uses `DB::transaction()` but the required facade was not imported into the model's namespace.