### PR TITLE
Fix: Add policies for surat and task workflows

### DIFF
--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -66,6 +66,11 @@ class TaskPolicy
             return true;
         }
 
+        // The creator of the task can update it.
+        if ($user->id === $task->creator_id) {
+            return true;
+        }
+
         // The person assigned to the task can update it.
         if ($task->assignees->contains($user)) {
             return true;


### PR DESCRIPTION
This commit resolves two consecutive 404 Not Found errors that occurred when a user tried to create a task from a letter.

1.  **Surat Policy Fix:**
    - Adds `showMakeTaskForm` and `makeTask` policy methods to `SuratPolicy.php`.
    - This fixes the initial 404 error when accessing the "Jadikan Tugas" page.
    - The policies ensure that any user who can view a letter can also access the form to create a task from it.

2.  **Task Policy Fix:**
    - Adds a check in `TaskPolicy.php`'s `update` method to allow a task's creator to edit it.
    - This fixes the second 404 error that occurred after creating the task, when the user was redirected to the task edit page.
    - The existing policy only allowed assignees to edit, not the creator.

These changes ensure the entire "make task from letter" workflow is authorized correctly for the user.