### PR TITLE
Fix: Add policy for make-task from surat

### DIFF
--- a/app/Policies/SuratPolicy.php
+++ b/app/Policies/SuratPolicy.php
@@ -49,6 +49,24 @@ class SuratPolicy
     }
 
     /**
+     * Determine whether the user can view the form to create a task from the letter.
+     */
+    public function showMakeTaskForm(User $user, Surat $surat): bool
+    {
+        // Any user who can view the letter can also see the 'make task' form.
+        return $this->view($user, $surat);
+    }
+
+    /**
+     * Determine whether the user can create a task from the letter.
+     */
+    public function makeTask(User $user, Surat $surat): bool
+    {
+        // Any user who can view the letter can also create a task from it.
+        return $this->view($user, $surat);
+    }
+
+    /**
      * Determine whether the user can create a project from the letter.
      */
     public function makeProject(User $user, Surat $surat): bool


### PR DESCRIPTION
Adds the necessary authorization policy methods (`showMakeTaskForm` and `makeTask`) to `SuratPolicy`.

This resolves an issue where users would receive a 404 Not Found error when trying to access the 'Jadikan Tugas' (Make Task) page from a letter's detail page. The error was caused by Laravel's policy auto-discovery, which was denying access because the corresponding policy methods did not exist.

The new policies delegate their logic to the existing `view` policy, ensuring that any user who can view a letter is also authorized to create a task from it.