### PR TITLE
feat(profile): Implement free-text input for Jabatan on completion form

### DIFF
--- a/app/Http/Controllers/CompleteProfileController.php
+++ b/app/Http/Controllers/CompleteProfileController.php
@@ -39,8 +39,7 @@ class CompleteProfileController extends Controller
     {
         $validated = $request->validate([
             'unit_id' => ['required', 'exists:units,id'],
-            // Validate that the jabatan_id exists and is not already taken by another user.
-            'jabatan_id' => ['required', 'exists:jabatans,id,user_id,NULL'],
+            'jabatan_name' => ['required', 'string', 'max:255'],
         ]);
 
         $user = Auth::user();
@@ -50,18 +49,15 @@ class CompleteProfileController extends Controller
         }
 
         DB::transaction(function () use ($validated, $user) {
-            // Find the selected Jabatan, which must be vacant.
-            $jabatan = Jabatan::where('id', $validated['jabatan_id'])
-                              ->whereNull('user_id')
-                              ->firstOrFail();
+            // Create a new Jabatan for the user based on their text input.
+            $jabatan = Jabatan::create([
+                'name' => $validated['jabatan_name'],
+                'unit_id' => $validated['unit_id'],
+                'user_id' => $user->id,
+            ]);
 
-            // Assign the user to the selected Jabatan.
-            $jabatan->user_id = $user->id;
-            $jabatan->save();
-
-            // Update the user's unit_id to match their new Jabatan's unit.
-            // This ensures consistency.
-            $user->unit_id = $jabatan->unit_id;
+            // Update the user's unit_id and recalculate their role based on hierarchy.
+            $user->unit_id = $validated['unit_id'];
             $user->save();
 
             // This static method will set the user's main role (Eselon, etc.)

--- a/resources/views/profile/complete.blade.php
+++ b/resources/views/profile/complete.blade.php
@@ -44,9 +44,9 @@
                                 <select id="sub_koordinator" class="unit-select block mt-1 w-full rounded-lg shadow-sm border-gray-300" data-level="4" data-placeholder="-- Pilih Sub Koordinator --" disabled><option value="">-- Pilih Koordinator Dahulu --</option></select>
                             </div>
                             <div class="mb-4">
-                                <label for="jabatan_id" class="block font-semibold text-sm text-gray-700 mb-1">5. Jabatan <span class="text-red-500 font-bold">*</span></label>
-                                <select name="jabatan_id" id="jabatan_id" required class="block mt-1 w-full rounded-lg shadow-sm border-gray-300" disabled><option value="">-- Pilih Unit Kerja Terakhir --</option></select>
-                                <x-input-error :messages="$errors->get('jabatan_id')" class="mt-2" />
+                                <label for="jabatan_name" class="block font-semibold text-sm text-gray-700 mb-1">5. Jabatan <span class="text-red-500 font-bold">*</span></label>
+                                <input type="text" name="jabatan_name" id="jabatan_name" required class="block mt-1 w-full rounded-lg shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" value="{{ old('jabatan_name') }}" placeholder="Contoh: Analis Kebijakan Ahli Pertama">
+                                <x-input-error :messages="$errors->get('jabatan_name')" class="mt-2" />
                             </div>
                             <input type="hidden" name="unit_id" id="unit_id" value="">
                         </div>
@@ -67,17 +67,14 @@
     $(document).ready(function() {
         const unitIdInput = $('#unit_id');
         const unitSelects = $('.unit-select');
-        const jabatanSelect = $('#jabatan_id');
+        const jabatanNameInput = $('#jabatan_name');
         const submitButton = $('#submit_button');
 
         function checkFormValidity() {
+            // The form is valid if a final unit is selected and the jabatan name is not empty.
             const isUnitSelected = unitIdInput.val() !== '';
-            const isJabatanSelected = jabatanSelect.val() !== '';
-            submitButton.prop('disabled', !(isUnitSelected && isJabatanSelected));
-        }
-
-        function resetJabatanSelect() {
-            jabatanSelect.empty().append(new Option('-- Pilih Unit Kerja Terakhir --', '')).prop('disabled', true);
+            const isJabatanFilled = jabatanNameInput.val().trim() !== '';
+            submitButton.prop('disabled', !(isUnitSelected && isJabatanFilled));
         }
 
         function resetSubsequentSelects(level) {
@@ -89,32 +86,6 @@
                     select.empty().append(new Option(placeholder, '')).prop('disabled', true);
                 }
             }
-            // Also reset the jabatan dropdown whenever a unit changes
-            resetJabatanSelect();
-        }
-
-        function fetchVacantJabatans(unitId) {
-            jabatanSelect.prop('disabled', true).html('<option value="">-- Memuat Jabatan... --</option>');
-            $.ajax({
-                url: `/api/units/${unitId}/vacant-jabatans`,
-                type: 'GET',
-                success: function(jabatans) {
-                    jabatanSelect.empty().append(new Option('-- Pilih Jabatan --', ''));
-                    if (jabatans.length > 0) {
-                        $.each(jabatans, function(key, jabatan) {
-                            jabatanSelect.append(new Option(jabatan.name, jabatan.id));
-                        });
-                        jabatanSelect.prop('disabled', false);
-                    } else {
-                        jabatanSelect.html(new Option('-- Tidak ada jabatan kosong --', '')).prop('disabled', true);
-                    }
-                    checkFormValidity();
-                },
-                error: function() {
-                    jabatanSelect.html(new Option('-- Gagal memuat jabatan --', '')).prop('disabled', true);
-                    checkFormValidity();
-                }
-            });
         }
 
         unitSelects.on('change', function() {
@@ -156,23 +127,19 @@
                             });
                             nextSelect.prop('disabled', false);
                         } else {
-                            // No child units, so this is the final unit. Fetch jabatans.
+                            // No child units, so this is the final unit.
                             nextSelect.html(new Option('-- Tidak ada unit bawahan --', '')).prop('disabled', true);
-                            fetchVacantJabatans(selectedValue);
                         }
                     },
                     error: function() {
                         nextSelect.html(new Option('-- Gagal memuat data --', '')).prop('disabled', true);
                     }
                 });
-            } else {
-                 // This is the last unit dropdown, so fetch jabatans for it.
-                 fetchVacantJabatans(selectedValue);
             }
             checkFormValidity();
         });
 
-        jabatanSelect.on('change', function() {
+        jabatanNameInput.on('input', function() {
             checkFormValidity();
         });
 


### PR DESCRIPTION
This commit aligns the profile completion page with the final user requirement for the 'Jabatan' field to be a free-text input rather than a dropdown selection.

The following changes have been made:
- The `store` method in `CompleteProfileController` has been reverted to its original logic, which validates a `jabatan_name` string and creates a new `Jabatan` record.
- The `complete.blade.php` view has been modified to replace the `jabatan_id` dropdown with a `jabatan_name` text input.
- The accompanying JavaScript has been simplified, removing the API call to fetch jabatans and updating the form validation to check for input in the new text field.

This commit also retains the critical bug fix for the unit dropdowns:
- The `create` method in `CompleteProfileController` continues to use the correct `whereHas` query to fetch Eselon I units based on their hierarchy depth, preventing SQL errors.