### PR TITLE
Fix: Allow all roles to create ad-hoc tasks

### DIFF
--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -45,6 +45,18 @@ class TaskPolicy
     }
 
     /**
+     * Determine whether the user can create tasks.
+     *
+     * @param  \App\Models\User  $user
+     * @return bool
+     */
+    public function create(User $user): bool
+    {
+        // Allow all authenticated users to create ad-hoc tasks.
+        return true;
+    }
+
+    /**
      * Tentukan apakah pengguna bisa mengupdate tugas.
      */
     public function update(User $user, Task $task): bool


### PR DESCRIPTION
The `TaskPolicy` was missing a `create` method. In Laravel, when a policy method is missing, the action is denied by default, causing a 403 Unauthorized error.

This change adds the `create` method to `TaskPolicy` and makes it return `true`, allowing any authenticated user to access the ad-hoc task creation page as requested.