### PR TITLE
feat: Add video background to login and register pages

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -127,6 +127,51 @@
       margin: 0;
     }
 
+    .video-background-container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: -2;
+    }
+
+    #background-video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .video-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.5); /* Overlay gelap */
+    }
+
+    .container {
+        position: relative;
+        z-index: 1;
+    }
+
+    .left-side, .right-side {
+        background-color: transparent !important;
+    }
+
+    .form-box {
+        background-color: rgba(255, 255, 255, 0.9);
+        padding: 40px;
+        border-radius: 15px;
+        box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    }
+
+    .right-side {
+        clip-path: none !important; /* Hapus clip-path agar tidak memotong video */
+    }
+
+
     /* RESPONSIVE */
     @media (max-width: 768px) {
       .container {
@@ -165,6 +210,14 @@
   </style>
 </head>
 <body>
+
+  <div class="video-background-container">
+    <video autoplay muted loop id="background-video">
+      <source src="{{ asset('videos/background.mp4') }}" type="video/mp4">
+      Your browser does not support the video tag.
+    </video>
+    <div class="video-overlay"></div>
+  </div>
 
   <div class="container">
     <div class="left-side">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -134,6 +134,50 @@
       text-decoration: none;
     }
 
+    .video-background-container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: -2;
+    }
+
+    #background-video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .video-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.5); /* Overlay gelap */
+    }
+
+    .container {
+        position: relative;
+        z-index: 1;
+    }
+
+    .left-side, .right-side {
+        background-color: transparent !important;
+    }
+
+    .form-box {
+        background-color: rgba(255, 255, 255, 0.9);
+        padding: 40px;
+        border-radius: 15px;
+        box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    }
+
+    .left-side {
+        clip-path: none !important; /* Hapus clip-path agar tidak memotong video */
+    }
+
     /* RESPONSIVE */
     @media (max-width: 768px) {
       .container {
@@ -170,6 +214,14 @@
   </style>
 </head>
 <body>
+
+  <div class="video-background-container">
+    <video autoplay muted loop id="background-video">
+      <source src="{{ asset('videos/background.mp4') }}" type="video/mp4">
+      Your browser does not support the video tag.
+    </video>
+    <div class="video-overlay"></div>
+  </div>
 
   <div class="container">
     <div class="left-side">


### PR DESCRIPTION
This commit introduces a video background to the authentication pages (login and register) to create a more dynamic and visually appealing user experience, in line with the "Tamasya" theme.

- Adds an HTML5 <video> element to `login.blade.php` and `register.blade.php`.
- The video is configured to autoplay, loop, and be muted.
- Adds inline CSS to make the video a full-screen background using `position: fixed` and `object-fit: cover`.
- Includes a semi-transparent dark overlay to ensure the form content remains readable.
- Adjusts the form container to have a semi-transparent background, appearing as a card on top of the video.
- Removes the `clip-path` property that was interfering with the full-screen background effect.