### PR TITLE
Feat: Automate Role and Eselon Sync for Unit Heads

### DIFF
--- a/database/migrations/2025_09_22_104248_add_level_eselon_to_units_table.php
+++ b/database/migrations/2025_09_22_104248_add_level_eselon_to_units_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->integer('level_eselon')->nullable()->after('type')->comment('Echelon level of the unit, e.g., 1, 2, 3, 4');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropColumn('level_eselon');
+        });
+    }
+};


### PR DESCRIPTION
This commit introduces a comprehensive system for automatically managing user roles and echelons based on their appointment as a 'Kepala Unit' (Head of Unit). It also includes the fix from the previous task to correctly filter the dropdown list of potential unit heads.

Key changes:
- Adds a `level_eselon` integer column to the `units` table via a new database migration. This column stores the intrinsic echelon level of each unit.
- Implements new methods in the `User` model (`syncRoleAndEselonFromUnit`, `removeAsHeadOfUnit`) to handle the business logic for updating a user's profile when they are appointed or removed as a unit head.
- The logic correctly handles both 'Struktural' and 'Fungsional' unit types, setting the appropriate role and echelon value.
- Updates the `UnitController@update` method to use these new model methods, creating a fully automated and atomic process when the head of a unit is changed.
- The `UnitController@edit` method has also been corrected to properly filter the list of potential unit heads, showing only members of the current unit who are not already leading another unit.