### PR TITLE
Fix: Prioritize task completion for project progress

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -38,6 +38,17 @@ class Project extends Model
      */
     public function getProgressAttribute(): int
     {
+        // --- START PERBAIKAN ---
+        // Prioritaskan status selesai berdasarkan jumlah tugas. Jika semua tugas selesai, progress adalah 100%.
+        // Ini menangani kasus di mana tugas selesai tetapi waktu tidak dicatat.
+        $totalTasks = (int) ($this->attributes['tasks_count'] ?? $this->tasks()->count());
+        $completedTasks = (int) ($this->attributes['completed_tasks_count'] ?? $this->completedTasks()->count());
+
+        if ($totalTasks > 0 && $totalTasks === $completedTasks) {
+            return 100;
+        }
+        // --- END PERBAIKAN ---
+
         // Prioritize time-based progress if data is available from eager loading
         if (isset($this->attributes['tasks_sum_estimated_hours'])) {
             $totalEstimatedHours = (float) $this->attributes['tasks_sum_estimated_hours'];
@@ -54,15 +65,6 @@ class Project extends Model
         }
 
         // Fallback to task-based progress if no time estimates are set
-        if (isset($this->attributes['tasks_count'])) {
-            $totalTasks = (int) $this->attributes['tasks_count'];
-            $completedTasks = (int) ($this->attributes['completed_tasks_count'] ?? 0);
-        } else {
-            // Fallback for a single model instance if not eager loaded
-            $totalTasks = $this->tasks()->count();
-            $completedTasks = $this->completedTasks()->count();
-        }
-
         if ($totalTasks === 0) {
             return 0;
         }


### PR DESCRIPTION
The project progress bar on the dashboard was not updating correctly because the progress calculation logic in the `Project` model's `getProgressAttribute` accessor incorrectly prioritized time-based progress over task-based completion.

This resulted in projects showing 0% progress if tasks were marked as complete but had no time logged against them.

This change modifies the `getProgressAttribute` to first check if all tasks in the project are complete. If `tasks_count` equals `completed_tasks_count`, it immediately returns 100%, ensuring that the completion status is accurately reflected. The time-based calculation is now only used as a secondary method of determining progress if the project is not yet fully complete based on task counts.