### PR TITLE
Fix: Resolve 404 errors in "make task from letter" workflow

### DIFF
--- a/app/Http/Controllers/SuratController.php
+++ b/app/Http/Controllers/SuratController.php
@@ -160,8 +160,14 @@ class SuratController extends Controller
      */
     public function makeTask(Request $request, Surat $surat)
     {
-        $defaultStatus = \App\Models\TaskStatus::where('key', 'pending')->firstOrFail();
-        $defaultPriority = \App\Models\PriorityLevel::where('name', 'Normal')->firstOrFail();
+        $defaultStatus = \App\Models\TaskStatus::firstOrCreate(
+            ['key' => 'pending'],
+            ['label' => 'Pending']
+        );
+        $defaultPriority = \App\Models\PriorityLevel::firstOrCreate(
+            ['name' => 'Normal'],
+            ['level' => 2, 'color' => '#f9b52c']
+        );
 
         $task = Task::create([
             'title' => $surat->perihal,


### PR DESCRIPTION
This commit resolves a series of issues that caused 404 Not Found errors during the process of creating a task from a letter. The fix involves three parts:

1.  **Add Surat Policy:**
    - Adds `showMakeTaskForm` and `makeTask` policy methods to `SuratPolicy.php`.
    - This fixes the initial 404 error when a user tries to access the "Jadikan Tugas" confirmation page, ensuring they are authorized for the action.

2.  **Add Task Creator Policy:**
    - Modifies the `update` method in `TaskPolicy.php` to grant edit permissions to the creator of a task (`creator_id`).
    - This fixes a 404 error that occurred after the task was created and the user was redirected to the task edit page. The original policy only allowed assignees to edit.

3.  **Harden Default Model Lookups:**
    - Changes `firstOrFail()` to `firstOrCreate()` in `SuratController@makeTask` when fetching default task statuses and priorities.
    - This prevents a `ModelNotFoundException` (which results in a 404) if the default seed data for 'pending' status or 'Normal' priority is missing from the database, making the feature more robust.

Together, these changes ensure the entire workflow is functional and resilient.