### PR TITLE
Fix: Resolve three separate bugs across the application

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -602,14 +602,16 @@ public function getAvatarColorsAttribute(): array
         // The depth is the number of ancestors, which is 1-based (root is 1).
         $depth = $unitHeaded->ancestors()->count();
 
-        // Determine the base functional role based on the depth of the unit they lead.
-        $newRoleName = match ($depth) {
-            2 => 'Eselon I',
-            3 => 'Eselon II',
-            4 => 'Koordinator',
-            5 => 'Sub Koordinator',
-            default => 'Staf', // Fallback for heads of other units (e.g., root)
-        };
+        // --- ROBUST ROLE DETERMINATION ---
+        // Priority 1: Check for specific unit names that have fixed roles.
+        if ($unitHeaded->name === 'Koordinator') {
+            $newRoleName = 'Koordinator';
+        } elseif ($unitHeaded->name === 'Sub Koordinator') {
+            $newRoleName = 'Sub Koordinator';
+        } else {
+            // Priority 2: Fallback to the existing depth-based logic for other units.
+            $newRoleName = $unitHeaded->getExpectedHeadRole();
+        }
 
         // If the unit is 'Struktural', map functional roles to their Eselon equivalents.
         if ($unitHeaded->type === 'Struktural') {


### PR DESCRIPTION
This commit addresses three distinct issues reported by the user:

1.  **Fix 404 error when creating a task from a letter:**
    - The `makeTask` method in `SuratController` was failing with a `ModelNotFoundException` if default `TaskStatus` or `PriorityLevel` records were missing from the database.
    - The code has been changed to use `firstOrCreate()` instead of `firstOrFail()`, making the feature more robust by creating these default records if they do not exist.

2.  **Fix 403 error on leave detail page:**
    - Users with the 'staff' role were getting a "403 This action is unauthorized" error when trying to view a leave detail page (`/leaves/{id}`).
    - This was caused by the absence of a policy for the `LeaveRequest` model.
    - A new `LeaveRequestPolicy` has been created and registered. Its `view` method returns `true` to allow all roles to view the leave detail page, as per the user's requirement.

3.  **Fix incorrect Jabatan for Unit Heads:**
    - A user assigned as head of a unit named 'Koordinator' was incorrectly receiving the 'Sub Koordinator' role.
    - The role assignment logic in `User::syncRoleFromUnit` was based on a brittle 'depth' calculation.
    - The logic has been updated to first check for specific unit names ('Koordinator', 'Sub Koordinator') before falling back to the depth-based calculation, ensuring correct role assignment for these specific cases.