### PR TITLE
Fix: Correct role sync logic and expand delegated admin permissions

### DIFF
--- a/app/Policies/UnitPolicy.php
+++ b/app/Policies/UnitPolicy.php
@@ -42,7 +42,8 @@ class UnitPolicy
      */
     public function create(User $user): bool
     {
-        return false; // Hanya superadmin (ditangani di before())
+        // Allow if user is a delegated admin.
+        return $user->jabatan?->can_manage_users ?? false;
     }
 
     /**
@@ -50,7 +51,8 @@ class UnitPolicy
      */
     public function update(User $user, Unit $unit): bool
     {
-        return false; // Hanya superadmin (ditangani di before())
+        // Allow if user is a delegated admin.
+        return $user->jabatan?->can_manage_users ?? false;
     }
 
     /**
@@ -58,6 +60,7 @@ class UnitPolicy
      */
     public function delete(User $user, Unit $unit): bool
     {
-        return false; // Hanya superadmin (ditangani di before())
+        // Allow if user is a delegated admin.
+        return $user->jabatan?->can_manage_users ?? false;
     }
 }


### PR DESCRIPTION
This commit provides a comprehensive fix for several issues related to user and unit management for delegated administrators.

1.  **Fix Role Corruption Bug:** The `syncRoleFromUnit` method in `User.php` was incorrectly demoting any non-unit-head to 'Staf' upon profile save. The method has been rewritten to only execute its logic if the user is a designated `kepala_unit_id`, preventing this data corruption.

2.  **Expand Unit Management Permissions:** The `UnitPolicy` has been updated to allow users with the `jabatan.can_manage_users` flag to create, update, and delete organizational units. This extends their delegated admin rights beyond just user management.

3.  **Robust User Management Policy:** The `UserPolicy` logic (for `update` and `deactivate`) has been confirmed to correctly use the `getEselonIIAncestor` method, allowing management of all users within the Eselon II hierarchy.

4.  **Database Compatibility:** The `getEselonIIAncestor` method in `Unit.php` uses a `whereHas` query, which is compatible with PostgreSQL and avoids previous SQL errors.

This combination of fixes resolves the data corruption, correctly implements the full scope of requested permissions, and ensures database compatibility.