### PR TITLE
Fix(users): Correct role sync and user visibility for structural heads

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -32,8 +32,15 @@ class UserController extends Controller
 
             // For certain roles like Eselon III or IV, the scope should be their entire Eselon II unit.
             if ($scopeUnit && $loggedInUser->hasRole(['Eselon III', 'Eselon IV'])) {
-                $eselonIIUnit = $scopeUnit->getEselonIIAncestor();
-                if ($eselonIIUnit) {
+                // Manually traverse up to find the Eselon II unit ancestor.
+                // An Eselon II unit is at depth 2 (Root is 0, Eselon I is 1).
+                $eselonIIUnit = $scopeUnit;
+                while ($eselonIIUnit->parentUnit && $eselonIIUnit->ancestors()->count() > 2) {
+                    $eselonIIUnit = $eselonIIUnit->parentUnit;
+                }
+
+                // Final check to ensure we landed on an actual Eselon II unit.
+                if ($eselonIIUnit && $eselonIIUnit->ancestors()->count() == 2) {
                     $scopeUnit = $eselonIIUnit;
                 }
             }


### PR DESCRIPTION
This commit addresses two related issues for structural unit heads:

1.  **Role Synchronization:** The `syncRoleFromUnit` method in the User model has been updated to ensure that for users with a 'Struktural' `jenis_jabatan`, their role is determined by their `eselon` value and not incorrectly overridden by unit hierarchy logic during user profile updates.

2.  **User Visibility:** The `index` method in `UserController` has been updated. For users with 'Eselon III' or 'Eselon IV' roles, the query for the user list is now correctly scoped to their entire parent Eselon II unit, granting them the appropriate visibility over their organizational structure.