### PR TITLE
Fix: Correct role mapping for structural positions

### DIFF
--- a/app/Services/OrganizationalDataImporterService.php
+++ b/app/Services/OrganizationalDataImporterService.php
@@ -147,8 +147,8 @@ class OrganizationalDataImporterService
             $roleName = match ($item->Eselon) {
                 '1-A' => 'Eselon I',
                 '2-A' => 'Eselon II',
-                '3-A' => 'Koordinator',
-                '4-A' => 'Sub Koordinator',
+                '3-A' => 'Eselon III',
+                '4-A' => 'Eselon IV',
                 default => null,
             };
         }


### PR DESCRIPTION
The OrganizationalDataImporterService was incorrectly mapping Eselon 3 and 4 to 'Koordinator' and 'Sub Koordinator' roles respectively for structural positions. This caused a mismatch between the user's actual eselon level and their assigned role in the system.

This commit updates the `determineRole` method to map Eselon 3-A to the 'Eselon III' role and Eselon 4-A to the 'Eselon IV' role, which aligns with the user's structural hierarchy as requested.