### PR TITLE
feat: Restrict edit and archive actions for Eselon I/II roles

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -47,6 +47,11 @@ class UserPolicy
      */
     public function update(User $user, User $model): bool
     {
+        // Block Eselon I and Eselon II from editing any user.
+        if ($user->hasRole(['Eselon I', 'Eselon II'])) {
+            return false;
+        }
+
         // Delegated admin with Eselon II scope
         if ($user->jabatan?->can_manage_users) {
             $managerEselonIIUnit = $user->unit?->getEselonIIAncestor();
@@ -72,6 +77,11 @@ class UserPolicy
      */
     public function deactivate(User $user, User $model): bool
     {
+        // Block Eselon I and Eselon II from deactivating any user.
+        if ($user->hasRole(['Eselon I', 'Eselon II'])) {
+            return false;
+        }
+
         if ($user->id === $model->id) {
             return false; // Cannot deactivate self
         }

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -126,21 +126,25 @@
                                             <x-dropdown-link :href="route('users.show', $user)">
                                                 {{ __('Lihat Profil') }}
                                             </x-dropdown-link>
-                                            <x-dropdown-link :href="route('users.edit', $user)">
-                                                {{ __('Edit') }}
-                                            </x-dropdown-link>
+                                            @can('update', $user)
+                                                <x-dropdown-link :href="route('users.edit', $user)">
+                                                    {{ __('Edit') }}
+                                                </x-dropdown-link>
+                                            @endcan
                                             @if(Auth::user()->isSuperAdmin() && Auth::id() !== $user->id && !$user->isSuperAdmin())
                                                 <x-dropdown-link :href="route('admin.users.impersonate', $user)">
                                                     {{ __('Tiru Pengguna') }}
                                                 </x-dropdown-link>
                                             @endif
-                                            <div class="border-t border-gray-100"></div>
-                                            <form action="{{ route('users.deactivate', $user) }}" method="POST" onsubmit="return confirm('{{ __('Apakah Anda yakin ingin mengarsipkan pengguna ini?') }}');">
-                                                @csrf
-                                                <x-dropdown-link :href="route('users.deactivate', $user)" onclick="event.preventDefault(); this.closest('form').submit();">
-                                                    <span class="text-yellow-600">{{ __('Arsipkan') }}</span>
-                                                </x-dropdown-link>
-                                            </form>
+                                            @can('deactivate', $user)
+                                                <div class="border-t border-gray-100"></div>
+                                                <form action="{{ route('users.deactivate', $user) }}" method="POST" onsubmit="return confirm('{{ __('Apakah Anda yakin ingin mengarsipkan pengguna ini?') }}');">
+                                                    @csrf
+                                                    <x-dropdown-link :href="route('users.deactivate', $user)" onclick="event.preventDefault(); this.closest('form').submit();">
+                                                        <span class="text-yellow-600">{{ __('Arsipkan') }}</span>
+                                                    </x-dropdown-link>
+                                                </form>
+                                            @endcan
                                         </x-slot>
                                     </x-dropdown>
                                 </td>


### PR DESCRIPTION
This commit introduces authorization checks to prevent users with the "Eselon I" or "Eselon II" roles from editing or archiving other users.

- Modified `app/Policies/UserPolicy.php` to add checks in the `update` and `deactivate` methods. These methods now return `false` if the acting user has the "Eselon I" or "Eselon II" role.
- Updated `resources/views/users/index.blade.php` to wrap the "Edit" and "Archive" buttons in `@can` directives. This ensures the UI elements are hidden for users who do not have the required permissions, aligning the frontend with the backend policy changes.