### PR TITLE
Fix: Correctly display direct supervisor in user list

### DIFF
--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -106,8 +106,11 @@
                                     </span>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap">
-                                    <div class="text-sm font-medium text-gray-900">{{ $user->atasan->name ?? '-' }}</div>
-                                    <div class="text-sm text-gray-500">{{ $user->atasan->jabatan->name ?? '' }}</div>
+                                    @php
+                                        $atasan = $user->getAtasanLangsung();
+                                    @endphp
+                                    <div class="text-sm font-medium text-gray-900">{{ $atasan->name ?? '-' }}</div>
+                                    <div class="text-sm text-gray-500">{{ $atasan->jabatan->name ?? '' }}</div>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     <div class="text-sm text-gray-900 flex items-center">


### PR DESCRIPTION
The user list view was incorrectly using the `atasan` relationship, which relies on the `atasan_id` column. This caused the supervisor to be empty for users where this column was not set.

This change modifies the view to use the `getAtasanLangsung()` method from the `User` model. This method contains the correct and more robust logic to determine a user's direct supervisor based on the organizational hierarchy (unit and position).

This ensures that the correct supervisor is always displayed, even when the `atasan_id` is not explicitly set in the database.