### PR TITLE
fix(profile): Correctly fetch units by hierarchy depth

### DIFF
--- a/app/Http/Controllers/CompleteProfileController.php
+++ b/app/Http/Controllers/CompleteProfileController.php
@@ -22,8 +22,9 @@ class CompleteProfileController extends Controller
             return redirect()->route('dashboard');
         }
 
-        // Fetch units specifically at the 'Eselon I' level for the initial dropdown.
-        $eselonIUnits = Unit::where('level', Unit::LEVEL_ESELON_I)->orderBy('name')->get();
+        // Fetch units at Eselon I level. Based on the hierarchy logic in the Unit model
+        // (getExpectedHeadRole), an Eselon I unit is at depth 2, meaning it has 2 ancestors.
+        $eselonIUnits = Unit::withCount('ancestors')->having('ancestors_count', 2)->orderBy('name')->get();
         $selectedUnitPath = []; // For the form partial
 
         return view('profile.complete', compact('eselonIUnits', 'selectedUnitPath'));


### PR DESCRIPTION
This commit fixes a fatal SQL error on the profile completion page caused by an incorrect assumption in the previous commit. The `units` table does not have a `level` column.

The logic in `CompleteProfileController@create` has been corrected to fetch Eselon I units by their depth in the hierarchy. It now correctly queries for units that have an ancestor count of 2, which corresponds to the Eselon I level as defined in the `Unit` model's business logic.

This commit retains the other necessary fixes from the previous submission:
- The `store` method correctly validates and assigns a vacant `jabatan_id`.
- The view's JavaScript correctly populates the `jabatan_id` dropdown.