### PR TITLE
Fix: Correct data in user edit unit dropdowns

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -183,7 +183,7 @@ class UserController extends Controller
         // Asumsi hanya ada satu root unit (Kementerian)
         $rootUnit = Unit::whereNull('parent_unit_id')->first();
         // Ambil anak-anaknya sebagai unit Eselon I
-        $eselonIUnits = $rootUnit ? $rootUnit->children()->orderBy('name')->get() : collect();
+        $eselonIUnits = $rootUnit ? $rootUnit->childUnits()->orderBy('name')->get() : collect();
 
         $selectedUnitPath = [];
         if ($user->unit) {


### PR DESCRIPTION
The user edit form was displaying an incorrect hierarchy in the unit selection dropdowns. The 'Eselon I' dropdown was populated with the top-level Ministry unit, and the pre-selected values for existing users were shifted accordingly.

This commit fixes the issue by:
1. Modifying the `UserController@edit` method to fetch the correct 'Eselon I' units (children of the root unit) for the first dropdown.
2. Adjusting the `$selectedUnitPath` to remove the root unit ID, aligning the path with the dropdown levels.
3. Using the correct `childUnits` relationship name on the Unit model.