### PR TITLE
Fix(users): Ensure role for structural users is based on eselon

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -28,29 +28,10 @@ class UserController extends Controller
         $query = User::with(['unit', 'jabatan', 'atasan.jabatan', 'roles']);
 
         if (!$loggedInUser->isSuperAdmin()) {
-            $scopeUnit = $loggedInUser->unit;
-
-            // For certain roles like Eselon III or IV, the scope should be their entire Eselon II unit.
-            if ($scopeUnit && $loggedInUser->hasRole(['Eselon III', 'Eselon IV'])) {
-                $eselonIIUnit = $scopeUnit->getEselonIIAncestor();
-                if ($eselonIIUnit) {
-                    $scopeUnit = $eselonIIUnit;
-                }
-            }
-
-            if ($scopeUnit) {
-                $unitIds = $scopeUnit->getAllSubordinateUnitIds();
-                $unitIds[] = $scopeUnit->id;
-                $query->whereIn('unit_id', array_unique($unitIds));
-            } else {
-                // Fallback for users with no unit: they can only see themselves.
-                $query->where('id', $loggedInUser->id);
-            }
-
-            // Exclude Superadmins from the list for non-Superadmin viewers.
-            $query->whereDoesntHave('roles', function ($q) {
-                $q->where('name', 'Superadmin');
-            });
+            $query->inUnitAndSubordinatesOf($loggedInUser)
+                  ->whereDoesntHave('roles', function ($q) {
+                      $q->where('name', 'Superadmin');
+                  });
         }
 
         $query->orderBy('name');


### PR DESCRIPTION
This commit fixes a bug where a structural user's role (e.g., Eselon IV) would be incorrectly changed upon editing their profile. The `User::syncRoleFromUnit` method, called during the update process, was improperly recalculating the role based on the user's unit depth, overriding the correct role defined by their `Eselon` value.

The `syncRoleFromUnit` method in the User model has been updated to:
- First, check if the user has a 'Struktural' `jenis_jabatan` and a defined `eselon` value.
- If true, it syncs the role based on the `eselon` value and immediately returns, preventing the rest of the function from executing.
- This ensures that the role for structural employees is always derived from their `Eselon` data, as intended.